### PR TITLE
Restore across service plans

### DIFF
--- a/bin/broker
+++ b/bin/broker
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-broker_host="10.0.2.2:9292"
+broker_host="127.0.0.1:9292"
 instance_guid=""
 plan_id=""
 service_id=""
@@ -11,6 +11,7 @@ auth_header=""
 function init() {
   # service instance name
   local name="${1}"
+  [[ -z $name ]] && echo "Service name absent" && exit
   # instance
   local instance=$(cf curl "/v2/service_instances?q=name:${name}" | jq -r .resources[0])
   instance_guid=$(echo ${instance} | jq -r .metadata.guid)
@@ -33,6 +34,10 @@ function init_without_instance() {
   auth_header=$(cat ~/.cf/config.json | jq -r .AccessToken)
 }
 
+function info() {
+  curl "http://${broker_host}/api/v1/info" -L -k
+}
+
 ########## GENERAL
 
 function service_instance_state() {
@@ -52,7 +57,12 @@ function backup_start() {
   # backup type
   local backup_type="${2:-online}"
   # start backup
-  local result=$(curl -s -H "Authorization: ${auth_header}" -H "Accept: application/json" "http://${broker_host}/api/v1/service_instances/${instance_guid}/backup" -X POST -d "type=${backup_type}&space_guid=${space_guid}&plan_id=${plan_id}")
+  local result=$(curl -skL                                                   \
+    -H "Authorization: ${auth_header}"                                       \
+    -H "Accept: application/json"                                            \
+    "http://${broker_host}/api/v1/service_instances/${instance_guid}/backup" \
+    -X POST                                                                  \
+    -d "type=${backup_type}&space_guid=${space_guid}&plan_id=${plan_id}")
   # return
   echo ${result}
 }
@@ -61,7 +71,10 @@ function backup_state() {
   # init
   init "${1}"
   # get backup state
-  local result=$(curl -s -H "Authorization: ${auth_header}" -H "Accept: application/json" "http://${broker_host}/api/v1/service_instances/${instance_guid}/backup?space_guid=${space_guid}")
+  local result=$(curl -skL             \
+    -H "Authorization: ${auth_header}" \
+    -H "Accept: application/json"      \
+    "http://${broker_host}/api/v1/service_instances/${instance_guid}/backup?space_guid=${space_guid}")
   # return
   echo ${result}
 }
@@ -83,7 +96,13 @@ function restore_start() {
   # backup guid
   local backup_guid="${2:-null}"
   # start restore
-  local result=$(curl -s -H "Authorization: ${auth_header}" -H "Accept: application/json" "http://${broker_host}/api/v1/service_instances/${instance_guid}/restore" -X POST -d "backup_guid=${backup_guid}&space_guid=${space_guid}&plan_id=${plan_id}")
+  local result=$(curl                                                         \
+    -skL                                                                      \
+    --post302                                                                 \
+    -H "Authorization: ${auth_header}"                                        \
+    -H "Accept: application/json"                                             \
+    "http://${broker_host}/api/v1/service_instances/${instance_guid}/restore" \
+    -X POST -d "backup_guid=${backup_guid}&space_guid=${space_guid}&plan_id=${plan_id}")
   # return
   echo ${result}
 }
@@ -92,7 +111,11 @@ function restore_state() {
   # init
   init "${1}"
   # get restore state
-  local result=$(curl -s -H "Authorization: ${auth_header}" -H "Accept: application/json" "http://${broker_host}/api/v1/service_instances/${instance_guid}/restore?space_guid=${space_guid}")
+  local result=$(curl                  \
+    -skL                               \
+    --post302                          \
+    -H "Authorization: ${auth_header}" \
+    -H "Accept: application/json" "http://${broker_host}/api/v1/service_instances/${instance_guid}/restore?space_guid=${space_guid}")
   # return
   echo ${result}
 }
@@ -189,6 +212,7 @@ function dispatch() {
     "-h") help; exit 0;;
     "--host") broker_host="${2}"; dispatch ${@:3};;
     "state")        service_instance_state ${@:2};;
+    "info")         info ${@:2};;
     "backup-start") backup_start ${@:2};;
     "backup-state") backup_state ${@:2};;
     "backup-abort") backup_abort ${@:2};;

