### PR TITLE
Fixes issues #117 #118 #119 OOB Statuspoller fix (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ cf delete-service -f my-service
 ```
 ## How to obtain support
 
-If you need any support, have any question or have found a bug, please report it in the [GitHub bug tracking system](https://github.com/sap/service-fabrik-broker/issues). We shall get back to you.
+If you need any support, have any question or have found a bug, please report it in the [GitHub bug tracking system](https://github.com/cloudfoundry-incubator/service-fabrik-broker/issues). You can also reach us out on our [Slack Channel](https://cloudfoundry.slack.com/messages/C814KVC59).
 
 ## Advanced Debugging
 

--- a/lib/controllers/ServiceFabrikAdminController.js
+++ b/lib/controllers/ServiceFabrikAdminController.js
@@ -468,7 +468,7 @@ class ServiceFabrikAdminController extends BaseController {
     const oobBackupManager = fabrik.oobBackupManager.getInstance(req.query.bosh_director);
     return oobBackupManager
       .getBackup(req.params.name, req.query.backup_guid)
-      .map(data => _.omit(data, 'secret', 'agent_ip'))
+      .map(data => _.omit(data, 'secret', 'agent_ip', 'logs'))
       .then(backups => {
         const locals = {
           backups: backups

--- a/lib/fabrik/OobBackupManager.js
+++ b/lib/fabrik/OobBackupManager.js
@@ -106,7 +106,8 @@ class OobBackupManager {
                     root_folder: CONST.FABRIK_OUT_OF_BAND_DEPLOYMENTS.ROOT_FOLDER_NAME
                   }, {
                     state: lastOperation.state,
-                    logs: logs
+                    logs: logs,
+                    snapshotId: lastOperation.snapshotId
                   })
                 );
             }

--- a/lib/jobs/OperationStatusPollerJob.js
+++ b/lib/jobs/OperationStatusPollerJob.js
@@ -8,6 +8,7 @@ const moment = require('moment');
 const CONST = require('../constants');
 const errors = require('../errors');
 const ScheduleManager = require('./ScheduleManager');
+const backupStore = require('../iaas').backupStoreForOob;
 const Promise = require('bluebird');
 
 class OperationStatusPollerJob extends BaseJob {
@@ -25,14 +26,26 @@ class OperationStatusPollerJob extends BaseJob {
       const msg = `Operation status poller cannot be initiated as the required mandatory params 
       (deployment_name | type | operation | operation_response.backup_guid) is empty : ${JSON.stringify(options)}`;
       logger.error(msg);
-      this.runFailed(new errors.BadRequest(msg), {}, job, done);
-      return;
+      return this.runFailed(new errors.BadRequest(msg), {}, job, done);
+    } else if (_.get(options, 'operation') !== 'backup' && _.get(options, 'operation') !== 'restore') {
+      const msg = `Operation pollinng not supported for operation - ${options.operation}`;
+      logger.error(msg);
+      const err = {
+        statusCode: `ERR_${options.operation.toUpperCase()}_NOT_SUPPORTED`,
+        statusMessage: msg
+      };
+      return this.runFailed(err, {}, job, done);
+    } else {
+      return this.checkOperationCompletionStatus(options.operation_response, job)
+        .then(operationStatusResponse => this.runSucceeded(operationStatusResponse, job, done))
+        .catch(err => {
+          logger.error(`Error occurred while running operation ${options.operation} status poller for deployment ${_.get(options, 'deployment_name')}.`, err);
+          return this.runFailed(err, {}, job, done);
+        });
     }
-
-    return this.checkOperationCompletionStatus(options.operation_response, job, done);
   }
 
-  static checkOperationCompletionStatus(operationResp, job, done) {
+  static checkOperationCompletionStatus(operationResp, job) {
     function isFinished(state) {
       return _.includes(['succeeded', 'failed', 'aborted'], state);
     }
@@ -41,63 +54,71 @@ class OperationStatusPollerJob extends BaseJob {
     const operationName = job.attrs.data.operation;
     const backupGuid = job.attrs.data.operation_response.backup_guid;
     const boshDirectorName = job.attrs.data.bosh_director;
-    try {
-      Promise.try(() => {
-          if (operationName === 'backup') {
-            return this
-              .getBrokerClient()
-              .getDeploymentBackupStatus(deploymentName, operationResp.token, boshDirectorName);
-          } else if (operationName === 'restore') {
-            return this
-              .getBrokerClient()
-              .getDeploymentRestoreStatus(deploymentName, operationResp.token, boshDirectorName);
-          } else {
-            this.runFailed(new errors.BadRequest(`${operationName} NOT supported for job ${CONST.JOB.OPERATION_STATUS_POLLER}`), {}, job, done);
-          }
-        })
-        .then(operationStatusResponse => {
-          if (isFinished(operationStatusResponse.state)) {
-            ScheduleManager.cancelSchedule(`${deploymentName}_${operationName}_${backupGuid}`, CONST.JOB.OPERATION_STATUS_POLLER)
+
+    return Promise.try(() => {
+        if (operationName === 'backup') {
+          return this
+            .getBrokerClient()
+            .getDeploymentBackupStatus(deploymentName, operationResp.token, boshDirectorName);
+        } else if (operationName === 'restore') {
+          return this
+            .getBrokerClient()
+            .getDeploymentRestoreStatus(deploymentName, operationResp.token, boshDirectorName);
+        } else {
+          throw new errors.BadRequest(`Operation ${operationName} not supported by status poller.`);
+        }
+      })
+      .then(operationStatusResponse => {
+        if (isFinished(operationStatusResponse.state)) {
+          return ScheduleManager.cancelSchedule(`${deploymentName}_${operationName}_${backupGuid}`, CONST.JOB.OPERATION_STATUS_POLLER)
+            .then(() => {
+              logger.info(`Deployment ${deploymentName} ${operationName} for backup guid ${backupGuid} completed -`, operationStatusResponse);
+              return operationStatusResponse;
+            });
+        } else {
+          logger.info(`Deployment ${deploymentName} ${operationName} for backup guid ${backupGuid} still in-progress - `, operationStatusResponse);
+          const currTime = moment();
+          // 'backup_restore_status_poller_timeout' config data might need to put in job data: operation specific
+          // operation can be other than backup/restore : thought just for future reference
+          if (currTime.diff(operationStartedAt) > config.backup.backup_restore_status_poller_timeout) {
+            return ScheduleManager.cancelSchedule(`${deploymentName}_${operationName}_${backupGuid}`, CONST.JOB.OPERATION_STATUS_POLLER)
               .then(() => {
-                logger.info(`Deployment ${deploymentName} ${operationName} for backup guid ${backupGuid} completed -`, operationStatusResponse);
-                if (operationStatusResponse.state === 'succeeded') {
-                  this.runSucceeded(operationStatusResponse, job, done);
-                } else {
-                  const msg = `Deployment ${deploymentName} ${operationName} for backup guid ${backupGuid} ${operationStatusResponse.state}`;
-                  logger.error(msg);
-                  const err = {
-                    statusCode: `ERR_DEPLOYMENT_${operationName.toUpperCase()}_${operationStatusResponse.state.toUpperCase()}`,
-                    statusMessage: msg
-                  };
-                  this.runFailed(err, operationStatusResponse, job, done);
-                }
+                const msg = `Deployment ${deploymentName} ${operationName} with backup guid ${backupGuid} exceeding timeout time 
+                      ${config.backup.backup_restore_status_poller_timeout / 1000 / 60} (mins). Stopping status check`;
+                logger.error(msg);
+                return operationStatusResponse;
               });
           } else {
-            logger.info(`Deployment ${deploymentName} ${operationName} for backup guid ${backupGuid} still in-progress - `, operationStatusResponse);
-            const currTime = moment();
-            // 'backup_restore_status_poller_timeout' config data might need to put in job data: operation specific
-            // operation can be other than backup/restore : thought just for future reference
-            if (currTime.diff(operationStartedAt) > config.backup.backup_restore_status_poller_timeout) {
-              ScheduleManager.cancelSchedule(`${deploymentName}_${operationName}_${backupGuid}`, CONST.JOB.OPERATION_STATUS_POLLER)
-                .then(() => {
-                  const msg = `Deployment ${deploymentName} ${operationName} with backup guid ${backupGuid} exceeding timeout time 
-                      ${config.backup.backup_restore_status_poller_timeout / 1000 / 60} (mins). Stopping status check`;
-                  logger.error(msg);
-                  const err = {
-                    statusCode: 'ERR_BACKUP_TIME_OUT',
-                    statusMessage: msg
-                  };
-                  return this.runFailed(err, operationStatusResponse, job, done);
-                });
-            } else {
-              this.runSucceeded(operationStatusResponse, job, done);
-            }
+            return operationStatusResponse;
           }
-        });
-    } catch (err) {
-      logger.error(`Error occurred while checking for deployment ${deploymentName} ${operationName} status. More info:`, err);
-      this.runFailed(err, {}, job, done);
-    }
+        }
+      })
+      .catch(errors.NotFound, (err) => {
+        return Promise.try(() => {
+            if (operationName === 'backup') {
+              return backupStore
+                .patchBackupFile({
+                  deployment_name: deploymentName,
+                  root_folder: CONST.FABRIK_OUT_OF_BAND_DEPLOYMENTS.ROOT_FOLDER_NAME,
+                  backup_guid: backupGuid
+                }, {
+                  state: CONST.OPERATION.ABORTED
+                });
+            } else if (operationName === 'restore') {
+              return backupStore
+                .patchRestoreFile({
+                  deployment_name: deploymentName,
+                  root_folder: CONST.FABRIK_OUT_OF_BAND_DEPLOYMENTS.ROOT_FOLDER_NAME
+                }, {
+                  state: CONST.OPERATION.ABORTED
+                });
+            }
+          })
+          .then(() => ScheduleManager.cancelSchedule(`${deploymentName}_${operationName}_${backupGuid}`, CONST.JOB.OPERATION_STATUS_POLLER))
+          .then(() => {
+            throw err;
+          });
+      });
   }
 }
 

--- a/lib/jobs/OperationStatusPollerJob.js
+++ b/lib/jobs/OperationStatusPollerJob.js
@@ -9,6 +9,7 @@ const CONST = require('../constants');
 const errors = require('../errors');
 const ScheduleManager = require('./ScheduleManager');
 const backupStore = require('../iaas').backupStoreForOob;
+const utils = require('../utils');
 const Promise = require('bluebird');
 
 class OperationStatusPollerJob extends BaseJob {
@@ -46,9 +47,7 @@ class OperationStatusPollerJob extends BaseJob {
   }
 
   static checkOperationCompletionStatus(operationResp, job) {
-    function isFinished(state) {
-      return _.includes(['succeeded', 'failed', 'aborted'], state);
-    }
+
     const operationStartedAt = moment(new Date(job.attrs.data.operation_job_started_at));
     const deploymentName = job.attrs.data.deployment_name;
     const operationName = job.attrs.data.operation;
@@ -69,10 +68,13 @@ class OperationStatusPollerJob extends BaseJob {
         }
       })
       .then(operationStatusResponse => {
-        if (isFinished(operationStatusResponse.state)) {
+        operationStatusResponse.jobCancelled = false;
+        operationStatusResponse.operationTimedOut = false;
+        if (utils.isServiceFabrikOperationFinished(operationStatusResponse.state)) {
           return ScheduleManager.cancelSchedule(`${deploymentName}_${operationName}_${backupGuid}`, CONST.JOB.OPERATION_STATUS_POLLER)
             .then(() => {
               logger.info(`Deployment ${deploymentName} ${operationName} for backup guid ${backupGuid} completed -`, operationStatusResponse);
+              operationStatusResponse.jobCancelled = true;
               return operationStatusResponse;
             });
         } else {
@@ -86,6 +88,8 @@ class OperationStatusPollerJob extends BaseJob {
                 const msg = `Deployment ${deploymentName} ${operationName} with backup guid ${backupGuid} exceeding timeout time 
                       ${config.backup.backup_restore_status_poller_timeout / 1000 / 60} (mins). Stopping status check`;
                 logger.error(msg);
+                operationStatusResponse.jobCancelled = true;
+                operationStatusResponse.operationTimedOut = true;
                 return operationStatusResponse;
               });
           } else {

--- a/test/acceptance/service-fabrik-admin.deployments.backups.director.spec.js
+++ b/test/acceptance/service-fabrik-admin.deployments.backups.director.spec.js
@@ -63,7 +63,6 @@ describe('service-fabrik-admin', function () {
       backup_guid: backup_guid,
       deployment_name: deployment_name,
       state: 'succeeded',
-      logs: [],
       trigger: CONST.BACKUP.TRIGGER.SCHEDULED
     };
     const restore_data = {

--- a/test/jobs.OperationStatusPollerJob.spec.js
+++ b/test/jobs.OperationStatusPollerJob.spec.js
@@ -95,6 +95,8 @@ describe('Jobs', function () {
             expect(baseJobLogRunHistoryStub.firstCall.args[0]).to.eql(undefined);
             expect(baseJobLogRunHistoryStub.firstCall.args[1].state).to.eql('succeeded');
             expect(baseJobLogRunHistoryStub.firstCall.args[1].stage).to.eql('Creating volume');
+            expect(baseJobLogRunHistoryStub.firstCall.args[1].operationTimedOut).to.eql(false);
+            expect(baseJobLogRunHistoryStub.firstCall.args[1].jobCancelled).to.eql(true);
             expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
             expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
             done();
@@ -118,6 +120,8 @@ describe('Jobs', function () {
             expect(baseJobLogRunHistoryStub.firstCall.args[0]).to.eql(undefined);
             expect(baseJobLogRunHistoryStub.firstCall.args[1].state).to.eql('succeeded');
             expect(baseJobLogRunHistoryStub.firstCall.args[1].stage).to.eql('Restore completed successfully');
+            expect(baseJobLogRunHistoryStub.firstCall.args[1].operationTimedOut).to.eql(false);
+            expect(baseJobLogRunHistoryStub.firstCall.args[1].jobCancelled).to.eql(true);
             expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
             expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
             done();
@@ -140,6 +144,8 @@ describe('Jobs', function () {
           expect(baseJobLogRunHistoryStub.firstCall.args[0]).to.eql(undefined);
           expect(baseJobLogRunHistoryStub.firstCall.args[1].state).to.eql('processing');
           expect(baseJobLogRunHistoryStub.firstCall.args[1].stage).to.eql('Creating volume');
+          expect(baseJobLogRunHistoryStub.firstCall.args[1].operationTimedOut).to.eql(false);
+          expect(baseJobLogRunHistoryStub.firstCall.args[1].jobCancelled).to.eql(false);
           expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
           expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
           done();
@@ -156,6 +162,8 @@ describe('Jobs', function () {
           expect(baseJobLogRunHistoryStub).to.be.calledOnce;
           expect(baseJobLogRunHistoryStub.firstCall.args[0]).to.eql(undefined);
           expect(baseJobLogRunHistoryStub.firstCall.args[1].state).to.eql('processing');
+          expect(baseJobLogRunHistoryStub.firstCall.args[1].operationTimedOut).to.eql(false);
+          expect(baseJobLogRunHistoryStub.firstCall.args[1].jobCancelled).to.eql(false);
           expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
           expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
           done();
@@ -178,6 +186,8 @@ describe('Jobs', function () {
           expect(baseJobLogRunHistoryStub.firstCall.args[0]).to.eql(undefined);
           expect(baseJobLogRunHistoryStub.firstCall.args[1].state).to.eql('processing');
           expect(baseJobLogRunHistoryStub.firstCall.args[1].stage).to.eql('Creating volume');
+          expect(baseJobLogRunHistoryStub.firstCall.args[1].operationTimedOut).to.eql(true);
+          expect(baseJobLogRunHistoryStub.firstCall.args[1].jobCancelled).to.eql(true);
           expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
           expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
           done();
@@ -265,6 +275,23 @@ describe('Jobs', function () {
           expect(baseJobLogRunHistoryStub.firstCall.args[0].name).to.eql('BadRequest');
           expect(baseJobLogRunHistoryStub.firstCall.args[0].reason).to.eql('Bad Request');
           expect(baseJobLogRunHistoryStub.firstCall.args[0].status).to.eql(400);
+          expect(baseJobLogRunHistoryStub.firstCall.args[1]).to.eql({});
+          expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
+          expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
+          done();
+        });
+      });
+
+      it('should log error in case  operation is other than backup or restore', function (done) {
+        let sfClientStub;
+        sfClientStub = sinon.stub(OperationStatusPollerJob, 'getBrokerClient');
+        const job = getJobBasedOnOperation('snapshot');
+        OperationStatusPollerJob.run(job, () => {
+          const invalidInputMsg = `Operation pollinng not supported for operation - snapshot`;
+          expect(sfClientStub).not.to.be.called;
+          sfClientStub.restore();
+          expect(baseJobLogRunHistoryStub.firstCall.args[0].statusMessage).to.eql(invalidInputMsg);
+          expect(baseJobLogRunHistoryStub.firstCall.args[0].statusCode).to.eql(`ERR_SNAPSHOT_NOT_SUPPORTED`);
           expect(baseJobLogRunHistoryStub.firstCall.args[1]).to.eql({});
           expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
           expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);

--- a/test/mocks/serviceBrokerClient.js
+++ b/test/mocks/serviceBrokerClient.js
@@ -32,7 +32,7 @@ function startDeploymentBackup(name, response, payload) {
     });
 }
 
-function getDeploymentBackupStatus(name, token, state, boshDirector) {
+function getDeploymentBackupStatus(name, token, state, boshDirector, responseStatus) {
   const backupState = {
     state: state || 'processing',
     stage: 'Creating volume',
@@ -50,17 +50,21 @@ function getDeploymentBackupStatus(name, token, state, boshDirector) {
     .replyContentLength()
     .get(`/admin/deployments/${name}/backup/status`)
     .query(queryParams)
-    .reply(200, backupState);
+    .reply(responseStatus || 200, backupState);
 }
 
-function getDeploymentRestoreStatus(name, token, state) {
+function getDeploymentRestoreStatus(name, token, state, responseStatus) {
   const restoreState = {
     state: state || 'processing',
     stage: 'Restore completed successfully',
     updated_at: isoDate(Date.now())
   };
+  let queryParams = {
+    token: token
+  };
   return nock(serviceBrokerUrl)
     .replyContentLength()
-    .get(`/admin/deployments/${name}/restore/status?token=${token}`)
-    .reply(200, restoreState);
+    .get(`/admin/deployments/${name}/restore/status`)
+    .query(queryParams)
+    .reply(responseStatus || 200, restoreState);
 }


### PR DESCRIPTION
1. StatusPoller should cancel itself when NotFound error occurred form
  Status check API
2. Added UT to cover above scenario
3. Added UTs to cover resotre status check scenario
4. Patching metadata file of OOB backup with snapshotId when
   required
5. Discarding log from GET all backups of an OOB deployment.