### PR TITLE
Refactoring the middleware and LockManager

### DIFF
--- a/broker/lib/middleware.js
+++ b/broker/lib/middleware.js
@@ -29,7 +29,7 @@ exports.validateRequest = function () {
   return function (req, res, next) {
     /* jshint unused:false */
     if (req.instance.async && (_.get(req, 'query.accepts_incomplete', 'false') !== 'true')) {
-      next(new UnprocessableEntity('This request requires client support for asynchronous service operations.', 'AsyncRequired'));
+      return next(new UnprocessableEntity('This request requires client support for asynchronous service operations.', 'AsyncRequired'));
     }
     next();
   };
@@ -39,7 +39,7 @@ exports.validateCreateRequest = function () {
   return function (req, res, next) {
     /* jshint unused:false */
     if (!_.get(req.body, 'space_guid') || !_.get(req.body, 'organization_guid')) {
-      next(new BadRequest('This request is missing mandatory organization guid and/or space guid.'));
+      return next(new BadRequest('This request is missing mandatory organization guid and/or space guid.'));
     }
     next();
   };

--- a/broker/lib/middleware.js
+++ b/broker/lib/middleware.js
@@ -25,15 +25,20 @@ exports.isFeatureEnabled = function (featureName) {
   };
 };
 
-exports.validateRequest = function (operationType) {
+exports.validateRequest = function () {
   return function (req, res, next) {
     /* jshint unused:false */
     if (req.instance.async && (_.get(req, 'query.accepts_incomplete', 'false') !== 'true')) {
       next(new UnprocessableEntity('This request requires client support for asynchronous service operations.', 'AsyncRequired'));
     }
-    if (_.includes([CONST.OPERATION_TYPE.CREATE], operationType) &&
-      //TODO-PR - Move this to validateCreateRequest and have ValidateRequest for all HTTP Operations and not for each operation type in the route setup code.
-      (!_.get(req.body, 'space_guid') || !_.get(req.body, 'organization_guid'))) {
+    next();
+  };
+};
+
+exports.validateCreateRequest = function () {
+  return function (req, res, next) {
+    /* jshint unused:false */
+    if (!_.get(req.body, 'space_guid') || !_.get(req.body, 'organization_guid')) {
       next(new BadRequest('This request is missing mandatory organization guid and/or space guid.'));
     }
     next();
@@ -49,7 +54,7 @@ exports.lock = function (operationType, lastOperationCall) {
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
             resourceId: req.params.instance_id,
-            operation: operationType ? operationType : req.query.operation.type // This is for the last operation call
+            operation: operationType ? operationType : utils.decodeBase64(req.query.operation).type // This is for the last operation call
           }
         })
         .then(() => next())
@@ -68,16 +73,14 @@ exports.lock = function (operationType, lastOperationCall) {
   };
 };
 
-exports.isWriteLocked = function () {
-  //TODO-PR - can name this method to checkBlockingOperationInProgress or checkWriteLocked -- as this is really not returning a boolean.
+exports.checkBlockingOperationInProgress = function () {
   return function (req, res, next) {
     if (req.manager.name === CONST.INSTANCE_TYPE.DIRECTOR && config.enable_service_fabrik_v2) {
       // Acquire lock for this instance
-      return lockManager.isWriteLocked(req.params.instance_id)
-        .then(isWriteLocked => {
-          if (isWriteLocked) {
-            //TODO-PR - Its better to fetchLock here instead of a boolean as you can better construct the error with the operaiton and the time the lock has been acquired.
-            next(new DeploymentAlreadyLocked(req.params.instance_id, undefined, `Resource ${req.params.instance_id} is write locked`));
+      return lockManager.checkWriteLockStatus(req.params.instance_id)
+        .then(writeLockStatus => {
+          if (writeLockStatus.isWriteLocked) {
+            next(new DeploymentAlreadyLocked(req.params.instance_id, undefined, `Resource ${req.params.instance_id} is write locked for ${writeLockStatus.lockDetails.lockedResourceDetails.operation} at ${lockTime}`));
           } else {
             next();
           }

--- a/broker/lib/middleware.js
+++ b/broker/lib/middleware.js
@@ -80,7 +80,7 @@ exports.checkBlockingOperationInProgress = function () {
       return lockManager.checkWriteLockStatus(req.params.instance_id)
         .then(writeLockStatus => {
           if (writeLockStatus.isWriteLocked) {
-            next(new DeploymentAlreadyLocked(req.params.instance_id, undefined, `Resource ${req.params.instance_id} is write locked for ${writeLockStatus.lockDetails.lockedResourceDetails.operation} at ${lockTime}`));
+            next(new DeploymentAlreadyLocked(req.params.instance_id, undefined, `Resource ${req.params.instance_id} is write locked for ${writeLockStatus.lockDetails.lockedResourceDetails.operation} at ${writeLockStatus.lockDetails.lockTime}`));
           } else {
             next();
           }

--- a/broker/lib/routes/broker/v2.js
+++ b/broker/lib/routes/broker/v2.js
@@ -33,14 +33,14 @@ router.use(commonMiddleware.error({
 instanceRouter.use(controller.handler('ensurePlatformContext'));
 instanceRouter.use(controller.handler('assignInstance'));
 instanceRouter.route('/')
-  .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(CONST.OPERATION_TYPE.CREATE), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
-  .patch([middleware.checkQuota(), middleware.validateRequest(CONST.OPERATION_TYPE.UPDATE), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
-  .delete([middleware.validateRequest(CONST.OPERATION_TYPE.DELETE), controller.handleWithResourceLocking('deleteInstance', CONST.OPERATION_TYPE.DELETE)])
+  .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
+  .patch([middleware.checkQuota(), middleware.validateRequest(), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
+  .delete([middleware.validateRequest(), controller.handleWithResourceLocking('deleteInstance', CONST.OPERATION_TYPE.DELETE)])
   .all(commonMiddleware.methodNotAllowed(['PUT', 'PATCH', 'DELETE']));
 instanceRouter.route('/last_operation')
   .get([middleware.lock(undefined, true), controller.handler('getLastInstanceOperation')]) //passing undefined as last operation operationType is part of the req
   .all(commonMiddleware.methodNotAllowed(['GET']));
 instanceRouter.route('/service_bindings/:binding_id')
-  .put([middleware.isWriteLocked(), controller.handler('putBinding')])
-  .delete(middleware.isWriteLocked(), controller.handler('deleteBinding'))
+  .put([middleware.checkBlockingOperationInProgress(), controller.handler('putBinding')])
+  .delete(middleware.checkBlockingOperationInProgress(), controller.handler('deleteBinding'))
   .all(commonMiddleware.methodNotAllowed(['PUT', 'DELETE']));

--- a/eventmesh/LockManager.js
+++ b/eventmesh/LockManager.js
@@ -102,7 +102,7 @@ class LockManager {
     opts.lockType = this._getLockType(opts.lockedResourceDetails.operation);
     opts.lockTTL = opts.lockTTL ? opts.lockTTL : Infinity;
     _.extend(opts, {
-      'lockTime': currentTime
+      'lockTime': opts.lockTime ? opts.lockTime : currentTime
     });
     logger.debug(`Attempting to acquire lock on resource with resourceId: ${resourceId} `);
     return eventmesh.apiServerClient.getResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, resourceId)

--- a/eventmesh/LockManager.js
+++ b/eventmesh/LockManager.js
@@ -45,7 +45,7 @@ class LockManager {
         return {
           isWriteLocked: false,
           lockDetails: undefined
-        }
+        };
       });
   }
 
@@ -128,7 +128,7 @@ class LockManager {
         }
       })
       .tap(() => logger.debug(`Successfully acquired lock on resource with resourceId: ${resourceId}`))
-      .catch(NotFound, err => {
+      .catch(NotFound, () => {
         const spec = {
           options: JSON.stringify(opts)
         };
@@ -145,7 +145,7 @@ class LockManager {
         return eventmesh.apiServerClient.createLock(CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, body)
           .tap(() => logger.debug(`Successfully acquired lock on resource with resourceId: ${resourceId} `));
       })
-      .catch(Conflict, err => {
+      .catch(Conflict, () => {
         return eventmesh.apiServerClient.getResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, resourceId)
           .then(resource => {
             console.log('Hi');

--- a/eventmesh/LockManager.js
+++ b/eventmesh/LockManager.js
@@ -148,7 +148,6 @@ class LockManager {
       .catch(Conflict, () => {
         return eventmesh.apiServerClient.getResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, resourceId)
           .then(resource => {
-            console.log('Hi');
             const resourceBody = resource.body;
             const currentlLockDetails = JSON.parse(resourceBody.spec.options);
             const currentLockTime = new Date(currentlLockDetails.lockTime);

--- a/test/test_broker/eventmesh.LockManager.spec.js
+++ b/test/test_broker/eventmesh.LockManager.spec.js
@@ -135,7 +135,7 @@ describe('eventmesh', () => {
         return lockManager.checkWriteLockStatus('lockId1')
           .then(result => {
             expect(result.isWriteLocked).to.eql(true);
-            expect(result.lockDetails.lockType).to.eql("WRITE");
+            expect(result.lockDetails.lockType).to.eql('WRITE');
             expect(result.lockDetails.lockedResourceDetails).to.eql(lockoptions.lockId1.lockedResourceDetails);
             expect(getLockResourceOptionsSpy.callCount).to.equal(1);
             expect(getLockResourceOptionsSpy.firstCall.args[0]).to.eql(CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS);

--- a/test/test_broker/eventmesh.LockManager.spec.js
+++ b/test/test_broker/eventmesh.LockManager.spec.js
@@ -31,7 +31,7 @@ const lockoptions = {
   lockId1: buildLockResourceOptions(CONST.ETCD.LOCK_TYPE.WRITE),
   lockId2: buildLockResourceOptions(CONST.ETCD.LOCK_TYPE.WRITE, undefined, 1),
   lockId3: buildLockResourceOptions(CONST.ETCD.LOCK_TYPE.READ),
-  conflictresource: buildLockResourceOptions(CONST.ETCD.LOCK_TYPE.WRITE, undefined, 1)
+  conflictresource: buildLockResourceOptions(CONST.ETCD.LOCK_TYPE.WRITE)
 };
 const lock = {
   lockId1: {
@@ -239,7 +239,7 @@ describe('eventmesh', () => {
             expect(getResourceSpy.firstCall.args[2]).to.eql('lockId5');
           });
       });
-      it.only('should throw a conflict error if api server gives incorrect response', () => {
+      it('should throw a conflict error if api server gives incorrect response', () => {
         const lockManager = new apiServerLockManager();
         return lockManager.lock('conflictresource', lockoptions.conflictresource)
           .catch((err) => {


### PR DESCRIPTION
- middleware validateRequest is now broken into two method
  - One for all request and one for create only
  - Renamed isWriteLocked of middleware
  - Showing the lock details in the error description

- Renamed to checkWriteLockStatus in LockManager
  - Passing additional details from this method
  - Using Multicatch
  - Passing more info in case of a lock conflict
  - Adding testcase for the conflict case