--- a/lib/controllers/ServiceFabrikApiController.js
+++ b/lib/controllers/ServiceFabrikApiController.js
@@ -296,7 +296,7 @@ class ServiceFabrikApiController extends BaseController {
           throw new UnprocessableEntity(`Can not restore backup '${backup_guid}' due to state '${metadata.state}'`);
         }
         if (!req.manager.isRestorePossible(metadata.plan_id)) {
-          throw new UnprocessableEntity(`Backup '${backup_guid}' to restore from is not applicable to the instance's service plan`);
+          throw new UnprocessableEntity(`Cannot restore backup: '${backup_guid}' to plan:'${metadata.plan_id}'`);
         }
       })
       .then(metadata => this.fabrik

--- a/lib/controllers/ServiceFabrikApiController.js
+++ b/lib/controllers/ServiceFabrikApiController.js
@@ -276,7 +276,6 @@ class ServiceFabrikApiController extends BaseController {
     req.manager.verifyFeatureSupport('restore');
     const backup_guid = req.body.backup_guid;
     const space_guid = req.entity.space_guid;
-    const plan_id = req.manager.plan.id;
     const bearer = _
       .chain(req.headers)
       .get('authorization')
@@ -296,7 +295,7 @@ class ServiceFabrikApiController extends BaseController {
         if (metadata.state !== 'succeeded') {
           throw new UnprocessableEntity(`Can not restore backup '${backup_guid}' due to state '${metadata.state}'`);
         }
-        if (metadata.plan_id !== plan_id) {
+        if (!req.manager.isRestorePossible(metadata.plan_id)) {
           throw new UnprocessableEntity(`Backup '${backup_guid}' to restore from is not applicable to the instance's service plan`);
         }
       })
@@ -440,13 +439,12 @@ class ServiceFabrikApiController extends BaseController {
       .set('instance_id', req.params.instance_id)
       .set('trigger', CONST.BACKUP.TRIGGER.SCHEDULED)
       .set('space_guid', req.entity.space_guid)
-      .set('plan_id', req.manager.plan.id)
       .set('service_id', req.manager.service.id)
       .value();
     return this.cloudController.getOrgAndSpaceDetails(data.instance_id, data.space_guid)
       .then(space => {
         const serviceDetails = catalog.getService(data.service_id);
-        const planDetails = catalog.getPlan(data.plan_id);
+        const planDetails = catalog.getPlan(req.manager.plan.id);
         _.chain(data)
           .set('service_name', serviceDetails.name)
           .set('service_plan_name', planDetails.name)

--- a/lib/fabrik/BaseManager.js
+++ b/lib/fabrik/BaseManager.js
@@ -33,6 +33,10 @@ class BaseManager {
     return this.settings.update_predecessors || [];
   }
 
+  get restorePredecessors() {
+    return this.settings.restore_predecessors || this.updatePredecessors;
+  }
+
   isAutoUpdatePossible() {
     throw new NotImplementedBySubclass('isAutoUpdatePossible');
   }
@@ -40,6 +44,11 @@ class BaseManager {
   isUpdatePossible(plan_id) {
     const previousPlan = _.find(this.service.plans, ['id', plan_id]);
     return this.plan === previousPlan || _.includes(this.updatePredecessors, previousPlan.id);
+  }
+
+  isRestorePossible(plan_id) {
+    const previousPlan = _.find(this.service.plans, ['id', plan_id]);
+    return this.plan === previousPlan || _.includes(this.restorePredecessors, previousPlan.id);
   }
 
   getSecurityGroupName(guid) {

--- a/lib/iaas/BackupStoreForServiceInstance.js
+++ b/lib/iaas/BackupStoreForServiceInstance.js
@@ -11,14 +11,12 @@ class BackupStoreForServiceInstance extends BackupStore {
     const keys = {
       backup: [
         'service_id',
-        'plan_id',
         'instance_guid',
         'backup_guid',
         'started_at'
       ],
       restore: [
         'service_id',
-        'plan_id',
         'instance_guid'
       ]
     };
@@ -32,17 +30,13 @@ class BackupStoreForServiceInstance extends BackupStore {
     }
     const space_guid = options.space_guid;
     const service_id = options.service_id;
-    const plan_id = options.plan_id;
     const instance_guid = options.instance_guid || options.instance_id;
     let prefix = `${space_guid}/backup`;
 
     if (service_id) {
       prefix += `/${service_id}`;
-      if (plan_id) {
-        prefix += `.${plan_id}`;
-        if (instance_guid) {
-          prefix += `.${instance_guid}`;
-        }
+      if (instance_guid) {
+        prefix += `.${instance_guid}`;
       }
     }
     return prefix;
@@ -51,7 +45,6 @@ class BackupStoreForServiceInstance extends BackupStore {
   findBackupFilename(options) {
     const space_guid = options.space_guid;
     const service_id = options.service_id;
-    const plan_id = options.plan_id;
     const instance_guid = options.instance_guid || options.instance_id;
     const backup_guid = options.backup_guid;
     const iteratees = ['started_at'];
@@ -60,8 +53,8 @@ class BackupStoreForServiceInstance extends BackupStore {
     let predicate;
     let message = `No backup found`;
 
-    if (service_id && plan_id && instance_guid) {
-      prefix += `/${service_id}.${plan_id}.${instance_guid}`;
+    if (service_id && instance_guid) {
+      prefix += `/${service_id}.${instance_guid}`;
       if (backup_guid) {
         prefix += `.${backup_guid}`;
         message = `Backup '${backup_guid}' not found`;
@@ -86,7 +79,6 @@ class BackupStoreForServiceInstance extends BackupStore {
   listLastBackupFiles(options) {
     const space_guid = options.space_guid;
     const service_id = options.service_id;
-    const plan_id = options.plan_id;
     const iteratees = ['instance_guid', 'started_at'];
 
     let prefix = `${space_guid}/backup`;
@@ -94,9 +86,6 @@ class BackupStoreForServiceInstance extends BackupStore {
 
     if (service_id) {
       prefix += `/${service_id}`;
-      if (plan_id) {
-        prefix += `.${plan_id}`;
-      }
     }
 
     return this
@@ -116,7 +105,6 @@ class BackupStoreForServiceInstance extends BackupStore {
   listLastRestoreFiles(options) {
     const space_guid = options.space_guid;
     const service_id = options.service_id;
-    const plan_id = options.plan_id;
     const iteratees = ['instance_guid'];
 
     let prefix = `${space_guid}/restore`;
@@ -124,9 +112,6 @@ class BackupStoreForServiceInstance extends BackupStore {
 
     if (service_id) {
       prefix += `/${service_id}`;
-      if (plan_id) {
-        prefix += `.${plan_id}`;
-      }
     }
 
     return this

--- a/test/acceptance/service-broker-api.instances.director.spec.js
+++ b/test/acceptance/service-broker-api.instances.director.spec.js
@@ -179,7 +179,7 @@ describe('service-broker-api', function () {
 
       describe('#deprovision', function () {
         it('returns 202 Accepted', function () {
-          const restoreFilename = `${space_guid}/restore/${service_id}.${plan_id}.${instance_id}.json`;
+          const restoreFilename = `${space_guid}/restore/${service_id}.${instance_id}.json`;
           const restorePathname = `/${container}/${restoreFilename}`;
           mocks.director.getDeploymentManifest();
           mocks.agent.getInfo();

--- a/test/acceptance/service-fabrik-admin.backups.director.spec.js
+++ b/test/acceptance/service-fabrik-admin.backups.director.spec.js
@@ -31,7 +31,7 @@ describe('service-fabrik-admin', function () {
         started_at: started_at,
         space_guid: space_guid
       };
-      const backups = [_.omit(filenameObject, 'operation')];
+      const backups = [_.omit(filenameObject, 'operation', 'plan_id')];
       const filenameObj = filename.create(filenameObject).name;
       const pathname = `/${container}/${filenameObj}`;
       const data = {
@@ -94,7 +94,7 @@ describe('service-fabrik-admin', function () {
       });
 
       describe('#deleteBackup', function () {
-        const prefix = `${space_guid}/${operation}/${service_id}.${plan_id}.${instance_id}.${backup_guid}`;
+        const prefix = `${space_guid}/${operation}/${service_id}.${instance_id}.${backup_guid}`;
         it('should successfully delete an existing backup', function () {
           mocks.cloudProvider.list(container, prefix, [filenameObj]);
           mocks.cloudProvider.remove(pathname);

--- a/test/acceptance/service-fabrik-api.backups.director.spec.js
+++ b/test/acceptance/service-fabrik-api.backups.director.spec.js
@@ -15,13 +15,12 @@ describe('service-fabrik-api', function () {
       const backup_guid = '071acb05-66a3-471b-af3c-8bbf1e4180be';
       const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
       const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
-      const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
       const container = backupStore.containerName;
       const blueprintContainer = `${backupStore.containerPrefix}-blueprint`;
       const instance_id = 'ab0ed6d6-42d9-4318-9b65-721f34719499';
       const started_at = '2015-11-18T11-28-42Z';
       const prefix = `${space_guid}/backup`;
-      const filename = `${prefix}/${service_id}.${plan_id}.${instance_id}.${backup_guid}.${started_at}.json`;
+      const filename = `${prefix}/${service_id}.${instance_id}.${backup_guid}.${started_at}.json`;
       const pathname = `/${container}/${filename}`;
       const data = {
         backup_guid: backup_guid,

--- a/test/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/acceptance/service-fabrik-api.instances.director.spec.js
@@ -239,7 +239,7 @@ describe('service-fabrik-api', function () {
         });
       });
       describe('#backup-start', function () {
-        const prefix = `${space_guid}/backup/${service_id}.${plan_id}.${instance_id}.${backup_guid}`;
+        const prefix = `${space_guid}/backup/${service_id}.${instance_id}.${backup_guid}`;
         const filename = `${prefix}.${started_at}.json`;
         const pathname = `/${container}/${filename}`;
         const type = 'online';
@@ -252,7 +252,7 @@ describe('service-fabrik-api', function () {
           type: type,
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         };
-        const list_prefix = `${space_guid}/backup/${service_id}.${plan_id}.${instance_id}`;
+        const list_prefix = `${space_guid}/backup/${service_id}.${instance_id}`;
         const list_filename = `${list_prefix}.${backup_guid}.${started_at}.json`;
         const list_filename2 = `${list_prefix}.${backup_guid}.${isoDate(time+1)}.json`;
         const list_pathname = `/${container}/${list_filename}`;
@@ -579,7 +579,7 @@ describe('service-fabrik-api', function () {
       });
 
       describe('#backup-state', function () {
-        const prefix = `${space_guid}/backup/${service_id}.${plan_id}.${instance_id}`;
+        const prefix = `${space_guid}/backup/${service_id}.${instance_id}`;
         const filename = `${prefix}.${backup_guid}.${started_at}.json`;
         const pathname = `/${container}/${filename}`;
         const data = {
@@ -670,7 +670,7 @@ describe('service-fabrik-api', function () {
       });
 
       describe('#backup-abort', function () {
-        const prefix = `${space_guid}/backup/${service_id}.${plan_id}.${instance_id}`;
+        const prefix = `${space_guid}/backup/${service_id}.${instance_id}`;
         const filename = `${prefix}.${backup_guid}.${started_at}.json`;
         const pathname = `/${container}/${filename}`;
         const data = {
@@ -735,10 +735,10 @@ describe('service-fabrik-api', function () {
       });
 
       describe('#restore-start', function () {
-        const restorePrefix = `${space_guid}/restore/${service_id}.${plan_id}.${instance_id}`;
+        const restorePrefix = `${space_guid}/restore/${service_id}.${instance_id}`;
         const backupPrefix = `${space_guid}/backup`;
         const restoreFilename = `${restorePrefix}.json`;
-        const backupFilename = `${backupPrefix}/${service_id}.${plan_id}.${instance_id}.${backup_guid}.${started_at}.json`;
+        const backupFilename = `${backupPrefix}/${service_id}.${instance_id}.${backup_guid}.${started_at}.json`;
         const restorePathname = `/${container}/${restoreFilename}`;
         const backupPathname = `/${container}/${backupFilename}`;
         const name = 'restore';
@@ -1005,7 +1005,7 @@ describe('service-fabrik-api', function () {
       });
 
       describe('#restore-state', function () {
-        const prefix = `${space_guid}/restore/${service_id}.${plan_id}.${instance_id}`;
+        const prefix = `${space_guid}/restore/${service_id}.${instance_id}`;
         const filename = `${prefix}.json`;
         const pathname = `/${container}/${filename}`;
         const data = {
@@ -1061,7 +1061,7 @@ describe('service-fabrik-api', function () {
       });
 
       describe('#restore-abort', function () {
-        const prefix = `${space_guid}/restore/${service_id}.${plan_id}.${instance_id}`;
+        const prefix = `${space_guid}/restore/${service_id}.${instance_id}`;
         const filename = `${prefix}.json`;
         const pathname = `/${container}/${filename}`;
         const data = {
@@ -1124,9 +1124,9 @@ describe('service-fabrik-api', function () {
 
       describe('#listLastBackups', function () {
         const prefix = `${space_guid}/backup/${service_id}`;
-        const filename1 = `${prefix}.${plan_id}.${instance_id}.${backup_guid}.${started_at}.json`;
-        const filename2 = `${prefix}.${plan_id}.${instance_id}.${backup_guid}.${isoDate(time+1)}.json`;
-        const filename3 = `${prefix}.${plan_id}.${instance_id}.${backup_guid}.${isoDate(time+2)}.json`;
+        const filename1 = `${prefix}.${instance_id}.${backup_guid}.${started_at}.json`;
+        const filename2 = `${prefix}.${instance_id}.${backup_guid}.${isoDate(time+1)}.json`;
+        const filename3 = `${prefix}.${instance_id}.${backup_guid}.${isoDate(time+2)}.json`;
         const pathname3 = `/${container}/${filename3}`;
         const data = {
           trigger: CONST.BACKUP.TRIGGER.ON_DEMAND,
@@ -1165,8 +1165,8 @@ describe('service-fabrik-api', function () {
       describe('#listLastRestores', function () {
         const instance_id2 = 'fff659f7-3fb4-4034-aaf3-ab103698f6b0';
         const prefix = `${space_guid}/restore/${service_id}`;
-        const filename1 = `${prefix}.${plan_id}.${instance_id}.json`;
-        const filename2 = `${prefix}.${plan_id}.${instance_id2}.json`;
+        const filename1 = `${prefix}.${instance_id}.json`;
+        const filename2 = `${prefix}.${instance_id2}.json`;
         const pathname1 = `/${container}/${filename1}`;
         const pathname2 = `/${container}/${filename2}`;
         const data = {
@@ -1209,8 +1209,8 @@ describe('service-fabrik-api', function () {
         const prefix = `${space_guid}/backup`;
         const started14DaysPrior = filename.isoDate(moment()
           .subtract(config.backup.retention_period_in_days + 1, 'days').toISOString());
-        const filenameObj = `${prefix}/${service_id}.${plan_id}.${instance_id}.${backup_guid}.${started_at}.json`;
-        const filename14DaysPrior = `${prefix}/${service_id}.${plan_id}.${instance_id}.${backup_guid}.${started14DaysPrior}.json`;
+        const filenameObj = `${prefix}/${service_id}.${instance_id}.${backup_guid}.${started_at}.json`;
+        const filename14DaysPrior = `${prefix}/${service_id}.${instance_id}.${backup_guid}.${started14DaysPrior}.json`;
         const pathname = `/${container}/${filenameObj}`;
         const pathName14DaysPrior = `/${container}/${filename14DaysPrior}`;
         const data = {

--- a/test/fabrik.DirectorManager.spec.js
+++ b/test/fabrik.DirectorManager.spec.js
@@ -35,6 +35,9 @@ var DirectorManager = proxyquire('../lib/fabrik/DirectorManager', {
 describe('fabrik', function () {
   describe('DirectorManager', function () {
     const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
+    const xsmall_plan_id = plan_id;
+    const small_plan_id = 'bc158c9a-7934-401e-94ab-057082a5073e';
+    let killJsHintWarning;
     let manager;
 
     before(function () {
@@ -55,6 +58,26 @@ describe('fabrik', function () {
         manager.findNetworkSegmentIndex(used_guid).then(res => expect(res).to.eql(21));
       });
     });
-
+    describe('#isRestorePossible', function () {
+      it('should return false when plan not in restore_predecessors', function () {
+        // restore not possible from small to xsmall
+        manager = new DirectorManager(catalog.getPlan(xsmall_plan_id));
+        manager.update_predecessors = [];
+        killJsHintWarning = expect(manager.isRestorePossible(small_plan_id)).to.be.false;
+      });
+      it('should return true when plan not in restore_predecessors', function () {
+        // restore possible from xsmall to small
+        manager = new DirectorManager(catalog.getPlan(small_plan_id));
+        manager.update_predecessors = [xsmall_plan_id];
+        killJsHintWarning = expect(manager.isRestorePossible(xsmall_plan_id)).to.be.true;
+      });
+    });
+    describe('#restorePredecessors', function () {
+      it('should return update_predecessors if restore_predecessors is not defined', function () {
+        manager = new DirectorManager(catalog.getPlan(small_plan_id));
+        manager.update_predecessors = [xsmall_plan_id];
+        expect(manager.restorePredecessors).to.eql(manager.update_predecessors);
+      });
+    });
   });
 });

--- a/test/fabrik.DirectorManager.spec.js
+++ b/test/fabrik.DirectorManager.spec.js
@@ -37,7 +37,7 @@ describe('fabrik', function () {
     const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
     const xsmall_plan_id = plan_id;
     const small_plan_id = 'bc158c9a-7934-401e-94ab-057082a5073e';
-    let killJsHintWarning;
+    let return_value;
     let manager;
 
     before(function () {
@@ -63,13 +63,13 @@ describe('fabrik', function () {
         // restore not possible from small to xsmall
         manager = new DirectorManager(catalog.getPlan(xsmall_plan_id));
         manager.update_predecessors = [];
-        killJsHintWarning = expect(manager.isRestorePossible(small_plan_id)).to.be.false;
+        return_value = expect(manager.isRestorePossible(small_plan_id)).to.be.false;
       });
       it('should return true when plan not in restore_predecessors', function () {
         // restore possible from xsmall to small
         manager = new DirectorManager(catalog.getPlan(small_plan_id));
         manager.update_predecessors = [xsmall_plan_id];
-        killJsHintWarning = expect(manager.isRestorePossible(xsmall_plan_id)).to.be.true;
+        return_value = expect(manager.isRestorePossible(xsmall_plan_id)).to.be.true;
       });
     });
     describe('#restorePredecessors', function () {

--- a/test/jobs.BackupReaperJobs.spec.js
+++ b/test/jobs.BackupReaperJobs.spec.js
@@ -19,7 +19,6 @@ describe('Jobs', function () {
     const index = mocks.director.networkSegmentIndex;
     const instance_id = mocks.director.uuidByIndex(index);
     const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
-    const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
     const backup_guid = '071acb05-66a3-471b-af3c-8bbf1e4180be';
     const backup_guid2 = '081acb05-66a3-471b-af3c-8bbf1e4180bf';
     //const backup_guid3 = '091acb05-66a3-471b-af3c-8bbf1e4180bg';
@@ -31,7 +30,7 @@ describe('Jobs', function () {
       .subtract(config.backup.retention_period_in_days + 4, 'days').toISOString());
     const started16DaysPrior = filename.isoDate(moment()
       .subtract(config.backup.retention_period_in_days + 2, 'days').toISOString());
-    const prefix = `${space_guid}/backup/${service_id}.${plan_id}.${instance_id}`;
+    const prefix = `${space_guid}/backup/${service_id}.${instance_id}`;
     //const fileName1Daysprior = `${prefix}.${backup_guid3}.${started1DaysPrior}.json`;
     const fileName16Daysprior = `${prefix}.${backup_guid}.${started16DaysPrior}.json`;
     const fileName18DaysPrior = `${prefix}.${backup_guid2}.${started18DaysPrior}.json`;

--- a/test/jobs.ScheduleBackupJob.spec.js
+++ b/test/jobs.ScheduleBackupJob.spec.js
@@ -35,8 +35,8 @@ describe('Jobs', function () {
         .subtract(config.backup.retention_period_in_days + 4, 'days').toISOString());
       const started14DaysPrior = filename.isoDate(moment()
         .subtract(config.backup.retention_period_in_days + 1, 'days').toISOString());
-      const prefix = `${space_guid}/backup/${service_id}.${plan_id}.${instance_id}`;
-      const failed_prefix = `${space_guid}/backup/${service_id}.${plan_id}.${failed_instance_id}`;
+      const prefix = `${space_guid}/backup/${service_id}.${instance_id}`;
+      const failed_prefix = `${space_guid}/backup/${service_id}.${failed_instance_id}`;
       const fileName1Daysprior = `${prefix}.${backup_guid3}.${started1DaysPrior}.json`;
       const fileName14Daysprior = `${prefix}.${backup_guid}.${started14DaysPrior}.json`;
       const fileName18DaysPrior = `${prefix}.${backup_guid2}.${started18DaysPrior}.json`;


### PR DESCRIPTION
With this change Service Fabrik should be able to restore the backup of
one plan across plans of the same instance. Only backups taken from
plans specified in the restore_predecessor section of the current plan
can be restored. If the restore_predecessor section is absent in the
plan update_predecessor is checked.

* Broker script changes for working with bosh-lite: Added `--post302`
  which is necessary to query broker when the url has redirection.
* Added restore_predecessors check for update operation.
* Removed plan_id from backup and restore file name.
* Unit and acceptance tests.