### PR TITLE
Add script to setup git-secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,16 @@ cf target -o dev -s broker
 * Clone this repo (assuming your working directory is ~/workspace)
 ```shell
 cd ~/workspace
-git clone https://github.com/sap/service-fabrik-broker
-cd service-fabrik-broker
 ```
+* Clone and setup fork and git-secrets ( requires [hub] and [git secrets] to be
+  installed)
+  ```
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/cloudfoundry-incubator/service-fabrik-broker/master/bin/clone-for-development)"
+  cd service-fabrik-broker
+  git checkout -b my-new-feature
+  # make code changes
+  git push <github_username> my-new-feature
+  ```
 * Install dependencies
 ```shell
 npm install
@@ -213,3 +220,6 @@ Finally, once in the SSH session, [these bash functions](https://docs.travis-ci.
 ## LICENSE
 
 This project is licensed under the Apache Software License, v. 2 except as noted otherwise in the [LICENSE](LICENSE) file.
+
+[hub]: https://github.com/github/hub
+[git secrets]: https://github.com/awslabs/git-secrets

--- a/bin/clone-for-development
+++ b/bin/clone-for-development
@@ -1,0 +1,22 @@
+#!/bin/bash
+if ! which hub > /dev/null ; then
+    echo "Install hub (https://github.com/github/hub):"
+    echo "Mac OS  : brew install hub"
+    echo "Windows : choco install hub"
+    echo "Linux   : Available in respective package manager"
+    exit
+fi
+
+if ! which git-secrets > /dev/null ; then
+    echo "Install git-secrets (https://github.com/awslabs/git-secrets):"
+    echo "Mac OS  : brew install git-secrets"
+    echo "Others  : https://github.com/awslabs/git-secrets#installing-git-secrets)"
+    exit
+fi
+
+git config --global hub.protocol https
+git clone https://github.com/cloudfoundry-incubator/service-fabrik-broker
+cd service-fabrik-broker
+hub fork
+git secrets --install
+git secrets --register-aws


### PR DESCRIPTION
The changes include:

* One line command to setup development repo

The command executes a script which:
* Clones the repo 
* Fork the repo to user account in github. If fork is already present, the fork is updated.
* Setup git-secrets to prevent commits when credential information is present

Issue #147 