### PR TITLE
Run js actions in separate process

### DIFF
--- a/config/templates/actions/ReserveIps.js
+++ b/config/templates/actions/ReserveIps.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const Promise = require('bluebird');
-const logger = require('../../../logger');
 const BaseAction = require('./BaseAction');
 
 class ReserveIps extends BaseAction {
+  /*jshint unused:false*/
   static executePreCreate(context) {
     return Promise.try(() => {
-      logger.info('Executing ReserveIPs.preCreate with parameters: ', context);
       return ['10.244.11.247'];
     });
   }

--- a/lib/fabrik/actions/ActionManager.js
+++ b/lib/fabrik/actions/ActionManager.js
@@ -12,6 +12,7 @@ const ScriptExecutor = require('../../utils/ScriptExecutor');
 class ActionManager {
   static getAction(phase, action) {
     try {
+      const actionScriptAbsPath = path.join(__dirname, 'js', `${action}.js`);
       const actionProcessor = require(`./js/${action}`);
       let actionHandler = actionProcessor[`execute${phase}`];
       if (typeof actionHandler !== 'function') {
@@ -19,7 +20,10 @@ class ActionManager {
       }
       const execute = function () {
         logger.info('Invoking handler with args..', arguments);
-        return actionHandler.apply(actionProcessor, arguments);
+        const jsExecuterAbsPath = path.join(__dirname, 'JSExecuter.js');
+        const command = `node ${jsExecuterAbsPath} ${action} ${phase}`;
+        const executor = new ScriptExecutor(actionScriptAbsPath, command);
+        return executor.execute.apply(executor, arguments);
       };
       return execute;
     } catch (err) {
@@ -28,7 +32,8 @@ class ActionManager {
       if (fs.existsSync(actionScriptAbsPath)) {
         logger.info(`action ${action} for phase ${phase} is defined in the script ${action}_${phase}`);
         const execute = function () {
-          const executor = new ScriptExecutor(actionScriptAbsPath);
+          const command = actionScriptAbsPath;
+          const executor = new ScriptExecutor(actionScriptAbsPath, command);
           return executor.execute.apply(executor, arguments);
         };
         return execute;

--- a/lib/fabrik/actions/JSExecuter.js
+++ b/lib/fabrik/actions/JSExecuter.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const Promise = require('bluebird');
+const action = process.argv[2];
+const phase = process.argv[3];
+let context = process.argv[4];
+
+const actionProcessor = require(`./js/${action}`);
+try {
+  context = JSON.parse(context);
+} catch (err) {
+  console.err('Error in parsing context ', context);
+}
+Promise.try(() => actionProcessor[`execute${phase}`](context))
+  .then(response => console.log(JSON.stringify(response)))
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/lib/utils/ScriptExecutor.js
+++ b/lib/utils/ScriptExecutor.js
@@ -9,13 +9,14 @@ const logger = require('../logger');
 const errors = require('../errors');
 
 class ScriptExecutor {
-  constructor(scriptAbsPath) {
+  constructor(scriptAbsPath, command) {
     const fileParts = _.split(scriptAbsPath, path.sep);
     this.fileName = fileParts[fileParts.length - 1];
     if (!fs.existsSync(scriptAbsPath)) {
       throw new errors.NotFound(`Script ${this.fileName} not found`);
     }
     this.scriptPath = scriptAbsPath;
+    this.command = command;
   }
 
   execute() {
@@ -25,7 +26,7 @@ class ScriptExecutor {
         _.assign(args, value);
       });
       logger.info(`executing script with arguments: ${JSON.stringify(args)} `);
-      child_process.exec(`${this.scriptPath} '${JSON.stringify(args)}'`, (err, stdout, stderr) => {
+      child_process.exec(`${this.command} '${JSON.stringify(args)}'`, (err, stdout, stderr) => {
         if (err === null) {
           try {
             stdout = JSON.parse(stdout);

--- a/test/utils.ScriptExecutor.spec.js
+++ b/test/utils.ScriptExecutor.spec.js
@@ -22,7 +22,7 @@ describe('utils', function () {
       fs.writeFileSync(actionScriptAbsPath, 'echo error response\nexit 1', {
         mode: 0o755
       });
-      let executor = new ScriptExecutor(actionScriptAbsPath);
+      let executor = new ScriptExecutor(actionScriptAbsPath, actionScriptAbsPath);
       return executor.execute()
         .then(() => fs.unlinkSync(actionScriptAbsPath))
         .catch(err => {


### PR DESCRIPTION
Currently js actions in deployment hooks are running in broker's node process. When merged, these changes will make js actions run in separate process.