### PR TITLE
Graceful Riemann connection and error handling

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -12,6 +12,11 @@ module.exports = Object.freeze({
     MAX_QUEUE_SIZE: 100,
     MAX_SEND_RETRIES: 2
   },
+  EVENT_LOG_RIEMANN_CLIENT_STATUS: {
+    INITIALIZING: 'initializing',
+    CONNECTED: 'connected',
+    DISCONNECTED: 'disconnected'
+  },
   OPERATION: {
     SUCCEEDED: 'succeeded',
     FAILED: 'failed',

--- a/common/constants.js
+++ b/common/constants.js
@@ -8,6 +8,10 @@ module.exports = Object.freeze({
   PLATFORM_CONTEXT_KEY: 'platform-context',
   NOT_APPLICABLE: 'NA',
   FINISHED_JOBS_RETENTION_DURATION_DAYS: 14,
+  EVENT_LOG_RIEMANN_CLIENT: {
+    MAX_QUEUE_SIZE: 100,
+    MAX_SEND_RETRIES: 2
+  },
   OPERATION: {
     SUCCEEDED: 'succeeded',
     FAILED: 'failed',

--- a/common/utils/EventLogRiemannClient.js
+++ b/common/utils/EventLogRiemannClient.js
@@ -9,7 +9,9 @@ const CONST = require('../constants');
 
 class EventLogRiemannClient {
   constructor(options) {
+    this.isInitializing = false;
     this.isInitialized = false;
+    this.QUEUED_REQUESTS = [];
     this.options = options;
     if (options.event_type) {
       pubsub.subscribe(options.event_type, (message, data) => this.handleEvent(message, _.cloneDeep(data)));
@@ -20,33 +22,51 @@ class EventLogRiemannClient {
 
   initialize() {
     try {
+      logger.debug('Connecting to Riemann');
+      this.isInitializing = true;
       this.riemannClient = riemannClient.createClient({
         host: this.options.host,
         port: this.options.port,
         transport: this.options.protocol
       });
       this.riemannClient.on('connect', () => {
+        this.isInitializing = false;
         this.isInitialized = true;
         logger.debug('Connected to Riemann');
-        //TODO : Some messages might be dropped during initialization or might trigger reinitialize
+        // Process requests enqued while riemann client was getting initialized
+        if(this._isRequestQueueNonEmpty()) {
+          this._processOutStandingRequest();
+        }
       });
       this.riemannClient.on('error', (err) => {
         if (this.options.show_errors) {
           logger.warn('error occurred with riemann ', err);
         }
-        this.isInitialized = false;
+        this.disconnect();
       });
       this.riemannClient.on('disconnect', () => {
         logger.debug('Disconnected from Riemann!');
+        this.isInitializing = false;
         this.isInitialized = false;
       });
     } catch (err) {
+      this.isInitializing = false;
+      this.isInitialized = false;
       if (this.options.show_errors) {
         logger.warn('Error initializing Riemann', err);
       }
       //Just log & do not propogate errors due to event logging
       //Event logging should in no way affect main event loop
       return;
+    }
+  }
+
+  disconnect() {
+    logger.info('Disconnecting Riemann');
+    this.isInitializing = false;
+    if (this.isInitialized) {
+      this.isInitialized = false;
+      this.riemannClient.disconnect();
     }
   }
 
@@ -97,14 +117,6 @@ class EventLogRiemannClient {
     return _.indexOf(httpResponseCodesToSkip, httpResponseCode) !== -1;
   }
 
-  disconnect() {
-    logger.info('Disconnecting Riemann');
-    if (this.isInitialized) {
-      this.isInitialized = false;
-      this.riemannClient.disconnect();
-    }
-  }
-
   logEvent(eventInfo, options) {
     //Transforming app specific event Information to Riemann specific format.
     const info = _
@@ -125,23 +137,70 @@ class EventLogRiemannClient {
         }
       })
       .value();
-    let attempt = 0;
+    this.sendEvent(info, 0);
+  }
+
+  sendEvent(info, attempt) {
     let messageSent = false;
-    do {
+    // Attempt to send event 2 times as enqueing request is also considered 1 attempt
+    while (!messageSent && attempt++ < CONST.EVENT_LOG_RIEMANN_CLIENT.MAX_SEND_RETRIES) {
       try {
-        if (!this.isInitialized) {
+        logger.debug(`Trying to send event to riemann, attempt ${attempt} : `  , info);
+        let enqueRequest = false;
+        if (!this.isInitialized && !this.isInitializing) {
           this.initialize();
+          enqueRequest = true;
+        } else if(this.isInitializing) {
+          enqueRequest = true
+        }
+        if(enqueRequest) {
+          this._enqueRequest(info, attempt);
+          return;
         }
         this.riemannClient.send(this.riemannClient.Event(info));
         logger.debug('logging following to riemann : ', info);
         messageSent = true;
       } catch (err) {
-        this.isInitialized = false;
+        this.disconnect();
         if (this.options.show_errors) {
-          logger.error('Error occurred while sending event to Riemann ', err);
+          logger.error(`Error occurred while sending event to Riemann, attempt ${attempt} `, err);
         }
       }
-    } while (!messageSent && ++attempt < 2);
+    }
+    if(!messageSent && attempt >= CONST.EVENT_LOG_RIEMANN_CLIENT.MAX_SEND_RETRIES) {
+      logger.error(`Event could not be sent to Riemann, max retries ${CONST.EVENT_LOG_RIEMANN_CLIENT.MAX_SEND_RETRIES} exceeded : `, info);
+    }
+  }
+  _enqueRequest(info, attempt) {
+    if(this.QUEUED_REQUESTS.length >= CONST.EVENT_LOG_RIEMANN_CLIENT.MAX_QUEUE_SIZE) {
+      logger.error(`Exceeded max queue size ${CONST.EVENT_LOG_RIEMANN_CLIENT.MAX_QUEUE_SIZE} for outstanding riemann events, dequeue first event`);
+      let request = this._dequeRequest();
+      logger.error(`Request discarded - `, request.info);
+    }
+    this.QUEUED_REQUESTS.push({
+      info: info,
+      attempt: attempt
+    });
+    logger.debug(`Request queued: `, info);
+  }
+
+  _dequeRequest() {
+    return this.QUEUED_REQUESTS.length === 0 ? null : this.QUEUED_REQUESTS.shift();
+  }
+
+  _isRequestQueueNonEmpty() {
+    return this.QUEUED_REQUESTS && this.QUEUED_REQUESTS.length > 0;
+  }
+
+  _processOutStandingRequest() {
+    logger.info(`Processing outstanding Riemann event send requests.. Queued Count: ${this.QUEUED_REQUESTS.length}`);
+    while(this._isRequestQueueNonEmpty()) {
+      let request = this._dequeRequest();
+      if (request !== null) {
+        logger.info(`Processing queued up request: `, request.info);
+        this.sendEvent(request.info, request.attempt);
+      }
+    }
   }
 }
 module.exports = EventLogRiemannClient;


### PR DESCRIPTION
Since riemann client emits events on **connect**, after calling `createClient`, we should wait for initialization to happen properly i.e. for **connect** event before sending event. Else they might get lost.
Hence events coming during this initialization time also need to be queued and retried after connect event is emitted.