### PR TITLE
Added addons as a non-foridden section in manifest

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -345,7 +345,8 @@ function hasChangesInForbiddenSections(diff) {
       'resource_pools',
       'networks',
       'properties',
-      'tags'
+      'tags',
+      'addons'
     ])
     .value();
   if (!_.isEmpty(forbiddenSections) && !_.includes(forbiddenSections, 'director_uuid')) {


### PR DESCRIPTION
Modified the code consider "addons" as a non-forbidden section while we check for outdated deployments .