### PR TITLE
Fix for BOSH deployments not being picked up from etcd queue (#307)

### DIFF
--- a/broker/lib/bosh/BoshOperationQueue.js
+++ b/broker/lib/bosh/BoshOperationQueue.js
@@ -174,12 +174,11 @@ class BoshOperationQueue {
   getDeploymentByName(name) {
     logger.debug('Getting deployment for ', name);
     const namespaceKey = getDeploymentKey(name);
-    return getKeyValue(getDeploymentKey(name), CONST.ETCD.JSON).then(val => {
-      if (val) {
-        return val[namespaceKey];
-      }
-      return val;
-    });
+    return getKeyValue(namespaceKey, CONST.ETCD.JSON)
+      .then(val => {
+        logger.debug(`found value for key ${namespaceKey}: ${val}`);
+        return val;
+      });
   }
 
   deleteBoshTask(serviceInstanceId) {

--- a/broker/lib/fabrik/DirectorManager.js
+++ b/broker/lib/fabrik/DirectorManager.js
@@ -283,17 +283,16 @@ class DirectorManager extends BaseManager {
   enqueueOrTrigger(shouldRunNow, scheduled, deploymentName) {
     const results = {
       cached: false,
-      shouldRunNow: false,
+      shouldRunNow: shouldRunNow,
       enqueue: false
     };
-    results.shouldRunNow = shouldRunNow;
     if (scheduled) {
       if (shouldRunNow) {
         //do not store in etcd for scheduled updates
         results.shouldRunNow = shouldRunNow;
         return results;
       } else {
-        throw new DeploymentDelayed(deploymentName);
+        throw new errors.DeploymentAttemptRejected(deploymentName);
       }
     } else {
       // user-triggered operations

--- a/broker/lib/fabrik/DirectorTaskPoller.js
+++ b/broker/lib/fabrik/DirectorTaskPoller.js
@@ -10,6 +10,7 @@ const config = require('../config');
 const boshCache = bosh.BoshOperationQueue;
 const TIME_POLL = 1 * 60 * 1000;
 const LockStatusPoller = require('./LockStatusPoller');
+const Promise = require('bluebird');
 
 class DirectorTaskPoller extends LockStatusPoller {
   constructor() {
@@ -25,7 +26,8 @@ class DirectorTaskPoller extends LockStatusPoller {
           })
           .then(cached => {
             let catalogPlan = catalog.getPlan(cached.plan_id);
-            return DirectorManager.load(catalogPlan).createOrUpdateDeployment(deploymentName, cached.params, cached.args);
+            return DirectorManager.load(catalogPlan)
+              .then(manager => manager.createOrUpdateDeployment(deploymentName, cached.params, cached.args));
           })
           .catch(e => {
             logger.error(`Error in scheduled deployment operation for ${deploymentName}`, e);

--- a/broker/lib/jobs/ServiceInstanceUpdateJob.js
+++ b/broker/lib/jobs/ServiceInstanceUpdateJob.js
@@ -97,7 +97,14 @@ class ServiceInstanceUpdateJob extends BaseJob {
           })
           .catch(err => {
             operationResponse.update_init = CONST.OPERATION.FAILED;
-            logger.error('Error occurred while updating service insance job :', err);
+            logger.error('Error occurred while updating service instance job :', err);
+            if (err instanceof errors.DeploymentAttemptRejected) {
+              //If deployment was staggered due to exhaustion of workers, reschedule update job
+              //Retry attempts do not count when deployment is staggered
+              //TODO: Need to check if the next run for scheduled update causes problems if the earlier deployment did not go through
+              trackAttempts = false;
+              err.statusMessage = 'Deployment attempt rejected due to BOSH overload. Update cannot be initiated';
+            }
             if (err instanceof errors.DeploymentAlreadyLocked) {
               //If deployment locked then backup is in progress. So reschedule update job,
               //Retry attempts dont count when deployment is locked for backup.

--- a/common/constants.js
+++ b/common/constants.js
@@ -12,6 +12,8 @@ module.exports = Object.freeze({
     BOSH_CANCELLING: 'cancelling'
   },
   FABRIK_SCHEDULED_OPERATION: 'scheduled',
+  FABRIK_OPERATION_STAGGERED: 'staggered',
+  FABRIK_OPERATION_COUNT_EXCEEDED: 'operation count exceeded',
   UNCATEGORIZED: 'uncategorized',
   DEPLOYMENT_LOCK_NAME: '_LOCK_',
   SERVICE_FABRIK_PREFIX: 'service-fabrik',

--- a/common/errors.js
+++ b/common/errors.js
@@ -196,6 +196,14 @@ class DeploymentAlreadyLocked extends UnprocessableEntity {
 }
 exports.DeploymentAlreadyLocked = DeploymentAlreadyLocked;
 
+class DeploymentAttemptRejected extends UnprocessableEntity {
+  constructor(deploymentName) {
+    let message = `Deployment ${deploymentName} ${CONST.FABRIK_OPERATION_STAGGERED}, Reason: ${CONST.FABRIK_OPERATION_COUNT_EXCEEDED}`;
+    super(message);
+  }
+}
+exports.DeploymentAttemptRejected = DeploymentAttemptRejected;
+
 class ServiceNotFound extends NotFound {
   constructor(id) {
     super(`Could not find Service with ID ${id}`);

--- a/test/test_broker/bosh.BoshOperationQueue.spec.js
+++ b/test/test_broker/bosh.BoshOperationQueue.spec.js
@@ -96,7 +96,7 @@ class SingleRangeStubber {
   json() {
     return Promise.try(() => {
       if (this.value) {
-        return JSON.parse(this.value);
+        return JSON.parse(this.value)[this.key];
       }
       return null;
     });


### PR DESCRIPTION
* Fix bosh deployments not being picked from etcd queue

- Rely on bluebird promise instead of native promise
- Use etcd json properly

* Fix bosh deployments not being picked from etcd queue

- Wrap DirectorManager.load in promise.try
- Rely on bluebird promise instead of native promise
- Use etcd json properly

* Reschedule update if operation is staggered

- Have unbounded retries if bosh rate limits are exceeded
- Handle deployment staggered isolated

* Handle test case for update job retry

* Incorporate review comments

- Minor change to remove try and always use Promise.then
- Add a TODO for posterity