### PR TITLE
Add logic to avoid multiple event subscribers in EventLogDBClient

### DIFF
--- a/lib/utils/EventLogDBClient.js
+++ b/lib/utils/EventLogDBClient.js
@@ -18,11 +18,15 @@ class EventLogDBClient {
   initialize() {
     const eventNames = _.get(config, 'monitoring.events_logged_in_db', '').replace(/\s*/g, '');
     this.eventsToBeLoggedInDB = eventNames.split(',');
-    if (_.get(this.options, 'event_type')) {
+    if (_.get(this.options, 'event_type') && this.HANDLE_EVENT_TOPIC === undefined) {
       this.HANDLE_EVENT_TOPIC = pubsub.subscribe(this.options.event_type, (message, data) => this.handleEvent(message, data));
       logger.debug(`EventLoggerDBClient subscribed to event ${this.options.event_type}`);
     } else {
-      logger.info('Event Type for EventLogDBClient is empty.!');
+      if (_.get(this.options, 'event_type') === undefined) {
+        logger.info('Event Type for EventLogDBClient is empty.!');
+      } else {
+        logger.info(`Already subscribed to event ${this.options.event_type}`);
+      }
     }
   }
 

--- a/test/utils.EventLogDBClient.spec.js
+++ b/test/utils.EventLogDBClient.spec.js
@@ -54,6 +54,15 @@ describe('utils', function () {
       expect(subscribeStub).to.be.calledTwice;
       expect(eventLogDBClient.eventsToBeLoggedInDB.length).to.equal(2);
     });
+    it('#initialize - subscribe only once to events', function () {
+      const eventLogDBClient = new EventLogDBClient({
+        event_type: 'SF.BROKER_EVENT'
+      });
+      initializeHandler();
+      initializeHandler();
+      expect(subscribeStub).to.be.calledThrice;
+      expect(eventLogDBClient.eventsToBeLoggedInDB.length).to.equal(2);
+    });
 
     describe('#logevent', function () {
       it('ignores invalid events', function () {


### PR DESCRIPTION
Closes #181 
* Modified the code to create event subscribers only once