### PR TITLE
Remove broker process hard dependency on Docker

### DIFF
--- a/broker/lib/fabrik/Fabrik.js
+++ b/broker/lib/fabrik/Fabrik.js
@@ -24,7 +24,12 @@ class Fabrik {
         case 'director':
           return DirectorManager;
         case 'docker':
-          return DockerManager;
+          if (config.enable_swarm_manager) {
+            return DockerManager;
+          } else {
+            assert.fail(plan.manager.name, ['director', 'virtual_host'], undefined, 'in');
+          }
+          break;
         case 'virtual_host':
           return VirtualHostManager;
         default:

--- a/broker/lib/fabrik/Fabrik.js
+++ b/broker/lib/fabrik/Fabrik.js
@@ -2,11 +2,11 @@
 
 const assert = require('assert');
 const Promise = require('bluebird');
+const config = require('../config');
 const catalog = require('../models').catalog;
 const Agent = require('./Agent');
 const VirtualHostAgent = require('./VirtualHostAgent');
 const DirectorManager = require('./DirectorManager');
-const DockerManager = require('./DockerManager');
 const VirtualHostManager = require('./VirtualHostManager');
 const ServiceFabrikOperation = require('./ServiceFabrikOperation');
 const FabrikStatusPoller = require('./FabrikStatusPoller');
@@ -14,6 +14,7 @@ const DBManager = require('./DBManager');
 const OobBackupManager = require('./OobBackupManager');
 const BasePlatformManager = require('./BasePlatformManager');
 const CONST = require('../constants');
+const DockerManager = config.enable_swarm_manager ? require('./DockerManager') : undefined;
 
 class Fabrik {
   static createManager(plan) {

--- a/broker/lib/index.js
+++ b/broker/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-exports.config = require('./config');
+const config = require('./config');
+exports.config = config;
 exports.errors = require('./errors');
 exports.jwt = require('./jwt');
 exports.logger = require('./logger');
@@ -9,7 +10,6 @@ exports.store = require('./store');
 exports.middleware = require('./middleware');
 exports.bosh = require('./bosh');
 exports.cf = require('./cf');
-exports.docker = require('./docker');
 exports.models = require('./models');
 exports.routes = require('./routes');
 exports.ScheduleManager = require('./jobs');
@@ -17,7 +17,9 @@ exports.fabrik = require('./fabrik');
 exports.controllers = require('./controllers');
 exports.iaas = require('./iaas');
 exports.bootstrap = bootstrap;
-
+if (config.enable_swarm_manager) {
+  exports.docker = require('./docker');
+}
 const logger = exports.logger;
 const docker = exports.docker;
 

--- a/test/test_broker/acceptance/service-fabrik-api.info.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.info.spec.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const assert = require('assert');
+const config = require('../../../common/config');
 const app = require('../support/apps').external;
 
 describe('service-fabrik-api', function () {
@@ -17,6 +18,23 @@ describe('service-fabrik-api', function () {
         .get(`${baseUrl}/info`)
         .catch(err => err.response)
         .then(res => {
+          assert.ok(res.body.db_status, 'Service fabrik info must return back db status');
+          expect(res).to.have.status(200);
+          expect(_.omit(res.body, 'db_status')).to.be.eql({
+            name: 'service-fabrik-broker',
+            api_version: '1.0',
+            ready: true
+          });
+          mocks.verify();
+        });
+    });
+    it('returns 200 Ok if swarm is disabled', function () {
+      config.enable_swarm_manager = false;
+      return chai.request(app)
+        .get(`${baseUrl}/info`)
+        .catch(err => err.response)
+        .then(res => {
+          config.enable_swarm_manager = true;
           assert.ok(res.body.db_status, 'Service fabrik info must return back db status');
           expect(res).to.have.status(200);
           expect(_.omit(res.body, 'db_status')).to.be.eql({

--- a/test/test_broker/acceptance/service-fabrik-api.info.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.info.spec.js
@@ -45,6 +45,21 @@ describe('service-fabrik-api', function () {
           mocks.verify();
         });
     });
+    it('returns 200 Ok if unable to fetch images', function () {
+      return chai.request(app)
+        .get(`${baseUrl}/info`)
+        .catch(err => err.response)
+        .then(res => {
+          assert.ok(res.body.db_status, 'Service fabrik info must return back db status');
+          expect(res).to.have.status(200);
+          expect(_.omit(res.body, 'db_status')).to.be.eql({
+            name: 'service-fabrik-broker',
+            api_version: '1.0',
+            ready: false
+          });
+          mocks.verify();
+        });
+    });
 
     it('returns 405 Method not allowed', function () {
       return chai.request(app)

--- a/test/test_broker/fabrik.DockerManager.spec.js
+++ b/test/test_broker/fabrik.DockerManager.spec.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const lib = require('../../broker/lib');
+const fabrik = require('../../broker/lib/fabrik/Fabrik');
+const config = lib.config;
 const portRegistry = lib.docker.portRegistry;
 const catalog = lib.models.catalog;
 const DockerManager = lib.fabrik.DockerManager;
@@ -32,6 +34,14 @@ describe('fabrik', function () {
     after(function () {
       portRegistry.willBeExhaustedSoon.restore();
       portRegistry.sample.restore();
+    });
+    it('Should return ', function () {
+      config.enable_swarm_manager = false;
+      return fabrik.createManager(catalog.getPlan(plan_id))
+        .catch(err => {
+          expect(err.code).to.eql('ERR_ASSERTION');
+          config.enable_swarm_manager = true;
+        });
     });
 
     describe('#createPortBindings', function () {


### PR DESCRIPTION
Fixes #280 
`getInfo` api now returns
`{"name":"service-fabrik-broker","api_version":"1.0","ready":true,"db_status":<db-status>}`
if `enable_swarm_manager` property is set to false