### PR TITLE
Fix parsing of space_guid from context during security group creation of Update Service flow

### DIFF
--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -69,7 +69,7 @@ class CfPlatformManager extends BasePlatformManager {
       .tap(() => logger.info('+-> Security group exists'))
       .catch(SecurityGroupNotFound, () => {
         logger.warn('+-> Security group does not exist. Trying to create it again.');
-        return this.ensureTenantId(options.context.space_guid)
+        return this.ensureTenantId(options)
           .then(() => this.createSecurityGroup(options));
       });
   }

--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -96,8 +96,7 @@ class CfPlatformManager extends BasePlatformManager {
 
   ensureTenantId(options) {
     return Promise
-      .try(() => options.context.space_guid ? options.context.space_guid : this.cloudController
-        .getServiceInstance(options.guid)
+      .try(() => _.get(options, 'context.space_guid') ? options.context.space_guid : this.cloudController.getServiceInstance(options.guid)
         .then(instance => instance.entity.space_guid)
       );
   }


### PR DESCRIPTION
- ensureTenantId accepts whole of options and not only space_guid