### PR TITLE
Change failed backup list

### DIFF
--- a/lib/reports/BackupReportManager.js
+++ b/lib/reports/BackupReportManager.js
@@ -130,12 +130,19 @@ class BackupReportManager {
               windowEndIndex++;
               windowStartIndex = windowEndIndex;
             }
+            // If on-demand backups are present then triggeredBackupCount might be less than backupSuccessCount + backupFailureCount
+            const scheduledBackupFailureCount = triggeredBackupCount - backupSuccessCount;
+            const backupFailureCount = scheduledBackupFailureCount < 0 ? (backupResults.length - backupSuccessCount) : scheduledBackupFailureCount;
+            let failedBackupList = [];
+            if (backupFailureCount > 0) {
+              failedBackupList = backupResults.slice(backupSuccessCount);
+            }
             const summary = {
               noBackupDays: noBackupDays,
               backupsTriggerred: triggeredBackupCount,
               backupsSucceeded: backupSuccessCount,
-              backupFailed: (triggeredBackupCount - backupSuccessCount),
-              failedBackups: backupResults.slice(backupSuccessCount),
+              backupFailed: backupFailureCount,
+              failedBackups: failedBackupList,
               failureCountForNConsecutiveDays: consecutiveBackupFailureCount
             };
             _.assign(instanceRecord, summary);


### PR DESCRIPTION
If `triggeredBackupCount - backupSuccessCount` is less than zero (ie. on demand backups are present) then set `backupFailureCount = backupResults.length - backupSuccessCount`