### PR TITLE
added bluebird Promise in the BaseManager

### DIFF
--- a/lib/fabrik/BaseManager.js
+++ b/lib/fabrik/BaseManager.js
@@ -6,6 +6,7 @@ const config = require('../config');
 const errors = require('../errors');
 const NotImplementedBySubclass = errors.NotImplementedBySubclass;
 const CONST = require('../constants');
+const Promise = require('bluebird');
 
 class BaseManager {
   constructor(plan) {


### PR DESCRIPTION
Solution for the issue https://github.com/cloudfoundry-incubator/service-fabrik-broker/issues/122 generated a regression issue. 
Root cause: The Promise returned from BaseManager.js was not a bluebird promise which was causing issue with .tap function called in FabrikStatusPoller, hence backup was failing.
This fix solves it.