### PR TITLE
Bluebird Promise referred instead of default promise

### DIFF
--- a/lib/jobs/ScheduledOobDeploymentBackupJob.js
+++ b/lib/jobs/ScheduledOobDeploymentBackupJob.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const Promise = require('bluebird');
 const logger = require('../logger');
 const config = require('../config');
 const moment = require('moment');


### PR DESCRIPTION
Promise.delay is used in scheduled OOB however bluebird promise was not referred. This resulted in runtime error `TypeError: Promise.delay is not a function` as seen in schedule worker logs. This PR should fix it.