### PR TITLE
Feature/fine grained sec groups

### DIFF
--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -116,11 +116,11 @@ class CfPlatformManager extends BasePlatformManager {
 
   buildSecurityGroupRules(options) {
     let portRule = '1024-65535';
-    if (options.port.exposedPorts) {
-      if (options.port.range) {
-        portRule = `${_.first(options.port.exposedPorts)}-${_.last(options.port.exposedPorts)}`;
+    if (options.securityGroupParams && options.securityGroupParams.exposed_ports) {
+      if (options.securityGroupParams.range) {
+        portRule = `${_.first(options.securityGroupParams.exposed_ports)}-${_.last(options.securityGroupParams.exposed_ports)}`;
       } else {
-        portRule = _.size(options.port.exposedPorts) === 1 ? `${_.first(options.port.exposedPorts)}` : `${_.join(options.port.exposedPorts,',')}`;
+        portRule = _.size(options.securityGroupParams.exposed_ports) === 1 ? `${_.first(options.securityGroupParams.exposed_ports)}` : `${_.join(options.securityGroupParams.exposed_ports,',')}`;
       }
     }
     return {

--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -114,17 +114,10 @@ class CfPlatformManager extends BasePlatformManager {
       );
   }
 
-  /*
-  {
-    protocol: 'tcp',
-    ips: ['10.11.20.248', '10.11.20.255'],
-    applicationAccessPorts: ['8080']
-  }
-  */
   buildSecurityGroupRules(options) {
     let portRule = '1024-65535';
-    if (options.applicationAccessPorts && _.size(options.applicationAccessPorts) > 0) {
-      portRule = _.size(options.applicationAccessPorts) === 1 ? `${_.first(options.applicationAccessPorts)}` : `${_.join(options.applicationAccessPorts,',')}`;
+    if (Array.isArray(options.applicationAccessPorts) && _.size(options.applicationAccessPorts) > 0) {
+      portRule = `${_.join(options.applicationAccessPorts,',')}`;
     }
     return {
       protocol: options.protocol,

--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -117,7 +117,7 @@ class CfPlatformManager extends BasePlatformManager {
   buildSecurityGroupRules(options) {
     let portRule = '1024-65535';
     if (Array.isArray(options.applicationAccessPorts) && _.size(options.applicationAccessPorts) > 0) {
-      portRule = `${_.join(options.applicationAccessPorts,',')}`;
+      portRule = _.join(options.applicationAccessPorts, ',');
     }
     return {
       protocol: options.protocol,

--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -114,14 +114,17 @@ class CfPlatformManager extends BasePlatformManager {
       );
   }
 
+  /*
+  {
+    protocol: 'tcp',
+    ips: ['10.11.20.248', '10.11.20.255'],
+    applicationAccessPorts: ['8080']
+  }
+  */
   buildSecurityGroupRules(options) {
     let portRule = '1024-65535';
-    if (options.securityGroupParams && options.securityGroupParams.exposed_ports) {
-      if (options.securityGroupParams.range) {
-        portRule = `${_.first(options.securityGroupParams.exposed_ports)}-${_.last(options.securityGroupParams.exposed_ports)}`;
-      } else {
-        portRule = _.size(options.securityGroupParams.exposed_ports) === 1 ? `${_.first(options.securityGroupParams.exposed_ports)}` : `${_.join(options.securityGroupParams.exposed_ports,',')}`;
-      }
+    if (options.applicationAccessPorts && _.size(options.applicationAccessPorts) > 0) {
+      portRule = _.size(options.applicationAccessPorts) === 1 ? `${_.first(options.applicationAccessPorts)}` : `${_.join(options.applicationAccessPorts,',')}`;
     }
     return {
       protocol: options.protocol,

--- a/broker/lib/fabrik/CfPlatformManager.js
+++ b/broker/lib/fabrik/CfPlatformManager.js
@@ -115,10 +115,18 @@ class CfPlatformManager extends BasePlatformManager {
   }
 
   buildSecurityGroupRules(options) {
+    let portRule = '1024-65535';
+    if (options.port.exposedPorts) {
+      if (options.port.range) {
+        portRule = `${_.first(options.port.exposedPorts)}-${_.last(options.port.exposedPorts)}`;
+      } else {
+        portRule = _.size(options.port.exposedPorts) === 1 ? `${_.first(options.port.exposedPorts)}` : `${_.join(options.port.exposedPorts,',')}`;
+      }
+    }
     return {
       protocol: options.protocol,
       destination: _.size(options.ips) === 1 ? `${_.first(options.ips)}` : `${_.first(options.ips)}-${_.last(options.ips)}`,
-      ports: _.size(options.ports) === 1 ? `${_.first(options.ports)}` : `${_.first(options.ports)}-${_.last(options.ports)}`
+      ports: portRule
     };
   }
 }

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -420,23 +420,18 @@ class DirectorInstance extends BaseInstance {
       .then(() => this.manager.deleteBinding(this.deploymentName, params.binding_id));
   }
 
-  getExposedPortsOfService() {
+  getSecurityGroupParamsOfService() {
     let service = this.manager.service.toJSON();
-    let range = _.get(service, 'security_group_params.range', false);
-    let exposedPorts = _.get(service, 'security_group_params.exposed_ports');
-    return {
-      range: range,
-      ports: exposedPorts
-    };
+    return _.get(service, 'security_group_params');
   }
 
   buildIpRules() {
-    let exposedPorts = this.getExposedPortsOfService();
+    let securityGroupParams = this.getSecurityGroupParamsOfService();
     return _.map(this.manager.getNetwork(this.networkSegmentIndex), net => {
       return {
         protocol: 'tcp',
         ips: net.static,
-        ports: exposedPorts
+        securityGroupParams: securityGroupParams
       };
     });
   }

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -420,12 +420,23 @@ class DirectorInstance extends BaseInstance {
       .then(() => this.manager.deleteBinding(this.deploymentName, params.binding_id));
   }
 
+  getExposedPortsOfService() {
+    let service = this.manager.service.toJSON();
+    let range = _.get(service, 'security_group_params.range', false);
+    let exposedPorts = _.get(service, 'security_group_params.exposed_ports');
+    return {
+      range: range,
+      ports: exposedPorts
+    };
+  }
+
   buildIpRules() {
+    let exposedPorts = this.getExposedPortsOfService();
     return _.map(this.manager.getNetwork(this.networkSegmentIndex), net => {
       return {
         protocol: 'tcp',
         ips: net.static,
-        ports: [1024, 65535]
+        ports: exposedPorts
       };
     });
   }

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -420,18 +420,18 @@ class DirectorInstance extends BaseInstance {
       .then(() => this.manager.deleteBinding(this.deploymentName, params.binding_id));
   }
 
-  getSecurityGroupParamsOfService() {
+  getApplicationAccessPortsOfService() {
     let service = this.manager.service.toJSON();
-    return _.get(service, 'security_group_params');
+    return _.get(service, 'application_access_ports');
   }
 
   buildIpRules() {
-    let securityGroupParams = this.getSecurityGroupParamsOfService();
+    let applicationAccessPorts = this.getApplicationAccessPortsOfService();
     return _.map(this.manager.getNetwork(this.networkSegmentIndex), net => {
       return {
         protocol: 'tcp',
         ips: net.static,
-        securityGroupParams: securityGroupParams
+        applicationAccessPorts: applicationAccessPorts
       };
     });
   }

--- a/broker/lib/models/Service.js
+++ b/broker/lib/models/Service.js
@@ -27,7 +27,8 @@ class Service {
         metadata: null,
         requires: [],
         plan_updateable: true,
-        dashboard_client: {}
+        dashboard_client: {},
+        security_group_params: null
       })
       .value();
   }
@@ -51,7 +52,8 @@ class Service {
       'metadata',
       'requires',
       'plan_updateable',
-      'dashboard_client'
+      'dashboard_client',
+      'security_group_params'
     ];
   }
 }

--- a/broker/lib/models/Service.js
+++ b/broker/lib/models/Service.js
@@ -28,7 +28,7 @@ class Service {
         requires: [],
         plan_updateable: true,
         dashboard_client: {},
-        security_group_params: null
+        application_access_ports: null
       })
       .value();
   }
@@ -53,7 +53,7 @@ class Service {
       'requires',
       'plan_updateable',
       'dashboard_client',
-      'security_group_params'
+      'application_access_ports'
     ];
   }
 }

--- a/test/test_broker/fabrik.CfPlatformManager.spec.js
+++ b/test/test_broker/fabrik.CfPlatformManager.spec.js
@@ -95,10 +95,7 @@ describe('fabrik', function () {
         let options = {
           protocol: 'tcp',
           ips: ['10.11.20.248', '10.11.20.255'],
-          securityGroupParams: {
-            range: false,
-            exposed_ports: ['8080']
-          }
+          applicationAccessPorts: ['8080']
         };
 
         let rules = cfPlatformManager.buildSecurityGroupRules(options);
@@ -111,47 +108,27 @@ describe('fabrik', function () {
         let options = {
           protocol: 'tcp',
           ips: ['10.11.20.248', '10.11.20.255'],
-          securityGroupParams: {
-            range: false,
-            exposed_ports: ['8080', '8081', '8082']
-          }
+          applicationAccessPorts: ['8080', '8081', '8082']
         };
-
         let rules = cfPlatformManager.buildSecurityGroupRules(options);
         assert(rules.protocol === 'tcp');
         assert(rules.destination === '10.11.20.248-10.11.20.255');
         assert(rules.ports === '8080,8081,8082');
       });
 
-      it('should handle empty security_groups_params', function () {
+      it('should handle empty applicationAccessPorts', function () {
         let options = {
           protocol: 'tcp',
           ips: ['10.11.20.248', '10.11.20.255'],
-          securityGroupParams: {}
+          applicationAccessPorts: undefined
         };
 
         let rules = cfPlatformManager.buildSecurityGroupRules(options);
+        console.log(rules);
         assert(rules.protocol === 'tcp');
         assert(rules.destination === '10.11.20.248-10.11.20.255');
         assert(rules.ports === '1024-65535');
       });
-
-      it('should handle range of ports', function () {
-        let options = {
-          protocol: 'tcp',
-          ips: ['10.11.20.248', '10.11.20.255'],
-          securityGroupParams: {
-            range: true,
-            exposed_ports: ['8080', '8085']
-          }
-        };
-
-        let rules = cfPlatformManager.buildSecurityGroupRules(options);
-        assert(rules.protocol === 'tcp');
-        assert(rules.destination === '10.11.20.248-10.11.20.255');
-        assert(rules.ports === '8080-8085');
-      });
-
     });
   });
 });

--- a/test/test_broker/fabrik.CfPlatformManager.spec.js
+++ b/test/test_broker/fabrik.CfPlatformManager.spec.js
@@ -124,7 +124,6 @@ describe('fabrik', function () {
         };
 
         let rules = cfPlatformManager.buildSecurityGroupRules(options);
-        console.log(rules);
         assert(rules.protocol === 'tcp');
         assert(rules.destination === '10.11.20.248-10.11.20.255');
         assert(rules.ports === '1024-65535');

--- a/test/test_broker/fabrik.CfPlatformManager.spec.js
+++ b/test/test_broker/fabrik.CfPlatformManager.spec.js
@@ -8,83 +8,150 @@ let config = require('../../broker/lib/config');
 
 describe('fabrik', function () {
   describe('CfPlatformManager', function () {
+    describe('feature.EnableSecurityGroupsOps', function () {
+      let cfPlatformManager = new CfPlatformManager('cf');
+      let prevVal = _.get(config, 'feature.EnableSecurityGroupsOps', true);
+      let sandbox, createSecurityGroupStub, deleteSecurityGroupStub, ensureSecurityGroupExistsStub;
 
-    let cfPlatformManager = new CfPlatformManager('cf');
-    let prevVal = _.get(config, 'feature.EnableSecurityGroupsOps', true);
-    let sandbox, createSecurityGroupStub, deleteSecurityGroupStub, ensureSecurityGroupExistsStub;
+      before(function () {
 
-    before(function () {
-
-      _.set(config, 'feature.EnableSecurityGroupsOps', false);
-      sandbox = sinon.sandbox.create();
-      createSecurityGroupStub = sandbox.stub(cfPlatformManager, 'createSecurityGroup');
-      createSecurityGroupStub
-        .withArgs({
-          'dummy': 'dummy'
-        })
-        .returns(Promise.try(() => {
-          return {
+        _.set(config, 'feature.EnableSecurityGroupsOps', false);
+        sandbox = sinon.sandbox.create();
+        createSecurityGroupStub = sandbox.stub(cfPlatformManager, 'createSecurityGroup');
+        createSecurityGroupStub
+          .withArgs({
             'dummy': 'dummy'
-          };
-        }));
+          })
+          .returns(Promise.try(() => {
+            return {
+              'dummy': 'dummy'
+            };
+          }));
 
-      deleteSecurityGroupStub = sandbox.stub(cfPlatformManager, 'deleteSecurityGroup');
-      deleteSecurityGroupStub
-        .withArgs({
-          'dummy': 'dummy'
-        })
-        .returns(Promise.try(() => {
-          return {
+        deleteSecurityGroupStub = sandbox.stub(cfPlatformManager, 'deleteSecurityGroup');
+        deleteSecurityGroupStub
+          .withArgs({
             'dummy': 'dummy'
-          };
-        }));
+          })
+          .returns(Promise.try(() => {
+            return {
+              'dummy': 'dummy'
+            };
+          }));
 
-      ensureSecurityGroupExistsStub = sandbox.stub(cfPlatformManager, 'ensureSecurityGroupExists');
-      ensureSecurityGroupExistsStub
-        .withArgs({
-          'dummy': 'dummy'
-        })
-        .returns(Promise.try(() => {
-          return {
+        ensureSecurityGroupExistsStub = sandbox.stub(cfPlatformManager, 'ensureSecurityGroupExists');
+        ensureSecurityGroupExistsStub
+          .withArgs({
             'dummy': 'dummy'
-          };
-        }));
+          })
+          .returns(Promise.try(() => {
+            return {
+              'dummy': 'dummy'
+            };
+          }));
 
+      });
+
+      after(function () {
+        _.set(config, 'feature.EnableSecurityGroupsOps', prevVal);
+        sandbox.restore();
+      });
+
+      it('should not make call to createSecurityGroup when EnableSecurityGroupsOps set to false', function () {
+        return cfPlatformManager
+          .postInstanceProvisionOperations({
+            'dummy': 'dummy'
+          })
+          .then(() => {
+            assert(!createSecurityGroupStub.called);
+          });
+      });
+
+      it('should not make call to deleteSecurityGroup when EnableSecurityGroupsOps set to false', function () {
+        return cfPlatformManager
+          .preInstanceDeleteOperations({
+            'dummy': 'dummy'
+          })
+          .then(() => {
+            assert(!deleteSecurityGroupStub.called);
+          });
+      });
+
+      it('should not make call to ensureSecurityGroupExists when EnableSecurityGroupsOps set to false', function () {
+        return cfPlatformManager
+          .postInstanceUpdateOperations({
+            'dummy': 'dummy'
+          })
+          .then(() => {
+            assert(!ensureSecurityGroupExistsStub.called);
+          });
+      });
     });
 
-    after(function () {
-      _.set(config, 'feature.EnableSecurityGroupsOps', prevVal);
-      sandbox.restore();
-    });
+    describe('#buildSecurityGroupRules', function () {
+      let cfPlatformManager = new CfPlatformManager('cf');
 
-    it('should not make call to createSecurityGroup when EnableSecurityGroupsOps set to false', function () {
-      return cfPlatformManager
-        .postInstanceProvisionOperations({
-          'dummy': 'dummy'
-        })
-        .then(() => {
-          assert(!createSecurityGroupStub.called);
-        });
-    });
+      it('should return single port rule', function () {
+        let options = {
+          protocol: 'tcp',
+          ips: ['10.11.20.248', '10.11.20.255'],
+          securityGroupParams: {
+            range: false,
+            exposed_ports: ['8080']
+          }
+        };
 
-    it('should not make call to deleteSecurityGroup when EnableSecurityGroupsOps set to false', function () {
-      return cfPlatformManager
-        .preInstanceDeleteOperations({
-          'dummy': 'dummy'
-        })
-        .then(() => {
-          assert(!deleteSecurityGroupStub.called);
-        });
-    });
+        let rules = cfPlatformManager.buildSecurityGroupRules(options);
+        assert(rules.protocol === 'tcp');
+        assert(rules.destination === '10.11.20.248-10.11.20.255');
+        assert(rules.ports === '8080');
+      });
 
-    it('should not make call to ensureSecurityGroupExists when EnableSecurityGroupsOps set to false', function () {
-      return cfPlatformManager
-        .postInstanceUpdateOperations({
-          'dummy': 'dummy'
-        })
-        .then(() => {
-          assert(!ensureSecurityGroupExistsStub.called);
-        });
+      it('should return comma separated port rule', function () {
+        let options = {
+          protocol: 'tcp',
+          ips: ['10.11.20.248', '10.11.20.255'],
+          securityGroupParams: {
+            range: false,
+            exposed_ports: ['8080', '8081', '8082']
+          }
+        };
+
+        let rules = cfPlatformManager.buildSecurityGroupRules(options);
+        assert(rules.protocol === 'tcp');
+        assert(rules.destination === '10.11.20.248-10.11.20.255');
+        assert(rules.ports === '8080,8081,8082');
+      });
+
+      it('should handle empty security_groups_params', function () {
+        let options = {
+          protocol: 'tcp',
+          ips: ['10.11.20.248', '10.11.20.255'],
+          securityGroupParams: {}
+        };
+
+        let rules = cfPlatformManager.buildSecurityGroupRules(options);
+        assert(rules.protocol === 'tcp');
+        assert(rules.destination === '10.11.20.248-10.11.20.255');
+        assert(rules.ports === '1024-65535');
+      });
+
+      it('should handle range of ports', function () {
+        let options = {
+          protocol: 'tcp',
+          ips: ['10.11.20.248', '10.11.20.255'],
+          securityGroupParams: {
+            range: true,
+            exposed_ports: ['8080', '8085']
+          }
+        };
+
+        let rules = cfPlatformManager.buildSecurityGroupRules(options);
+        assert(rules.protocol === 'tcp');
+        assert(rules.destination === '10.11.20.248-10.11.20.255');
+        assert(rules.ports === '8080-8085');
+      });
+
     });
   });
 });

--- a/test/test_broker/models.Service.spec.js
+++ b/test/test_broker/models.Service.spec.js
@@ -80,7 +80,7 @@ describe('models', () => {
           plan_updateable: true,
           dashboard_client: {},
           plans: [],
-          security_group_params: null
+          application_access_ports: null
         });
       });
     });

--- a/test/test_broker/models.Service.spec.js
+++ b/test/test_broker/models.Service.spec.js
@@ -79,7 +79,8 @@ describe('models', () => {
           requires: [],
           plan_updateable: true,
           dashboard_client: {},
-          plans: []
+          plans: [],
+          security_group_params: null
         });
       });
     });


### PR DESCRIPTION
* Requirement is to enable the creation of security groups for specific ports at the time of service instance creation. Currently, application security groups are created for entire port range of 1024-65k, exposing service instance components to attack initiated from inside the bound apps.

* Modified the flow of building rules for security group creation to consume relevant exposed port information from services catalog.

* Tested on dev landscape for blueprint service and will run through the dev pipeline once catalogs of other services are also updated.

* This change does not take care of update of application security groups of existing instances.