### PR TITLE
Fix for the blank security group creation problem

### DIFF
--- a/config/eventlog-config-internal.yml
+++ b/config/eventlog-config-internal.yml
@@ -10,14 +10,14 @@ defaults:
   ignore_service_fabrik_operation: false # flag to indicate if service-fabrik operations are to be excluded. for ex. broker update (HTTP Patch)
                                          #  gets invoked via backup/restore etc, which are to be ignored when coming via HTTP Patch.
   include_response_body: false # wheter HTTP response body is to be logged after sanitization or not
-"/cf/v2/catalog":
+"/:platform(cf|k8s)/v2/catalog":
   GET:
     enabled: true
     event_name: broker_catalog
     description: Get broker service catalog
     tags:
     - catalog
-"/cf/v2/service_instances/:instance_id":
+"/:platform(cf|k8s)/v2/service_instances/:instance_id":
   PUT:
     enabled: true
     event_name: create_instance
@@ -40,7 +40,7 @@ defaults:
     http_success_codes:
     - 200
     - 410
-"/cf/v2/service_instances/:instance_id/service_bindings/:binding_id":
+"/:platform(cf|k8s)/v2/service_instances/:instance_id/service_bindings/:binding_id":
   PUT:
     enabled: true
     event_name: create_binding
@@ -57,7 +57,7 @@ defaults:
     http_success_codes:
     - 200
     - 410
-"/cf/v2/service_instances/:instance_id/last_operation":
+"/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation":
   GET:
     enabled: true
     cf_last_operation: true

--- a/lib/fabrik/CfPlatformManager.js
+++ b/lib/fabrik/CfPlatformManager.js
@@ -37,7 +37,7 @@ class CfPlatformManager extends BasePlatformManager {
 
   createSecurityGroup(options) {
     const name = this.getSecurityGroupName(options.guid);
-    const rules = _.map(options.ruleOptions, opts => this.buildSecurityGroupRules(opts));
+    const rules = _.map(options.ipRuleOptions, opts => this.buildSecurityGroupRules(opts));
     logger.info(`Creating security group '${name}' with rules ...`, rules);
     return utils
       .retry(tries => {
@@ -70,7 +70,7 @@ class CfPlatformManager extends BasePlatformManager {
       .catch(SecurityGroupNotFound, () => {
         logger.warn('+-> Security group does not exist. Trying to create it again.');
         return this.ensureTenantId(options.context.space_guid)
-          .then(() => this.createSecurityGroup(options.ruleOptions));
+          .then(() => this.createSecurityGroup(options));
       });
   }
 

--- a/lib/fabrik/DirectorInstance.js
+++ b/lib/fabrik/DirectorInstance.js
@@ -117,7 +117,7 @@ class DirectorInstance extends BaseInstance {
             .then(() => this.platformManager.postInstanceProvisionOperations({
               ipRuleOptions: this.buildIpRules(),
               guid: this.guid,
-              context: this.platformContext
+              context: operation.context
             }))
             .tap(() => operation.state === CONST.OPERATION.SUCCEEDED ? this.scheduleAutoUpdate() : {});
 
@@ -125,7 +125,7 @@ class DirectorInstance extends BaseInstance {
           return this.platformManager.postInstanceUpdateOperations({
             ipRuleOptions: this.buildIpRules(),
             guid: this.guid,
-            context: this.platformContext
+            context: operation.context
           });
         }
       })

--- a/lib/fabrik/DockerInstance.js
+++ b/lib/fabrik/DockerInstance.js
@@ -83,7 +83,7 @@ class DockerInstance extends BaseInstance {
       .then(() => this.platformManager.postInstanceProvisionOperations({
         ipRuleOptions: this.buildIpRules(),
         guid: this.guid,
-        context: this.platformContext
+        context: params.context
       }));
   }
 

--- a/test/EventLogInterceptor.spec.js
+++ b/test/EventLogInterceptor.spec.js
@@ -74,7 +74,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '5a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/5a6e7c34-d97c-4fc0-95e6-7a3bc8030b14';
-      const route = '/cf/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('PUT', url, route, {}, pathParams, {}, dockerManager, respBody, 200);
       return Promise
@@ -99,7 +99,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '5a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/5a6e7c34-d97c-4fc0-95e6-7a3bc8030b14';
-      const route = '/cf/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('DELETE', url, route, {}, pathParams, {}, dockerManager, respBody, 200);
       return Promise
@@ -124,7 +124,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15';
-      const route = '/cf/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('PUT', url, route, {}, pathParams, {}, directorManager, respBody, 202);
       return Promise
@@ -149,7 +149,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15';
-      const route = '/cf/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('DELETE', url, route, {}, pathParams, {}, directorManager, respBody, 202);
       return Promise
@@ -176,7 +176,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b14';
-      const route = '/cf/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('PATCH', url, route, {}, pathParams, {}, directorManager, respBody, 202);
       return Promise
@@ -235,7 +235,7 @@ describe('EventLogInterceptor', function () {
         binding_id: '082da7c8-c557-4b3d-b698-3b0a9a3ca947'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b14/service_bindings/082da7c8-c557-4b3d-b698-3b0a9a3ca947';
-      const route = '/cf/v2/service_instances/:instance_id/service_bindings/:binding_id';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/service_bindings/:binding_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('PUT', url, route, {}, pathParams, {}, directorManager, respBody, 201);
       return Promise
@@ -262,7 +262,7 @@ describe('EventLogInterceptor', function () {
         binding_id: '082da7c8-c557-4b3d-b698-3b0a9a3ca947'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b14/service_bindings/082da7c8-c557-4b3d-b698-3b0a9a3ca947';
-      const route = '/cf/v2/service_instances/:instance_id/service_bindings/:binding_id';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/service_bindings/:binding_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('DELETE', url, route, {}, pathParams, {}, directorManager, respBody, 200);
       return Promise
@@ -605,7 +605,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'succeeded',
@@ -646,7 +646,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'succeeded',
@@ -687,7 +687,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'failed',
@@ -728,7 +728,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'failed',
@@ -769,7 +769,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'succeeded',
@@ -810,7 +810,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'failed',
@@ -851,7 +851,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const op = {
         type: 'update',
         subtype: 'backup',
@@ -893,7 +893,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const op = {
         type: 'update',
         subtype: 'backup',
@@ -935,7 +935,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const op = {
         type: 'update',
         subtype: 'restore',
@@ -977,7 +977,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/cf/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
       const op = {
         type: 'update',
         subtype: 'restore',

--- a/test/acceptance/service-broker-api.catalog.spec.js
+++ b/test/acceptance/service-broker-api.catalog.spec.js
@@ -19,7 +19,6 @@ describe('service-broker-api', function () {
           expect(res).to.have.status(200);
           expect(res.body.services).to.be.instanceof(Array);
           expect(res.body.services).to.have.length(2);
-          console.log(res.body.services[0].plans);
           expect(res.body.services[0].plans).to.have.length(7);
           expect(res.body.services[1].plans).to.have.length(2);
         });


### PR DESCRIPTION
* Fix the blank security group problem becasue of variable name mismatch
* Directly sending context for sec group creation instead of reading from platform context
* Changed the event logger paths