### PR TITLE
Bug/dashboard

### DIFF
--- a/broker/lib/bosh/BoshDirectorClient.js
+++ b/broker/lib/bosh/BoshDirectorClient.js
@@ -625,21 +625,9 @@ class BoshDirectorClient extends HttpClient {
     const query = _.assign({
       limit: 1000
     }, options);
-    let shouldFetch = fetchDirectorForDeployment === true;
-    var configPromise = new Promise((resolve, reject) => {
-      if (shouldFetch) {
-        var fetchedConfigs = [];
-        this.getDirectorConfig(options.deployment)
-          .then(directorConfig => {
-            fetchedConfigs.push(directorConfig);
-            resolve(fetchedConfigs);
-          });
-      } else {
-        resolve(this.primaryConfigs);
-      }
-    });
-
-    return configPromise.map(directorConfig => {
+    return Promise.try(() => fetchDirectorForDeployment ? this.getDirectorConfig(options.deployment) : this.primaryConfigs)
+      .then(configs => Array.isArray(configs) ? configs : [configs])
+      .map(directorConfig => {
         return this
           .makeRequestWithConfig({
             method: 'GET',

--- a/broker/lib/bosh/BoshDirectorClient.js
+++ b/broker/lib/bosh/BoshDirectorClient.js
@@ -628,21 +628,21 @@ class BoshDirectorClient extends HttpClient {
 
     //Get the corresponding directorConfig first and then request to that config directly.
     return this.getDirectorConfig(options.deployment)
-    .then(configForDeployment => {
-      return this.makeRequestWithConfig({
-        method: 'GET',
-        url: '/tasks',
-        qs: _.pick(query, ['limit', 'state', 'deployment'])
-      }, 200, configForDeployment);
-    })
-    .then(res => JSON.parse(res.body))
-    .map(task => {
-      task.id = `${options.deployment}_${task.id}`;
-      return task;
-    })
-    .reduce((all_tasks, tasks) => all_tasks.concat(tasks), []);    
+      .then(configForDeployment => {
+        return this.makeRequestWithConfig({
+          method: 'GET',
+          url: '/tasks',
+          qs: _.pick(query, ['limit', 'state', 'deployment'])
+        }, 200, configForDeployment);
+      })
+      .then(res => JSON.parse(res.body))
+      .map(task => {
+        task.id = `${options.deployment}_${task.id}`;
+        return task;
+      })
+      .reduce((all_tasks, tasks) => all_tasks.concat(tasks), []);
   }
-  
+
   getTasks(options) {
     const query = _.assign({
       limit: 1000

--- a/broker/lib/bosh/BoshDirectorClient.js
+++ b/broker/lib/bosh/BoshDirectorClient.js
@@ -621,6 +621,28 @@ class BoshDirectorClient extends HttpClient {
 
   /*  Task operations */
 
+  getTasksForDashboard(options) {
+    const query = _.assign({
+      limit: 1000
+    }, options);
+
+    //Get the corresponding directorConfig first and then request to that config directly.
+    return this.getDirectorConfig(options.deployment)
+    .then(configForDeployment => {
+      return this.makeRequestWithConfig({
+        method: 'GET',
+        url: '/tasks',
+        qs: _.pick(query, ['limit', 'state', 'deployment'])
+      }, 200, configForDeployment);
+    })
+    .then(res => JSON.parse(res.body))
+    .map(task => {
+      task.id = `${options.deployment}_${task.id}`;
+      return task;
+    })
+    .reduce((all_tasks, tasks) => all_tasks.concat(tasks), []);    
+  }
+  
   getTasks(options) {
     const query = _.assign({
       limit: 1000

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -10,6 +10,7 @@ const logger = require('../logger');
 const errors = require('../errors');
 const jwt = require('../jwt');
 const utils = require('../utils');
+const catalog = require('../models').catalog;
 const NotFound = errors.NotFound;
 const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const ScheduleManager = require('../jobs');
@@ -321,10 +322,19 @@ class DirectorInstance extends BaseInstance {
         this.cloudController.getServiceInstance(this.guid),
         this.initialize(operation).then(() => this.manager.getDeploymentInfo(this.deploymentName))
       ])
-      .spread((instance, deploymentInfo) => ({
-        title: `${this.plan.service.metadata.displayName || 'Service'} Dashboard`,
-        plan: this.plan,
-        service: this.plan.service,
+      .spread((instance,deploymentInfo) => {
+        return Promise.all([
+          instance,
+          deploymentInfo,
+          this.cloudController.getServicePlan(instance.entity.service_plan_guid,{})
+        ]);
+      })
+      .spread((instance, deploymentInfo, planInfo) => {
+        var currentPlan = catalog.getPlan(planInfo.entity.unique_id);
+        return {
+        title: `${currentPlan.service.metadata.displayName || 'Service'} Dashboard`,
+        plan: currentPlan,
+        service: currentPlan.service,
         instance: _.set(instance, 'task', deploymentInfo),
         files: [{
           id: 'status',
@@ -332,7 +342,8 @@ class DirectorInstance extends BaseInstance {
           language: 'yaml',
           content: yaml.dump(deploymentInfo)
         }]
-      }));
+      };
+    });
   }
 
   scheduleBackUp() {

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -330,9 +330,9 @@ class DirectorInstance extends BaseInstance {
         ),
         this.initialize(operation).then(() => this.manager.getDeploymentInfo(this.deploymentName))
       ])
-      .spread((consolidated, deploymentInfo) => {
-        let instance = consolidated.instance;
-        let planInfo = consolidated.plan;
+      .spread((instanceInfo, deploymentInfo) => {
+        let instance = instanceInfo.instance;
+        let planInfo = instanceInfo.plan;
         let currentPlan = catalog.getPlan(planInfo.entity.unique_id);
         return {
           title: `${currentPlan.service.metadata.displayName || 'Service'} Dashboard`,

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -322,28 +322,28 @@ class DirectorInstance extends BaseInstance {
         this.cloudController.getServiceInstance(this.guid),
         this.initialize(operation).then(() => this.manager.getDeploymentInfo(this.deploymentName))
       ])
-      .spread((instance,deploymentInfo) => {
+      .spread((instance, deploymentInfo) => {
         return Promise.all([
           instance,
           deploymentInfo,
-          this.cloudController.getServicePlan(instance.entity.service_plan_guid,{})
+          this.cloudController.getServicePlan(instance.entity.service_plan_guid, {})
         ]);
       })
       .spread((instance, deploymentInfo, planInfo) => {
         var currentPlan = catalog.getPlan(planInfo.entity.unique_id);
         return {
-        title: `${currentPlan.service.metadata.displayName || 'Service'} Dashboard`,
-        plan: currentPlan,
-        service: currentPlan.service,
-        instance: _.set(instance, 'task', deploymentInfo),
-        files: [{
-          id: 'status',
-          title: 'Status',
-          language: 'yaml',
-          content: yaml.dump(deploymentInfo)
-        }]
-      };
-    });
+          title: `${currentPlan.service.metadata.displayName || 'Service'} Dashboard`,
+          plan: currentPlan,
+          service: currentPlan.service,
+          instance: _.set(instance, 'task', deploymentInfo),
+          files: [{
+            id: 'status',
+            title: 'Status',
+            language: 'yaml',
+            content: yaml.dump(deploymentInfo)
+          }]
+        };
+      });
   }
 
   scheduleBackUp() {

--- a/broker/lib/fabrik/DirectorManager.js
+++ b/broker/lib/fabrik/DirectorManager.js
@@ -483,9 +483,9 @@ class DirectorManager extends BaseManager {
 
   findDeploymentTask(deploymentName) {
     return this.director
-      .getTasksForDashboard({
+      .getTasks({
         deployment: deploymentName
-      })
+      }, true)
       .then(tasks => _
         .chain(tasks)
         .sortBy('id')

--- a/broker/lib/fabrik/DirectorManager.js
+++ b/broker/lib/fabrik/DirectorManager.js
@@ -483,7 +483,7 @@ class DirectorManager extends BaseManager {
 
   findDeploymentTask(deploymentName) {
     return this.director
-      .getTasks({
+      .getTasksForDashboard({
         deployment: deploymentName
       })
       .then(tasks => _

--- a/broker/lib/fabrik/DockerInstance.js
+++ b/broker/lib/fabrik/DockerInstance.js
@@ -361,7 +361,7 @@ class DockerInstance extends BaseInstance {
           this.getDetails(),
           this.getProcesses(),
           this.getLogs(),
-          this.cloudController.getServicePlan(instance.entity.service_plan_guid,{})
+          this.cloudController.getServicePlan(instance.entity.service_plan_guid, {})
         ]);
       })
       .spread((instance, details, processes, logs, planInfo) => {

--- a/test/test_broker/acceptance/dashboard.docker.spec.js
+++ b/test/test_broker/acceptance/dashboard.docker.spec.js
@@ -15,6 +15,7 @@ describe('dashboard', function () {
     const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
     const plan_id = '466c5078-df6e-427d-8fb2-c76af50c0f56';
     const instance_id = 'b3e03cb5-29cc-4fcf-9900-023cf149c554';
+    const service_plan_guid = '466c5078-df6e-427d-8fb2-c76af50c0f56';
     const plan = catalog.getPlan(plan_id);
 
     before(function () {
@@ -42,6 +43,7 @@ describe('dashboard', function () {
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
         mocks.cloudController.getServiceInstance(instance_id);
+        mocks.cloudController.getServicePlan(service_plan_guid, plan_id);
         mocks.docker.inspectContainer(instance_id);
         mocks.docker.inspectContainer(instance_id);
         mocks.docker.inspectContainer();

--- a/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
@@ -12,6 +12,8 @@ const fabrik = lib.fabrik;
 const backupStore = lib.iaas.backupStore;
 const ScheduleManager = require('../../../broker/lib/jobs');
 const CONST = require('../../../broker/lib/constants');
+const DirectorManager = lib.fabrik.DirectorManager;
+const cloudController = require('../../../broker/lib/cf').cloudController;
 
 describe('service-broker-api', function () {
   describe('instances', function () {
@@ -22,6 +24,7 @@ describe('service-broker-api', function () {
       const api_version = '2.12';
       const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
       const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
+      const service_plan_guid = '466c5078-df6e-427d-8fb2-c76af50c0f56';
       const plan = catalog.getPlan(plan_id);
       const plan_id_deprecated = 'b91d9512-b5c9-4c4a-922a-fa54ae67d235';
       const plan_id_update = 'd616b00a-5949-4b1c-bc73-0d3c59f3954a';
@@ -1689,6 +1692,66 @@ describe('service-broker-api', function () {
               expect(res).to.have.status(200);
               expect(res.body).to.eql({});
               mocks.verify();
+            });
+        });
+      });
+
+      describe('#getInfo', function () {
+
+        let sandbox, getDeploymentInfoStub, getServiceInstanceStub, getServicePlanStub;
+
+        before(function () {
+          sandbox = sinon.sandbox.create();
+          getDeploymentInfoStub = sandbox.stub(DirectorManager.prototype, 'getDeploymentInfo');
+          getServiceInstanceStub = sandbox.stub(cloudController, 'getServiceInstance');
+          getServicePlanStub = sandbox.stub(cloudController, 'getServicePlan');
+
+          let entity = {};
+          getServiceInstanceStub
+            .withArgs(instance_id)
+            .returns({
+              metadata: {
+                guid: instance_id
+              },
+              entity: _.assign({
+                name: 'blueprint',
+                service_plan_guid: '466c5078-df6e-427d-8fb2-c76af50c0f56'
+              }, entity)
+            });
+
+          getDeploymentInfoStub
+            .withArgs(deployment_name)
+            .returns({});
+
+          entity = {};
+          getServicePlanStub
+            .withArgs(service_plan_guid, {})
+            .returns({
+              entity: _.assign({
+                unique_id: plan_id,
+                name: 'blueprint'
+              }, entity)
+            });
+
+        });
+
+        after(function () {
+          sandbox.restore();
+        });
+
+        it('should return object with correct plan and service information', function () {
+          let context = {
+            platform: 'cloudfoundry'
+          };
+          return fabrik
+            .createInstance(instance_id, service_id, plan_id, context)
+            .then(instance => instance.getInfo())
+            .catch(err => err.response)
+            .then(res => {
+              expect(res.title).to.equal('Blueprint Dashboard');
+              expect(res.plan.id).to.equal(plan_id);
+              expect(res.service.id).to.equal(service_id);
+              expect(res.instance.metadata.guid).to.equal(instance_id);
             });
         });
       });

--- a/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
@@ -1709,29 +1709,35 @@ describe('service-broker-api', function () {
           let entity = {};
           getServiceInstanceStub
             .withArgs(instance_id)
-            .returns({
-              metadata: {
-                guid: instance_id
-              },
-              entity: _.assign({
-                name: 'blueprint',
-                service_plan_guid: '466c5078-df6e-427d-8fb2-c76af50c0f56'
-              }, entity)
-            });
+            .returns(Promise.try(() => {
+              return {
+                metadata: {
+                  guid: instance_id
+                },
+                entity: _.assign({
+                  name: 'blueprint',
+                  service_plan_guid: '466c5078-df6e-427d-8fb2-c76af50c0f56'
+                }, entity)
+              };
+            }));
 
           getDeploymentInfoStub
             .withArgs(deployment_name)
-            .returns({});
+            .returns(Promise.try(() => {
+              return {};
+            }));
 
           entity = {};
           getServicePlanStub
             .withArgs(service_plan_guid, {})
-            .returns({
-              entity: _.assign({
-                unique_id: plan_id,
-                name: 'blueprint'
-              }, entity)
-            });
+            .returns(Promise.try(() => {
+              return {
+                entity: _.assign({
+                  unique_id: plan_id,
+                  name: 'blueprint'
+                }, entity)
+              };
+            }));
 
         });
 

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -598,6 +598,7 @@ describe('bosh', () => {
       });
 
       it('should call getDirectorConfig when true passed for fetchDirectorForDeployment', function (done) {
+        /* jshint expr:true */
         mockBoshDirectorClient.getTasks({
           deployment: deployment_name
         }, true).then((content) => {

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -534,6 +534,36 @@ describe('bosh', () => {
       });
     });
 
+    describe('#getTasksForDashboard', () => {
+      it('returns a JSON object', (done) => {
+        let request = {
+          method: 'GET',
+          url: '/tasks',
+          qs: {
+            deployment: deployment_name,
+            limit: 1000
+          }
+        };
+
+        let response = {
+          body: JSON.stringify([{
+            id: 1234,
+            uuid: uuid.v4()
+          }]),
+          statusCode: 200 
+        };
+        
+        new MockBoshDirectorClient(request,response).getTasksForDashboard({
+          deployment: deployment_name
+        }).then(content => {
+          let body = JSON.parse(response.body)[0];
+          body.id = `${deployment_name}_${body.id}`;
+          expect(content).to.eql([body]);
+          done();
+        }).catch(done);
+      });
+    });
+
     describe('#getTasks', () => {
       it('returns a JSON object', (done) => {
         let request = {

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -550,10 +550,10 @@ describe('bosh', () => {
             id: 1234,
             uuid: uuid.v4()
           }]),
-          statusCode: 200 
+          statusCode: 200
         };
-        
-        new MockBoshDirectorClient(request,response).getTasksForDashboard({
+
+        new MockBoshDirectorClient(request, response).getTasksForDashboard({
           deployment: deployment_name
         }).then(content => {
           let body = JSON.parse(response.body)[0];

--- a/test/test_broker/mocks/cloudController.js
+++ b/test/test_broker/mocks/cloudController.js
@@ -118,7 +118,8 @@ function getServiceInstance(guid, entity, times) {
         guid: guid
       },
       entity: _.assign({
-        name: 'blueprint'
+        name: 'blueprint',
+        service_plan_guid: '466c5078-df6e-427d-8fb2-c76af50c0f56'
       }, entity)
     });
 }


### PR DESCRIPTION
* Bug description: 
1. Dashboard rendering fails when service plan is updated as the corresponding dashboard URL is not updated in cloud controller.
2.  In case of migration from one bosh to other, dashboard rendering code might query to older bosh to get tasks hence the dashboard rendering would fail.

* To resolve the part 1 of the bug, a call to cloud controller to get the current plan of the instance was added in both DockerInstance and DirectorInstance.

* To resolve part 2 of the bug, a new function getTasksForDashboard was added in BoshDirectorClient which queries only correct director instead of looping through all the primaryConfigs as original getTasks does. The 'correct' director is fetched from the cache using deployment name.

* Minor modification in docker dashboard acceptance test to accommodate extra call to CC.

* Added one unit test for getTasksForDashboard.  