### PR TITLE
Randomising schedule interval when input with hours

### DIFF
--- a/JobScheduler.js
+++ b/JobScheduler.js
@@ -102,7 +102,10 @@ class JobScheduler {
     this.serviceFabrikInMaintenance = true;
     _.each(this.jobWorkers, (id, key) => {
       logger.info(`+-> message From -> ${this.workerType} - To worker - ${id} - ${key}-${JSON.stringify(cluster.workers[key])}}`);
-      cluster.workers[key].send(CONST.TOPIC.APP_SHUTTING_DOWN);
+      if (cluster.workers[key]) {
+        //Dont send message to the same worker which threw the exception as it will be non-existent.
+        cluster.workers[key].send(CONST.TOPIC.APP_SHUTTING_DOWN);
+      }
     });
     this.workerCount = 0;
     this.jobWorkers = [];

--- a/lib/jobs/ScheduleManager.js
+++ b/lib/jobs/ScheduleManager.js
@@ -31,6 +31,9 @@ class ScheduleManager {
       if (interval === CONST.SCHEDULE.DAILY) {
         interval = this.getRandomDailySchedule();
         logger.info(`Schedule interval input as 'daily'. So setting following daily random schedule - ${interval}`);
+      } else if (interval.indexOf('hours') !== -1) {
+        interval = this.getRandomHourlySchedule(interval);
+        logger.info(`human hours interval input, so setting following hourly random schedule - ${interval}`);
       } else if (interval === CONST.SCHEDULE.RANDOM) {
         const JobDefinition = JobFabrik.getJob(jobType);
         interval = JobDefinition.getRandomRepeatInterval();
@@ -51,6 +54,22 @@ class ScheduleManager {
     const hr = utils.getRandomInt(0, 23);
     const min = utils.getRandomInt(0, 59);
     return `${min} ${hr} * * *`;
+  }
+
+  static getRandomHourlySchedule(interval) {
+    try {
+      const everyXhrs = parseInt(/^[0-9]+/.exec(interval)[0]);
+      logger.info(`schedule is to run every ${everyXhrs} hours`);
+      if (24 % everyXhrs === 0) {
+        //only for intervals whose multiple leads to 24 can we create a random cron. 
+        //For ex., with 7, we cant create a true random cron as it can lead to '34 1,8,15,22 * * *'
+        return utils.getRandomCronForEveryDayAtXHoursInterval(everyXhrs);
+      } else {
+        return interval;
+      }
+    } catch (err) {
+      throw new errors.BadRequest(`invalid interval ${interval} - hours must be valid integer`);
+    }
   }
 
   static saveJob(name, inputJobType, interval, jobData, user, runOnce) {

--- a/lib/utils/ScriptExecutor.js
+++ b/lib/utils/ScriptExecutor.js
@@ -12,9 +12,6 @@ class ScriptExecutor {
   constructor(scriptAbsPath) {
     const fileParts = _.split(scriptAbsPath, path.sep);
     this.fileName = fileParts[fileParts.length - 1];
-    if (!fs.existsSync(scriptAbsPath)) {
-      throw new errors.NotFound(`Script ${this.fileName} not found`);
-    }
     this.scriptPath = scriptAbsPath;
   }
 

--- a/lib/utils/ScriptExecutor.js
+++ b/lib/utils/ScriptExecutor.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require('fs');
 const Promise = require('bluebird');
 const _ = require('lodash');
 const path = require('path');

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -40,6 +40,7 @@ exports.deploymentNamesRegExp = deploymentNamesRegExp;
 exports.deploymentNameRegExp = deploymentNameRegExp;
 exports.getRandomInt = getRandomInt;
 exports.getRandomCronForOnceEveryXDays = getRandomCronForOnceEveryXDays;
+exports.getRandomCronForEveryDayAtXHoursInterval = getRandomCronForEveryDayAtXHoursInterval;
 exports.isDBConfigured = isDBConfigured;
 exports.isFeatureEnabled = isFeatureEnabled;
 exports.isServiceFabrikOperation = isServiceFabrikOperation;
@@ -298,6 +299,19 @@ function getRandomInt(min, max) {
   const factor = max - min === 1 ? 2 : (max - min);
   //If we want a random of just 2 numbers then the factor must be 2, else it will always return back the lesser of two number always.
   return Math.floor(Math.random() * (factor)) + min;
+}
+
+function getRandomCronForEveryDayAtXHoursInterval(everyXHours) {
+  assert.ok((everyXHours > 0 && everyXHours <= 24), 'Input hours can be any number between 1 to 24 only');
+  const min = exports.getRandomInt(0, 59);
+  //referred via exports to aid in stubbing for UT
+  let nthHour = exports.getRandomInt(0, everyXHours - 1); //Since we consider from 0
+  let hoursApplicable = `${nthHour}`;
+  while (nthHour + everyXHours < 24) {
+    nthHour = nthHour + everyXHours;
+    hoursApplicable = `${hoursApplicable},${nthHour}`;
+  }
+  return `${min} ${hoursApplicable} * * *`;
 }
 
 function getRandomCronForOnceEveryXDays(days, options) {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "jsdoc": "jsdoc -c jsdoc.json",
     "jshint": "jshint --exclude coverage,docs,jsdoc,node_modules,public,tmp  --reporter=node_modules/jshint-stylish .",
     "jshint-ci": "jshint --exclude coverage,docs,jsdoc,node_modules,public,tmp --reporter=checkstyle .",
-    "test": "node lib/LoadDeploymentActions.js && rm -f ./logs/test.log && _mocha test/ test/acceptance/",
+    "test": "rm -f ./logs/test.log && _mocha test/ test/acceptance/",
     "test-ci": "node lib/LoadDeploymentActions.js && rm -f ./logs/test.log && babel-node ./node_modules/.bin/isparta cover --report cobertura _mocha  -- test/acceptance/ test/ ",
     "test-cov": "node lib/LoadDeploymentActions.js &&  rm -f ./logs/test.log && babel-node ./node_modules/.bin/isparta cover _mocha -- test/ test/acceptance/",
     "jsformat": "js-beautify -r $(find -iname '*.js' -not -path '*node_modules*' -not -path '*public/js*')"

--- a/test/support/index.js
+++ b/test/support/index.js
@@ -36,3 +36,6 @@ global.expect = global.chai.expect;
  */
 global.chai.use(require('sinon-chai'));
 global.chai.use(require('chai-http'));
+//Load action scripts after decoding them from base64 from config.
+const ScriptExecutor = require('../../lib/utils/ScriptExecutor');
+(new ScriptExecutor(`node ${path.join(__dirname, '../..', 'lib', 'LoadDeploymentActions.js')}`)).execute();

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -49,5 +49,13 @@ describe('utils', function () {
       expect(utils.getRandomCronForOnceEveryXDays(7)).to.eql('1 1 1,8,15,22 * *');
       expect(utils.getRandomCronForOnceEveryXDays(15)).to.eql('1 1 1,16 * *');
     });
+    it('should return a random cron expression for every x hours for the day', function () {
+      const AssertionError = require('assert').AssertionError;
+      expect(utils.getRandomCronForEveryDayAtXHoursInterval.bind(utils, 29)).to.throw(AssertionError);
+      //bind returns a ref to function which is executed and checked for if it threw exception.
+      expect(utils.getRandomCronForEveryDayAtXHoursInterval(8)).to.eql('1 1,9,17 * * *');
+      expect(utils.getRandomCronForEveryDayAtXHoursInterval(7)).to.eql('1 1,8,15,22 * * *');
+      expect(utils.getRandomCronForEveryDayAtXHoursInterval(3)).to.eql('1 1,4,7,10,13,16,19,22 * * *');
+    });
   });
 });


### PR DESCRIPTION
When human-readable format of hours is specified as interval,
then the schedules are not randomized and all the jobs start
at the same 'n'th hour. So to address this issue, if the
input hour's multiples leads to 24 hrs, then we can effectively
create random cron schedules by randomizing the hrs between
0 to x-1 hour and repeating the hours till 24.
Examples:
'8 hours' : '23 0,8,16 * * *' ,   '10 2,10,18 * * *' 
'4 hours' : '59 1,5,9,13,17,21 * * *', '15 3,7,11,15,19,23 * * *'
'7 hours' : '7 hours' (not possible to randomize an hr whose multiple does not lead to 24)