### PR TITLE
changes to fix nocontainer issue related to docker & SF timeout issues

### DIFF
--- a/lib/docker/DockerClient.js
+++ b/lib/docker/DockerClient.js
@@ -22,7 +22,7 @@ class DockerClient extends Docker {
    */
   constructor(opts) {
     super(_.defaults({}, opts, config.docker, {
-      timeout: 60 * 1000
+      timeout: 170 * 1000
     }));
     this.constructor.monkeyPatchModem(this.modem);
   }

--- a/lib/docker/DockerClient.js
+++ b/lib/docker/DockerClient.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const Promise = require('bluebird');
 const config = require('../config');
 const logger = require('../logger');
+
 Promise.promisifyAll([
   require('dockerode/lib/docker'),
   require('dockerode/lib/container'),
@@ -22,7 +23,7 @@ class DockerClient extends Docker {
    */
   constructor(opts) {
     super(_.defaults({}, opts, config.docker, {
-      timeout: 170 * 1000
+      timeout: config.http_timeout
     }));
     this.constructor.monkeyPatchModem(this.modem);
   }

--- a/lib/fabrik/DockerInstance.js
+++ b/lib/fabrik/DockerInstance.js
@@ -66,6 +66,10 @@ class DockerInstance extends BaseInstance {
           };
           return context;
         }
+      })
+      .catch(DockerError.NotFound, () => {
+        logger.warn(`Container ${this.containerName} not found for instance`);
+        return {};
       });
   }
 

--- a/test/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/acceptance/service-broker-api.instances.docker.spec.js
@@ -205,6 +205,29 @@ describe('service-broker-api', function () {
             });
         });
 
+        it('returns 410 Gone', function () {
+          mocks.docker.inspectContainer(instance_id, {
+            Config: {
+              Env: ['context={"platform":"cloudfoundry"}']
+            }
+          },404);
+          return chai.request(app)
+            .delete(`${base_url}/service_instances/${instance_id}`)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id
+            })
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(410);
+              expect(res.body).to.eql({});
+              mocks.verify();
+            });
+        });
+
+
         it('returns 200 OK: for existing deployment not having platfrom-context in environment', function () {
           mocks.docker.inspectContainer(instance_id);
           mocks.cloudController.findSecurityGroupByName(instance_id);
@@ -220,7 +243,7 @@ describe('service-broker-api', function () {
             .set('X-Broker-API-Version', api_version)
             .auth(config.username, config.password)
             .then(res => {
-              expect(res).to.have.status(200);
+              expect(res).to.have.status(410);
               expect(res.body).to.eql({});
               mocks.verify();
             });

--- a/test/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/acceptance/service-broker-api.instances.docker.spec.js
@@ -206,11 +206,7 @@ describe('service-broker-api', function () {
         });
 
         it('returns 410 Gone', function () {
-          mocks.docker.inspectContainer(instance_id, {
-            Config: {
-              Env: ['context={"platform":"cloudfoundry"}']
-            }
-          },404);
+          mocks.docker.inspectContainer(instance_id, {},404);
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)
             .query({
@@ -226,7 +222,6 @@ describe('service-broker-api', function () {
               mocks.verify();
             });
         });
-
 
         it('returns 200 OK: for existing deployment not having platfrom-context in environment', function () {
           mocks.docker.inspectContainer(instance_id);

--- a/test/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/acceptance/service-broker-api.instances.docker.spec.js
@@ -243,7 +243,7 @@ describe('service-broker-api', function () {
             .set('X-Broker-API-Version', api_version)
             .auth(config.username, config.password)
             .then(res => {
-              expect(res).to.have.status(410);
+              expect(res).to.have.status(200);
               expect(res.body).to.eql({});
               mocks.verify();
             });

--- a/test/mocks/docker.js
+++ b/test/mocks/docker.js
@@ -114,7 +114,7 @@ function startContainer() {
     .reply(204);
 }
 
-function deleteContainer(guid) {
+function deleteContainer(guid, status) {
   const name = getContainerName(guid);
   return nock(dockerUrl)
     .delete(`/containers/${name || containerId}`)
@@ -122,10 +122,10 @@ function deleteContainer(guid) {
       v: true,
       force: true
     })
-    .reply(204);
+    .reply(status || 204);
 }
 
-function inspectContainer(guid, options) {
+function inspectContainer(guid, options, status) {
   if (_.isObject(guid)) {
     options = guid;
     guid = undefined;
@@ -156,7 +156,7 @@ function inspectContainer(guid, options) {
   return nock(dockerUrl)
     .replyContentLength()
     .get(`/containers/${name || containerId}/json`)
-    .reply(200, body);
+    .reply( status || 200, body);
 }
 
 function deleteVolumes(guid) {

--- a/test/mocks/docker.js
+++ b/test/mocks/docker.js
@@ -114,7 +114,7 @@ function startContainer() {
     .reply(204);
 }
 
-function deleteContainer(guid, status) {
+function deleteContainer(guid) {
   const name = getContainerName(guid);
   return nock(dockerUrl)
     .delete(`/containers/${name || containerId}`)
@@ -122,7 +122,7 @@ function deleteContainer(guid, status) {
       v: true,
       force: true
     })
-    .reply(status || 204);
+    .reply(204);
 }
 
 function inspectContainer(guid, options, status) {


### PR DESCRIPTION
Problem Cause
-----------------

During delete of the docker service (i.e docker container) the delete call goes from CF->SF-> Docker Swarm manager->Docker Node.

Due to a problem between SF->Swarm Manager communication we get Container Not Found issue

Normally Docker Node & Swarm takes around 3-6 Seconds to delete the container and it corresponding volume. SF make two calls to swarm manager for this
-one call to delete container
-one call to delete volume

for each call 'Service-fabrik' makes to swarm manager, SF waits for 60 seconds before it terminate/hungs up the call in case swarm manager takes more than 60 seconds to delete  and after finishing the delete call it cannot communicate back to service-fabrik as the call is already terminated.

if either of the delete calls (container/volume) takes more than 60 seconds SF terminates the call and returns error to CF i.e from CF perspective service delete failed and service stays cf but in docker node the container(i.e service) is deleted.

So for the service of CF there is no container as its already deleted and for any new delete call from CF to SF its returns 404 error to CF as container is already deleted.

Fix
---
In-case container is already deleted and CF (via user) make delete call again, SF will return HTTP 410 (Gone) response code so that CF can delete its orphan service instance.

To Reduce the Frequency of this issue happening we increase the SF  to docker HTTP call time-out from 60 seconds to 170 seconds


