### PR TITLE
Introduced new changes for Code Coverage using Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
        echo "No changes to the code formatting required.. "
      fi
   - "npm run -s jshint-ci"
-  - "npm run -s test-ci"
+  - "npm run -s test-coverall"
   - "npm run -s jsdoc"
   - |
      git secrets --scan-history || exit 1

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "babel-cli": "^6.9.0",
     "chai": "^3.5.0",
     "chai-http": "^2.0.1",
+    "coveralls": "^3.0.0",
     "docdash": "^0.3.0",
     "esformatter": "^0.10.0",
     "esformatter-braces": "^1.2.1",
@@ -78,11 +79,13 @@
     "esformatter-use-strict": "^3.0.0",
     "esformatter-var-each": "^2.1.0",
     "isparta": "^4.0.0",
-    "js-beautify": "1.6.14",
+    "js-beautify": "^1.6.14",
+    "jscover": "^1.0.0",
     "jsdoc": "^3.4.0",
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.2.0",
     "mocha": "^2.5.3",
+    "mocha-lcov-reporter": "^1.3.0",
     "nock": "^8.0.0",
     "proxyquire": "^1.7.9",
     "sinon": "^1.17.4",
@@ -105,8 +108,9 @@
     "jshint": "jshint --exclude coverage,docs,jsdoc,node_modules,public,tmp  --reporter=node_modules/jshint-stylish .",
     "jshint-ci": "jshint --exclude coverage,docs,jsdoc,node_modules,public,tmp --reporter=checkstyle .",
     "test": "rm -f ./logs/test.log && _mocha test/ test/acceptance/",
-    "test-ci": "node lib/LoadDeploymentActions.js && rm -f ./logs/test.log && babel-node ./node_modules/.bin/isparta cover --report cobertura _mocha  -- test/acceptance/ test/ ",
-    "test-cov": "node lib/LoadDeploymentActions.js &&  rm -f ./logs/test.log && babel-node ./node_modules/.bin/isparta cover _mocha -- test/ test/acceptance/",
-    "jsformat": "js-beautify -r $(find -iname '*.js' -not -path '*node_modules*' -not -path '*public/js*')"
+    "test-ci": "rm -f ./logs/test.log && babel-node ./node_modules/.bin/isparta cover --report cobertura _mocha  -- test/acceptance/ test/ ",
+    "test-cov": "rm -f ./logs/test.log && babel-node ./node_modules/.bin/isparta cover _mocha -- test/ test/acceptance/",
+    "test-coverall": "rm -f ./logs/test.log && babel-node ./node_modules/.bin/isparta cover --report lcovonly _mocha -- test/acceptance/ test/ && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "jsformat": "js-beautify -r $(find . -iname '*.js' -not -path '*node_modules*' -not -path '*public/js*')"
   }
 }

--- a/test/global.setup.js
+++ b/test/global.setup.js
@@ -5,6 +5,9 @@ const lib = require('../lib');
 const director = lib.bosh.director;
 let boshConfigCacheDetails = {};
 let deploymentIpsCacheDetails = {};
+
+process.on('unhandledRejection', (err) => console.log('Unhandled rejection - ', err.name));
+
 director.ready.then(() => {
   boshConfigCacheDetails = _.cloneDeep(director.boshConfigCache);
   deploymentIpsCacheDetails = _.cloneDeep(director.deploymentIpsCache);


### PR DESCRIPTION
* Existing Unit tests are covered by isparta library which
  previously used to generate a cobertura report.

* It has now been changed to generate a lcov report instead
  which can be forwarded to coveralls.io - so that changes can
  take effect.

* New PRs (Pull Requests) raised on this repository will automatically
  trigger code coverage tests and Coveralls will then report
  the changes (if any) in Code Coverage as a comment on the
  Pull Request page