### PR TITLE
Create a branch before running truffleHog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ script:
      git secrets --scan-history || exit 1
   - |
      echo "Full repo scan of truffleHog"
+     # truffleHog only scans git endpoints which have a ref.
+     # truffleHog check fails to detect changed because travis merge creates a detached HEAD
+     # Creating a branch to fix this issue
+     git checkout -b travis-merge
      high_entropy=$(trufflehog --json --entropy true --regex "$TRAVIS_BUILD_DIR")
      echo "Truffle hog output : $high_entropy"
      if [[ "$high_entropy" != "" ]] ; then exit 1; fi


### PR DESCRIPTION
truffleHog do not scan from a detached HEAD.
Pull requests to travis are merged to the origin but the HEAD is left
detached. Hence truffleHog check fails to detect changes.
Creating a branch to fix this issue