### PR TITLE
Updating docker port registry in case of start error

### DIFF
--- a/broker/lib/fabrik/DockerInstance.js
+++ b/broker/lib/fabrik/DockerInstance.js
@@ -245,6 +245,7 @@ class DockerInstance extends BaseInstance {
           .startContainer()
           .catch(DockerError.ServerError, err => self
             .removeContainer()
+            .then(() => docker.updatePortRegistry())
             .throw(new ContainerStartError(err.message))
           )
         );

--- a/test/test_broker/mocks/docker.js
+++ b/test/test_broker/mocks/docker.js
@@ -89,7 +89,7 @@ function getAllContainers(ports) {
     .reply(200, body);
 }
 
-function createContainer(guid) {
+function createContainer(guid, times) {
   const name = getContainerName(guid);
   const body = {
     Id: containerId,
@@ -102,16 +102,17 @@ function createContainer(guid) {
         `${name}-data-oS100M:/data`
       ]);
     })
+    .times(times || 1)
     .query({
       name: name
     })
     .reply(201, body);
 }
 
-function startContainer() {
+function startContainer(statusCode) {
   return nock(dockerUrl)
     .post(`/containers/${containerId}/start`)
-    .reply(204);
+    .reply(statusCode || 204);
 }
 
 function deleteContainer(guid) {


### PR DESCRIPTION
In HA scenario of SF broker, when failover happens new master doesn't have updated docker port registry info.
Suppose old master created a container allocated port e.g. 36555. After failover new master doesn't have 36555 in its cache entry. Now if new creation of container happens and 36555 is taken from free ports, container creation might fail if goes to same host.

To mitigate if container creation fails now we update cache.