### PR TITLE
Fix scheduler poll issue during maintenance

### DIFF
--- a/JobScheduler.js
+++ b/JobScheduler.js
@@ -140,6 +140,7 @@ class JobScheduler {
   }
 
   pollMaintenanceStatus() {
+    this.intervalTimer = undefined;
     const checkMaintenanceStatus = (resolve, reject) => {
       return maintenanceManager
         .getLastMaintenaceState()


### PR DESCRIPTION
If scheduler was earlier in maintenance and if it once again
goes into maintenance, then polling was not happening as the
variable 'intervalTimer' was already set with previous
interval's id. So resetting it everytime which should fix this
issue.