### PR TITLE
Fixes #160: Fixing broker startup if pkgcloud doesnt support iaas

### DIFF
--- a/lib/iaas/index.js
+++ b/lib/iaas/index.js
@@ -13,8 +13,12 @@ const getCloudClient = function (settings) {
   switch (settings.name) {
   case 'azure':
     return new AzureClient(settings);
-  default:
+  case 'aws':
+  case 'openstack':
+  case 'os':
     return new CloudProviderClient(settings);
+  default:
+    return new BaseCloudClient(settings);
   }
 };
 const cloudProvider = getCloudClient(config.backup.provider);


### PR DESCRIPTION
Description: Modifying the getCloudClient to return BaseCloudClient
in case of default cases to handle use-cases like Alibaba