### PR TITLE
API /v1/backups to work with instance_id parameter, when instance is deleted

### DIFF
--- a/broker/lib/iaas/CloudProviderClient.js
+++ b/broker/lib/iaas/CloudProviderClient.js
@@ -152,6 +152,7 @@ class CloudProviderClient extends BaseCloudClient {
       file = container;
       container = this.containerName;
     }
+    logger.debug(`Downloading file: ${file} from container ${container}`);
     return this
       .download({
         container: this.containerName,

--- a/test/test_broker/mocks/cloudController.js
+++ b/test/test_broker/mocks/cloudController.js
@@ -310,21 +310,22 @@ function getServiceInstancesInSpaceWithName(instance_name, space_guid, present) 
     });
 }
 
-function findServicePlanByInstanceId(instance_id, plan_guid, plan_unique_id) {
+function findServicePlanByInstanceId(instance_id, plan_guid, plan_unique_id, resources) {
+  const defaultResources = [{
+    metadata: {
+      guid: plan_guid
+    },
+    entity: {
+      unique_id: plan_unique_id
+    }
+  }];
   return nock(cloudControllerUrl)
     .get('/v2/service_plans')
     .query({
       q: `service_instance_guid:${instance_id}`
     })
     .reply(200, {
-      resources: [{
-        metadata: {
-          guid: plan_guid
-        },
-        entity: {
-          unique_id: plan_unique_id
-        }
-      }]
+      resources: resources ? resources : defaultResources
     });
 }
 


### PR DESCRIPTION
Modified SF broker API /v1/backups?space_guid= to also work with only instance guid and fetch backups list.
If the instance is not deleted, the API currently forms the prefix by fetching service/plan details from cloud controller / catalog and queries IaaS with this prefix.
Adding capability, if instance is deleted, the API still tries to fetch backups list by filtering on metadata file names based on instance_id parameter passed in API query.