### PR TITLE
Update truffleHog and git secrets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,9 @@ env:
   - SETTINGS_PATH="$(pwd)/config/settings.yml"
 script:
   - |
-     SECRETS=$(git diff "$TRAVIS_COMMIT_RANGE" | git secrets --scan -)
-     [[ -n "$SECRETS" ]] && echo "Failure: found secrets in repo $SECRETS" && exit 1;
-     depth=$(($(git rev-list --count "$TRAVIS_COMMIT_RANGE")+1))
-     echo "Running truffle hog with depth: $depth"
-     high_entropy=$(trufflehog --json --entropy true  --max_depth $depth . | jq -r '.commitHash')
-     [[ -n "$high_entropy" ]] && echo "FAILED: High entropy commits: $high_entropy" && exit 1
+     git secrets --install
+     git secrets --register-aws --global
+     git secrets --list
      IFS='' CHANGED_FILES=$(npm run -s jsformat -- | grep -v "unchanged")
      [[ -z $CHANGED_FILES ]] && NUM_CHANGED_FILES=0 || NUM_CHANGED_FILES=$(echo $CHANGED_FILES | wc -l)
      echo "Code formatting to be fixed in $NUM_CHANGED_FILES file(s)..."
@@ -33,3 +30,11 @@ script:
   - "npm run -s jshint-ci"
   - "npm run -s test-ci"
   - "npm run -s jsdoc"
+  - |
+     git secrets --scan-history || exit 1
+  - |
+     echo "Full repo scan of truffleHog"
+     trufflehog --json --entropy true ./
+     high_entropy=$(trufflehog --json --entropy true --regex ./)
+     echo "Truffle hog output : $high_entropy"
+     [[ -n "$high_entropy" ]] && exit 1

--- a/test/mocks/azureClient.js
+++ b/test/mocks/azureClient.js
@@ -2,6 +2,8 @@
 
 const _ = require('lodash');
 const nock = require('nock');
