### PR TITLE
Fixes for OSB API Changes

### DIFF
--- a/lib/fabrik/DirectorInstance.js
+++ b/lib/fabrik/DirectorInstance.js
@@ -25,15 +25,18 @@ class DirectorInstance extends BaseInstance {
   get platformContext() {
     return Promise.try(() => this.networkSegmentIndex ? this.deploymentName : this.manager.director.getDeploymentNameForInstanceId(this.guid))
       .then(deploymentName => this.manager.director.getDeploymentProperty(deploymentName, CONST.PLATFORM_CONTEXT_KEY))
+      .then(context => JSON.parse(context))
       .catch(NotFound, () => {
         /* Following is to handle existing deployments. 
            For them platform-context is not saved in deployment property. Defaults to CF.
          */
         logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
-      Setting default platform as '${CONST.PLATFORM.CF}'`);
-        return Promise.resolve({
+        Setting default platform as '${CONST.PLATFORM.CF}'`);
+
+        const context = {
           platform: CONST.PLATFORM.CF
-        });
+        };
+        return context;
       });
   }
 
@@ -76,17 +79,15 @@ class DirectorInstance extends BaseInstance {
   }
 
   deleteRestoreFile() {
-    Promise.try(() => {
-      if (_.includes(this.manager.agent.features, 'backup')) {
-        return this.platformManager.ensureTenantId()
-          .then(space_guid => this.manager.deleteRestoreFile(space_guid, this.guid))
-          .catch(err => {
-            logger.error(`Failed to delete restore file of instance '${this.guid}'`);
-            logger.error(err);
-            throw err;
-          });
-      }
-    });
+    if (_.includes(this.manager.agent.features, 'backup')) {
+      return Promise.try(() => this.platformManager.ensureTenantId())
+        .then(tenant_id => tenant_id ? this.manager.deleteRestoreFile(tenant_id, this.guid) : Promise.resolve({}))
+        .catch(err => {
+          logger.error(`Failed to delete restore file of instance '${this.guid}'`);
+          logger.error(err);
+          throw err;
+        });
+    }
   }
 
   finalize(operation) {
@@ -193,6 +194,7 @@ class DirectorInstance extends BaseInstance {
             .assign(result)
             .set('username', serviceFabrikOperation.username)
             .set('useremail', serviceFabrikOperation.useremail)
+            .set('context', params.context)
             .value()
           );
       });

--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -643,7 +643,7 @@ class DirectorManager extends BaseManager {
     const options = _.assign({
       service_id: this.service.id,
       plan_id: this.plan.id,
-      tenant_id: this.getTenantGuid(opts.context)
+      tenant_id: opts.context ? this.getTenantGuid(opts.context) : opts.tenant_id
     }, opts);
 
     function isFinished(state) {
@@ -777,7 +777,7 @@ class DirectorManager extends BaseManager {
     const options = _.assign({
       service_id: this.service.id,
       plan_id: this.plan.id,
-      tenant_id: this.getTenantGuid(opts.context)
+      tenant_id: opts.context ? this.getTenantGuid(opts.context) : opts.tenant_id
     }, opts);
 
     function isFinished(state) {

--- a/lib/fabrik/DockerInstance.js
+++ b/lib/fabrik/DockerInstance.js
@@ -61,9 +61,10 @@ class DockerInstance extends BaseInstance {
          */
           logger.warn(`Container env '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\
           Setting default platform as '${CONST.PLATFORM.CF}'`);
-          return Promise.resolve({
+          const context = {
             platform: CONST.PLATFORM.CF
-          });
+          };
+          return context;
         }
       });
   }

--- a/test/mocks/director.js
+++ b/test/mocks/director.js
@@ -304,7 +304,7 @@ function getDeploymentProperty(deploymentName, found, key, value) {
     .get(`/deployments/${deploymentName}/properties/${key}`)
     .reply(200,
       JSON.stringify({
-        value: value
+        value: JSON.stringify(value)
       } || {})
     );
 }


### PR DESCRIPTION
1. For non-cf platforms avoiding deleting restore file at the time of deletion of service instance
2. Parsing context from BOSH property
3. UT mock fix