### PR TITLE
Fix the code to check quota in update flow only if it is a plan update

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -135,6 +135,9 @@ exports.checkQuota = function () {
     if (utils.isServiceFabrikOperation(req.body)) {
       logger.debug('[Quota]: ServiceFabrikOperation : calling next handler..');
       next();
+    } else if ( CONST.HTTP_METHOD.PATCH === req.method && utils.isNotPlanUpdate(req.body)) {
+      logger.info(`[Quota]: Not a plan update .Previous plan id : '${req.body.previous_values.plan_id}' , Current plan id : '${req.body.plan_id}' . Skipping quota check : calling next handler..`);
+      next();
     } else {
       const platform = _.get(req, 'body.context.platform');
       if (platform === CONST.PLATFORM.CF) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -47,6 +47,7 @@ exports.isServiceFabrikOperationFinished = isServiceFabrikOperationFinished;
 exports.taskIdRegExp = taskIdRegExp;
 exports.hasChangesInForbiddenSections = hasChangesInForbiddenSections;
 exports.unifyDiffResult = unifyDiffResult;
+exports.isNotPlanUpdate = isNotPlanUpdate;
 
 function streamToPromise(stream, options) {
   const encoding = _.get(options, 'encoding', 'utf8');
@@ -331,6 +332,10 @@ function isServiceFabrikOperation(params) {
 
 function isServiceFabrikOperationFinished(state) {
   return _.includes([CONST.OPERATION.SUCCEEDED, CONST.OPERATION.FAILED, CONST.OPERATION.ABORTED], state);
+}
+
+function isNotPlanUpdate(params) {
+  return _.get(params, 'previous_values.plan_id') === undefined || _.get(params, 'plan_id') === undefined || _.get(params, 'previous_values.plan_id') === _.get(params, 'plan_id');
 }
 
 function hasChangesInForbiddenSections(diff) {


### PR DESCRIPTION
Currently the quota check is performed in `cf update` flow even if there is no plan update. 

This approach blocks the `cf update` for users who do not want to perform a plan update and who do not have sufficient quota.

Hence ensuring that the quota check is skipped in the update flow if its not a plan update.