### PR TITLE
Enable service fabrik integration with credhub

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -402,6 +402,17 @@ defaults: &defaults
     url: https://api.bosh-lite.com
     username: admin
     password: admin
+  
+  #############################
+  # CREDHUB SETTINGS #
+  #############################
+  cred_provider:
+    credhub_url: https://10.0.3.11:8443/api/
+    credhub_uaa_url: https://10.0.3.11:8443
+    credhub_client_id:  credhub-admin
+    credhub_client_secret: 
+    credhub_username: admin
+    credhub_user_password: admin
 
   ###################
   # DOCKER SETTINGS #

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -491,6 +491,7 @@ defaults: &defaults
       provider: &provider_blueprint
         name: boshlite
         container: blueprint_backup
+        credhub_key: '/service-fabrik/iaas/blueprint'
         credhub_username: blueprint-admin
         credhub_user_password: blueprint-secret
     rabbitmq: &agent_rabbitmq

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -491,6 +491,8 @@ defaults: &defaults
       provider: &provider_blueprint
         name: boshlite
         container: blueprint_backup
+        credhub_username: blueprint-admin
+        credhub_user_password: blueprint-secret
     rabbitmq: &agent_rabbitmq
       version: '1'
       hostname: <%= process.env.RABBITMQ_AGENT_HOSTNAME || '~' %>

--- a/broker/lib/models/Service.js
+++ b/broker/lib/models/Service.js
@@ -13,7 +13,8 @@ class Service {
         plans: _.map(options.plans, plan => {
           if (plan.manager.name === CONST.INSTANCE_TYPE.DIRECTOR && config.cred_provider) {
             //Inject credhub config into agent properties
-            _.assign(_.get(plan, 'manager.settings.context.agent.provider'), config.cred_provider);
+            _.assign(_.get(plan, 'manager.settings.context.agent.provider'),
+              _.omit(config.cred_provider, 'credhub_username', 'credhub_user_password'));
           }
           return new Plan(this, plan);
         })

--- a/broker/lib/models/Service.js
+++ b/broker/lib/models/Service.js
@@ -2,14 +2,21 @@
 
 const _ = require('lodash');
 const Plan = require('./Plan');
-
+const config = require('../config');
+const CONST = require('../constants');
 
 class Service {
   constructor(options) {
     _(this)
       .chain()
       .assign({
-        plans: _.map(options.plans, plan => new Plan(this, plan))
+        plans: _.map(options.plans, plan => {
+          if (plan.manager.name === CONST.INSTANCE_TYPE.DIRECTOR && config.cred_provider) {
+            //Inject credhub config into agent properties
+            _.assign(_.get(plan, 'manager.settings.context.agent.provider'), config.cred_provider);
+          }
+          return new Plan(this, plan);
+        })
       })
       .defaults(options, {
         bindable: true,

--- a/broker/lib/models/Service.js
+++ b/broker/lib/models/Service.js
@@ -11,8 +11,9 @@ class Service {
       .chain()
       .assign({
         plans: _.map(options.plans, plan => {
-          if (plan.manager.name === CONST.INSTANCE_TYPE.DIRECTOR && config.cred_provider) {
-            //Inject credhub config into agent properties
+          if (plan.manager.name === CONST.INSTANCE_TYPE.DIRECTOR && config.cred_provider &&
+            _.get(plan, 'manager.settings.context.agent.provider.credhub_key', undefined) !== undefined) {
+            //Inject credhub config into agent properties in case credhub is configured for the service
             _.assign(_.get(plan, 'manager.settings.context.agent.provider'),
               _.omit(config.cred_provider, 'credhub_username', 'credhub_user_password'));
           }

--- a/test/test_broker/models.Service.spec.js
+++ b/test/test_broker/models.Service.spec.js
@@ -1,30 +1,72 @@
 'use strict';
 
+const _ = require('lodash');
+const CONST = require('../../broker/lib/constants');
+const config = require('../../broker/lib/config');
 const Service = require('../../broker/lib/models/Service');
 
 describe('models', () => {
   describe('Service', () => {
-    let options = {
-      id: 42,
-      name: 'sample',
-      description: 'sample description',
-      bindable: false
-    };
-
-    let service = new Service(options);
-
     describe('constructor', () => {
+      let options = {
+        id: 42,
+        name: 'sample',
+        description: 'sample description',
+        bindable: false,
+        plans: [{
+          name: 'test-pan1',
+          manager: {
+            name: CONST.INSTANCE_TYPE.DIRECTOR,
+            settings: {
+              context: {
+                agent: {
+                  provider: {
+                    credhub_key: '/blueprint',
+                    credhub_user_name: 'uaa',
+                    credhub_pass_word: 'pwd'
+                  }
+                }
+              }
+            }
+          }
+        }, {
+          name: 'test-pan1',
+          manager: {
+            name: CONST.INSTANCE_TYPE.DOCKER
+          }
+        }]
+      };
+      let service = new Service(options);
       it('returns an initialized BaseModel object with defaults', () => {
+        const credHubProvider = {
+          credhub_key: '/blueprint',
+          credhub_user_name: 'uaa',
+          credhub_pass_word: 'pwd'
+        };
+        _.assign(credHubProvider,
+          _.omit(config.cred_provider, 'credhub_username', 'credhub_user_password'));
+
         expect(service.id).to.equal(options.id);
         expect(service.name).to.equal(options.name);
         expect(service.description).to.equal(options.description);
         expect(service.bindable).to.equal(options.bindable);
         expect(service.tags).to.eql([]);
         expect(service.plan_updateable).to.equal(true);
+        expect(service.plans[0].manager.settings.context.agent.provider).to.eql(credHubProvider);
+        expect(service.plans[1].manager).to.eql({
+          name: CONST.INSTANCE_TYPE.DOCKER
+        });
       });
     });
 
     describe('toJSON', () => {
+      let options = {
+        id: 42,
+        name: 'sample',
+        description: 'sample description',
+        bindable: false
+      };
+      let service = new Service(options);
       it('returns a JSON object', () => {
         expect(service.toJSON()).to.eql({
           id: options.id,


### PR DESCRIPTION
IAAS credentials need not be stored as part of the service. Supports credhub integration.
Passes credhub co-ordinates during service deployment.