### PR TITLE
Feature/security groups

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -146,6 +146,7 @@ defaults: &defaults
   enable_swarm_manager: true
   feature:
     ServiceInstanceAutoUpdate: true #Switch to turn on / turn off schedule_update feature
+    EnableSecurityGroupsOps: true
   # this timeout is set to 175 secs by default because CF has a default timeout of 180 secs
   http_timeout: 175000
   deployment_action_timeout: 80000

--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -9,6 +9,7 @@ const errors = require('../errors');
 const cloudController = require('../cf').cloudController;
 const logger = require('../logger');
 const CONST = require('../constants');
+const config = require('../config');
 const SecurityGroupNotCreated = errors.SecurityGroupNotCreated;
 const SecurityGroupNotFound = errors.SecurityGroupNotFound;
 const ordinals = ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth'];
@@ -24,15 +25,30 @@ class CfPlatformManager extends BasePlatformManager {
   }
 
   postInstanceProvisionOperations(options) {
-    return this.createSecurityGroup(options);
+    if(_.get(config,'feature.EnableSecurityGroupsOps',true)){
+      return this.createSecurityGroup(options);
+    } else{
+      logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.');
+      return;
+    }
   }
 
   preInstanceDeleteOperations(options) {
-    return this.deleteSecurityGroup(options);
+    if(_.get(config,'feature.EnableSecurityGroupsOps',true)){
+      return this.deleteSecurityGroup(options);
+    }else {
+      logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.');
+      return;
+    }
   }
 
   postInstanceUpdateOperations(options) {
-    return this.ensureSecurityGroupExists(options);
+    if(_.get(config,'feature.EnableSecurityGroupsOps',true)){
+      return this.ensureSecurityGroupExists(options);
+    }else {
+      logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.');
+      return;
+    }
   }
 
   createSecurityGroup(options) {

--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -25,25 +25,25 @@ class CfPlatformManager extends BasePlatformManager {
   }
 
   postInstanceProvisionOperations(options) {
-    if(_.get(config,'feature.EnableSecurityGroupsOps',true)){
+    if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
       return this.createSecurityGroup(options);
-    } else{
+    } else {
       return Promise.try(() => logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.'));
     }
   }
 
   preInstanceDeleteOperations(options) {
-    if(_.get(config,'feature.EnableSecurityGroupsOps',true)){
+    if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
       return this.deleteSecurityGroup(options);
-    }else {
+    } else {
       return Promise.try(() => logger.info('Feature EnableSecurityGroupsOps set to false. Not deleting security groups.'));
     }
   }
 
   postInstanceUpdateOperations(options) {
-    if(_.get(config,'feature.EnableSecurityGroupsOps',true)){
+    if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
       return this.ensureSecurityGroupExists(options);
-    }else {
+    } else {
       return Promise.try(() => logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.'));
     }
   }

--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -28,8 +28,7 @@ class CfPlatformManager extends BasePlatformManager {
     if(_.get(config,'feature.EnableSecurityGroupsOps',true)){
       return this.createSecurityGroup(options);
     } else{
-      logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.');
-      return;
+      return Promise.try(() => logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.'));
     }
   }
 
@@ -37,8 +36,7 @@ class CfPlatformManager extends BasePlatformManager {
     if(_.get(config,'feature.EnableSecurityGroupsOps',true)){
       return this.deleteSecurityGroup(options);
     }else {
-      logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.');
-      return;
+      return Promise.try(() => logger.info('Feature EnableSecurityGroupsOps set to false. Not deleting security groups.'));
     }
   }
 
@@ -46,8 +44,7 @@ class CfPlatformManager extends BasePlatformManager {
     if(_.get(config,'feature.EnableSecurityGroupsOps',true)){
       return this.ensureSecurityGroupExists(options);
     }else {
-      logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.');
-      return;
+      return Promise.try(() => logger.info('Feature EnableSecurityGroupsOps set to false. Not creating security groups.'));
     }
   }
 

--- a/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
@@ -883,11 +883,15 @@ describe('service-broker-api', function () {
           mocks.agent.getInfo();
           mocks.agent.deprovision();
           mocks.director.verifyDeploymentLockStatus();
-          mocks.cloudController.findSecurityGroupByName(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.findSecurityGroupByName(instance_id);
+          }
           mocks.cloudController.getServiceInstance(instance_id, {
             space_guid: space_guid
           });
-          mocks.cloudController.deleteSecurityGroup(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.deleteSecurityGroup(instance_id);
+          }
           mocks.director.deleteDeployment(task_id);
           mocks.cloudProvider.remove(restorePathname);
           return chai.request(app)
@@ -932,11 +936,15 @@ describe('service-broker-api', function () {
           mocks.agent.getInfo();
           mocks.agent.deprovision();
           mocks.director.verifyDeploymentLockStatus();
-          mocks.cloudController.findSecurityGroupByName(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.findSecurityGroupByName(instance_id);
+          }
           mocks.cloudController.getServiceInstance(instance_id, {
             space_guid: space_guid
           });
-          mocks.cloudController.deleteSecurityGroup(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.deleteSecurityGroup(instance_id);
+          }
           mocks.director.deleteDeployment(task_id);
           mocks.cloudProvider.remove(restorePathname);
           return chai.request(app)
@@ -1114,7 +1122,9 @@ describe('service-broker-api', function () {
           };
           mocks.director.getDeploymentTask(task_id, 'done');
           mocks.director.createDeploymentProperty('platform-context', context);
-          mocks.cloudController.createSecurityGroup(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.createSecurityGroup(instance_id);
+          }
           const payload = {
             repeatInterval: CONST.SCHEDULE.RANDOM,
             timeZone: 'Asia/Kolkata'
@@ -1259,7 +1269,9 @@ describe('service-broker-api', function () {
             space_guid: space_guid
           };
           mocks.director.getDeploymentTask(task_id, 'done');
-          mocks.cloudController.findSecurityGroupByName(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.findSecurityGroupByName(instance_id);
+          }
           const old = config.scheduler.jobs.service_instance_update.run_every_xdays;
           config.scheduler.jobs.service_instance_update.run_every_xdays = 15;
           config.mongodb.provision.plan_id = 'TEST';

--- a/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
@@ -55,7 +55,9 @@ describe('service-broker-api', function () {
 
       describe('#provision', function () {
         it('returns 201 Created', function () {
-          mocks.cloudController.createSecurityGroup(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.createSecurityGroup(instance_id);
+          }
           mocks.docker.createContainer(instance_id);
           mocks.docker.startContainer();
           mocks.docker.inspectContainer();
@@ -85,7 +87,9 @@ describe('service-broker-api', function () {
         });
 
         it('returns 201 Created - start fails once internally', function () {
-          mocks.cloudController.createSecurityGroup(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.createSecurityGroup(instance_id);
+          }
           mocks.docker.createContainer(instance_id, 2);
           mocks.docker.startContainer(500);
           mocks.docker.deleteContainer();
@@ -219,8 +223,10 @@ describe('service-broker-api', function () {
               Env: ['context={"platform":"cloudfoundry"}']
             }
           });
-          mocks.cloudController.findSecurityGroupByName(instance_id);
-          mocks.cloudController.deleteSecurityGroup(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.findSecurityGroupByName(instance_id);
+            mocks.cloudController.deleteSecurityGroup(instance_id);
+          }
           mocks.docker.deleteContainer();
           mocks.docker.deleteVolumes(instance_id);
           return chai.request(app)
@@ -258,8 +264,10 @@ describe('service-broker-api', function () {
 
         it('returns 200 OK: for existing deployment not having platfrom-context in environment', function () {
           mocks.docker.inspectContainer(instance_id);
-          mocks.cloudController.findSecurityGroupByName(instance_id);
-          mocks.cloudController.deleteSecurityGroup(instance_id);
+          if (_.get(config, 'feature.EnableSecurityGroupsOps', true)) {
+            mocks.cloudController.findSecurityGroupByName(instance_id);
+            mocks.cloudController.deleteSecurityGroup(instance_id);
+          }
           mocks.docker.deleteContainer();
           mocks.docker.deleteVolumes(instance_id);
           return chai.request(app)

--- a/test/test_broker/fabrik.CfPlatformManager.spec.js
+++ b/test/test_broker/fabrik.CfPlatformManager.spec.js
@@ -1,0 +1,70 @@
+const Promise = require('bluebird');
+const _ = require('lodash');
+const CfPlatformManager = require('../../broker/lib/fabrik/CfPlatformManager');
+const assert = require('assert');
+let config = require('../../broker/lib/config');
+
+describe('fabrik', function(){
+    describe('CfPlatformManager', function(){
+
+        let cfPlatformManager = new CfPlatformManager('cf');
+        let prevVal = _.get(config, 'feature.EnableSecurityGroupsOps', true);
+        let sandbox, createSecurityGroupStub, deleteSecurityGroupStub, ensureSecurityGroupExistsStub;
+
+        before(function(){
+
+            _.set(config, 'feature.EnableSecurityGroupsOps', false);
+            sandbox = sinon.sandbox.create();
+            createSecurityGroupStub = sandbox.stub(cfPlatformManager, 'createSecurityGroup');
+            createSecurityGroupStub
+            .withArgs({'dummy': 'dummy'})
+            .returns(Promise.try(() => {
+                return {'dummy': 'dummy'};
+            }));
+
+            deleteSecurityGroupStub = sandbox.stub(cfPlatformManager, 'deleteSecurityGroup');
+            deleteSecurityGroupStub
+            .withArgs({'dummy': 'dummy'})
+            .returns(Promise.try(() => {
+                return {'dummy': 'dummy'};
+            }));
+
+            ensureSecurityGroupExistsStub = sandbox.stub(cfPlatformManager, 'ensureSecurityGroupExists');
+            ensureSecurityGroupExistsStub
+            .withArgs({'dummy': 'dummy'})
+            .returns(Promise.try(() => {
+                return {'dummy': 'dummy'};
+            }));
+
+        });
+        
+        after(function () {
+            _.set(config,'feature.EnableSecurityGroupsOps',prevVal);
+            sandbox.restore();
+        });
+
+        it('should not make call to createSecurityGroup when EnableSecurityGroupsOps set to false', function(){
+            return cfPlatformManager
+            .postInstanceProvisionOperations({'dummy': 'dummy'})
+            .then(() => {
+                assert(!createSecurityGroupStub.called);
+            });
+        });
+
+        it('should not make call to deleteSecurityGroup when EnableSecurityGroupsOps set to false', function(){
+            return cfPlatformManager
+            .preInstanceDeleteOperations({'dummy': 'dummy'})
+            .then(() => {
+                assert(!deleteSecurityGroupStub.called);
+            });
+        });
+
+        it('should not make call to ensureSecurityGroupExists when EnableSecurityGroupsOps set to false', function(){
+            return cfPlatformManager
+            .postInstanceUpdateOperations({'dummy': 'dummy'})
+            .then(() => {
+                assert(!ensureSecurityGroupExistsStub.called);
+            });
+        });
+    });
+});

--- a/test/test_broker/fabrik.CfPlatformManager.spec.js
+++ b/test/test_broker/fabrik.CfPlatformManager.spec.js
@@ -1,70 +1,90 @@
+'use strict';
+
 const Promise = require('bluebird');
 const _ = require('lodash');
 const CfPlatformManager = require('../../broker/lib/fabrik/CfPlatformManager');
 const assert = require('assert');
 let config = require('../../broker/lib/config');
 
-describe('fabrik', function(){
-    describe('CfPlatformManager', function(){
+describe('fabrik', function () {
+  describe('CfPlatformManager', function () {
 
-        let cfPlatformManager = new CfPlatformManager('cf');
-        let prevVal = _.get(config, 'feature.EnableSecurityGroupsOps', true);
-        let sandbox, createSecurityGroupStub, deleteSecurityGroupStub, ensureSecurityGroupExistsStub;
+    let cfPlatformManager = new CfPlatformManager('cf');
+    let prevVal = _.get(config, 'feature.EnableSecurityGroupsOps', true);
+    let sandbox, createSecurityGroupStub, deleteSecurityGroupStub, ensureSecurityGroupExistsStub;
 
-        before(function(){
+    before(function () {
 
-            _.set(config, 'feature.EnableSecurityGroupsOps', false);
-            sandbox = sinon.sandbox.create();
-            createSecurityGroupStub = sandbox.stub(cfPlatformManager, 'createSecurityGroup');
-            createSecurityGroupStub
-            .withArgs({'dummy': 'dummy'})
-            .returns(Promise.try(() => {
-                return {'dummy': 'dummy'};
-            }));
+      _.set(config, 'feature.EnableSecurityGroupsOps', false);
+      sandbox = sinon.sandbox.create();
+      createSecurityGroupStub = sandbox.stub(cfPlatformManager, 'createSecurityGroup');
+      createSecurityGroupStub
+        .withArgs({
+          'dummy': 'dummy'
+        })
+        .returns(Promise.try(() => {
+          return {
+            'dummy': 'dummy'
+          };
+        }));
 
-            deleteSecurityGroupStub = sandbox.stub(cfPlatformManager, 'deleteSecurityGroup');
-            deleteSecurityGroupStub
-            .withArgs({'dummy': 'dummy'})
-            .returns(Promise.try(() => {
-                return {'dummy': 'dummy'};
-            }));
+      deleteSecurityGroupStub = sandbox.stub(cfPlatformManager, 'deleteSecurityGroup');
+      deleteSecurityGroupStub
+        .withArgs({
+          'dummy': 'dummy'
+        })
+        .returns(Promise.try(() => {
+          return {
+            'dummy': 'dummy'
+          };
+        }));
 
-            ensureSecurityGroupExistsStub = sandbox.stub(cfPlatformManager, 'ensureSecurityGroupExists');
-            ensureSecurityGroupExistsStub
-            .withArgs({'dummy': 'dummy'})
-            .returns(Promise.try(() => {
-                return {'dummy': 'dummy'};
-            }));
+      ensureSecurityGroupExistsStub = sandbox.stub(cfPlatformManager, 'ensureSecurityGroupExists');
+      ensureSecurityGroupExistsStub
+        .withArgs({
+          'dummy': 'dummy'
+        })
+        .returns(Promise.try(() => {
+          return {
+            'dummy': 'dummy'
+          };
+        }));
 
-        });
-        
-        after(function () {
-            _.set(config,'feature.EnableSecurityGroupsOps',prevVal);
-            sandbox.restore();
-        });
+    });
 
-        it('should not make call to createSecurityGroup when EnableSecurityGroupsOps set to false', function(){
-            return cfPlatformManager
-            .postInstanceProvisionOperations({'dummy': 'dummy'})
-            .then(() => {
-                assert(!createSecurityGroupStub.called);
-            });
-        });
+    after(function () {
+      _.set(config, 'feature.EnableSecurityGroupsOps', prevVal);
+      sandbox.restore();
+    });
 
-        it('should not make call to deleteSecurityGroup when EnableSecurityGroupsOps set to false', function(){
-            return cfPlatformManager
-            .preInstanceDeleteOperations({'dummy': 'dummy'})
-            .then(() => {
-                assert(!deleteSecurityGroupStub.called);
-            });
-        });
-
-        it('should not make call to ensureSecurityGroupExists when EnableSecurityGroupsOps set to false', function(){
-            return cfPlatformManager
-            .postInstanceUpdateOperations({'dummy': 'dummy'})
-            .then(() => {
-                assert(!ensureSecurityGroupExistsStub.called);
-            });
+    it('should not make call to createSecurityGroup when EnableSecurityGroupsOps set to false', function () {
+      return cfPlatformManager
+        .postInstanceProvisionOperations({
+          'dummy': 'dummy'
+        })
+        .then(() => {
+          assert(!createSecurityGroupStub.called);
         });
     });
+
+    it('should not make call to deleteSecurityGroup when EnableSecurityGroupsOps set to false', function () {
+      return cfPlatformManager
+        .preInstanceDeleteOperations({
+          'dummy': 'dummy'
+        })
+        .then(() => {
+          assert(!deleteSecurityGroupStub.called);
+        });
+    });
+
+    it('should not make call to ensureSecurityGroupExists when EnableSecurityGroupsOps set to false', function () {
+      return cfPlatformManager
+        .postInstanceUpdateOperations({
+          'dummy': 'dummy'
+        })
+        .then(() => {
+          assert(!ensureSecurityGroupExistsStub.called);
+        });
+    });
+  });
 });


### PR DESCRIPTION
* Requirement was to enable security groups operations based on a switch.
* Added new feature switch EnableSecurityGroupsOps (corresponding PR for boshrelease also being raised.)
* Modified CfPlatformManager to perform security groups operations only when this flag is set to true.
* Modified some unit tests to accommodate these changes. 