+const utils = require('../../lib/utils');
+
 const config = {
   backup: {
     retention_period_in_days: 14,
@@ -41,10 +43,15 @@ function encodePath(pathname) {
 }
 
 function auth() {
+  const token = {
+    type: 'update',
+    parameters: {},
+    task_id: 'service-fabrik-1790-46d34d39-83b1-4b2d-8260-50f2d66a0957_23598'
+  };
   return nock('https://login.microsoftonline.com')
     .replyContentLength()
     .post(`/${provider.tenant_id}/oauth2/token?api-version=1.0`, body => _.isObject(body))
-    .reply(200, '{\"token_type\":\"Bearer\",\"resource\":\"https://management.core.windows.net/\",\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDYyNTUzMjY5LCJuYmYiOjE0NjI1NTMyNjksImV4cCI6MTQ2MjU1NzE2OSwiYXBwaWQiOiJiOWU2ZTA3Yi1jNDNlLTQ3MzEtODVjYS05ODE3ODkyNzI0Y2QiLCJhcHBpZGFjciI6IjEiLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwib2lkIjoiNGUwNDNmODYtYjMzZC00YzNiLThjNTYtNWM3NTkyOGEzNzBlIiwic3ViIjoiNGUwNDNmODYtYjMzZC00YzNiLThjNTYtNWM3NTkyOGEzNzBlIiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidmVyIjoiMS4wIn0.rROtJoq7sd0BIfLtS-Ra9-xIN9lQPXnN0NvR8BWgEP8imEp1M3ryN8v1IUldiQeb6yhsf0Jg1QqA_vI8HUvCpDoCA7MvmSrMCVfrY7hKFDl9cJeFMILVXjWRbCHp29k0A_pz1r8au07_MmGGrEpBpc0Z5P1rr9qwOe4SmLCuC1poyNuERpwMtHXS4MwJ7mjz9OHsn_pvVxV9TMA-lcBxqfsxWPf8kbmHiFeyLonBftD-h0X7wjwJ-EGK6WSQ-bBtWyJNyJ6sDxqSUB4WpuywVVe_pCPcnKLhqD5tbW_thkyQG7nJ4bM_qqXvKIEtgxO0HGDIA7KS5AdMgBx8uNAC7g\"}', {
+    .reply(200, '{\"token_type\":\"Bearer\",\"resource\":\"https://management.core.windows.net/\",\"access_token\":\"' + utils.encodeBase64(token) + '\"}', {
       'cache-control': 'no-cache, no-store',
       pragma: 'no-cache',
       'content-type': 'application/json; charset=utf-8',
@@ -57,7 +64,7 @@ function auth() {
       'strict-transport-security': 'max-age=31536000; includeSubDomains',
       p3p: 'CP="DSP CUR OTPi IND OTRi ONL FIN"',
       'set-cookie': ['flight-uxoptin=true; path=/; secure; HttpOnly',
-        'esctx=AAABAAAAiL9Kn2Z27UubvWFPbm0gLY4-QrqiDgIz-sINlFJRDZ0O7CIVv7bQh4gFoVbsaXSs0r-5GztukLogUf2sAb9wT6h5SUOGBdHR8xuG1x0McpdIN6sEiyFu3A7y5h3qXk8STZhFpvCkUWhiOFtvGbebH1-MPESKUGn6BEfkVi7O8nkXgvT5ey-gEQHD9TsrLGtjIAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly',
+        'esctx=XXXXXXXXXX9XX2X27XXXXXXXXX0XXX4-XXXXXXXX-XXXXXXXXX0X7XXXX7XXX4XXXXXXXXXX0X-5XXXXXXXXXX2XXX9XX6X5XXXXXXXX8XXX1X0XXXXXX6XXXXXX3X7X5X3XXX8XXXXXXXXXXXXXXXXXXXXXX1-XXXXXXXX6XXXXXX7X8XXXXXX5XX-XXXXX9XXXXXXXXXX; domain=.login.microsoftonline.com; path=/; secure; HttpOnly',
         'x-ms-gateway-slice=productiona; path=/; secure; HttpOnly',
         'stsservicecookie=ests; path=/; secure; HttpOnly'
       ],

--- a/test/utils.EventLogDBClient.spec.js
+++ b/test/utils.EventLogDBClient.spec.js
@@ -4,6 +4,7 @@ const proxyquire = require('proxyquire');
 const pubsub = require('pubsub-js');
 const Repository = require('../lib/db').Repository;
 const CONST = require('../lib/constants');
+const jwt = require('../lib/jwt');
 
 describe('utils', function () {
   /* jshint expr:true */
@@ -87,6 +88,20 @@ describe('utils', function () {
         expect(saveStub).not.to.be.called;
       });
       it('successfully logs event to DB', function () {
+        const operation = {
+          aud: 'https://management.core.windows.net/',
+          iss: 'https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/',
+          iat: 1462553269,
+          nbf: 1462553269,
+          exp: 1462557169,
+          appid: 'b9e6e07b-c43e-4731-85ca-9817892724cd',
+          appidacr: '1',
+          idp: 'https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/',
+          oid: '4e043f86-b33d-4c3b-8c56-5c75928a370e',
+          sub: '4e043f86-b33d-4c3b-8c56-5c75928a370e',
+          tid: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+          ver: '1.0'
+        };
         const eventInfo = {
           host: '4c30f022-a041-4100-aa15-0c9979ca7938',
           eventName: 'CF.broker.0.service-fabrik.director.update_instance',
@@ -97,7 +112,7 @@ describe('utils', function () {
           time: new Date(),
           request: {
             instance_id: '46d34d39-83b1-4b2d-8260-50f2d66a0957',
-            operation: 'eyJ0eXBlIjoidXBkYXRlIiwicGFyYW1ldGVycyI6e30sInRhc2tfaWQiOiJzZXJ2aWNlLWZhYnJpay0xNzkwLTQ2ZDM0ZDM5LTgzYjEtNGIyZC04MjYwLTUwZjJkNjZhMDk1N18yMzU5OCJ9',
+            operation: jwt.sign(operation, 'secret'),
             plan_id: 'a49cd221-e8c2-4f22-a2a6-366bf00b5c54',
             service_id: '6db542eb-8187-4afc-8a85-e08b4a3cc24e',
             user: {


### PR DESCRIPTION
For enabling truffleHog check in the repository properly all high entropy strings
needs to be removed.
* The repository contains some strings which are either base64 encoded or jwt signed.
   Instead of directly using the encoded strings, the decoded objects are used 
   and they are encoded in run time. This increases legibility also.
* Git secrets needs to have providers explicitly installed.