### PR TITLE
virtualhost service instance deletion is failing because entry in deploymentIpsCache used in BoshDirectorClient is not cleaned

### DIFF
--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -383,6 +383,7 @@ class BoshDirectorClient extends HttpClient {
   }
 
   deleteDeployment(deploymentName) {
+    delete this.deploymentIpsCache[deploymentName];
     return this
       .makeRequest({
         method: 'DELETE',


### PR DESCRIPTION
Closes-Bug: https://github.com/cloudfoundry-incubator/service-fabrik-broker/issues/157
Description: virtualhost service instance deletion is failing because entry in deploymentIpsCache used in BoshDirectorClient is not cleaned when a deployment is deleted.
This fix removes the entry from deploymentIpsCache when delete deployment is called, as similarly done in the code when createOrUpdate is called [here](https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/master/lib/bosh/BoshDirectorClient.js#L350).