### PR TITLE
Allow not staggering scheduled updates through CF parameter

### DIFF
--- a/broker/lib/controllers/ServiceFabrikApiController.js
+++ b/broker/lib/controllers/ServiceFabrikApiController.js
@@ -838,9 +838,10 @@ class ServiceFabrikApiController extends FabrikBaseController {
         .chain({
           instance_id: req.params.instance_id,
           instance_name: req.entity.name,
-          deployment_name: deploymentName
+          deployment_name: deploymentName,
+          run_immediately: (req.body.runImmediately === 'true' ? true : false)
         })
-        .assign(_.omit(req.body, 'repeatInterval'))
+        .assign(_.omit(req.body, ['repeatInterval', 'runImmediately']))
         .value()
       )
       .then((jobData) => ScheduleManager

--- a/broker/lib/fabrik/DBManager.js
+++ b/broker/lib/fabrik/DBManager.js
@@ -177,10 +177,14 @@ class DBManager {
       const operation = createIfNotPresent ? 'Create' : 'Update';
       if (createIfNotPresent) {
         logger.warn('createIfNotPresent flag is set to true. Ensure this is happening only in the first deployment.');
+        // MongoDB update operations should go through to BOSH without any rate limits applied by broker
         params = {
           context: context,
           organization_guid: CONST.FABRIK_INTERNAL_MONGO_DB.ORG_ID,
           space_guid: CONST.FABRIK_INTERNAL_MONGO_DB.SPACE_ID,
+          parameters: {
+            _runImmediately: true
+          }
         };
       } else {
         params = {
@@ -189,6 +193,9 @@ class DBManager {
             plan_id: config.mongodb.provision.plan_id,
             organization_id: CONST.FABRIK_INTERNAL_MONGO_DB.ORG_ID,
             space_id: CONST.FABRIK_INTERNAL_MONGO_DB.SPACE_ID
+          },
+          parameters: {
+            _runImmediately: true
           }
         };
         logger.info('Updating DB Deployment...');
@@ -199,8 +206,6 @@ class DBManager {
       }
       params.network_index = config.mongodb.provision.network_index;
       params.skip_addons = true;
-      // MongoDB update operations should go through to BOSH without any rate limits applied by broker
-      params._runImmediately = true;
       return this.directorManager.createOrUpdateDeployment(config.mongodb.deployment_name, params)
         .tap(out => {
           const taskId = out.task_id;

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -175,6 +175,15 @@ class DirectorInstance extends BaseInstance {
     const token = _.get(params.parameters, 'service-fabrik-operation', null);
     if (token) {
       _.unset(params.parameters, 'service-fabrik-operation');
+      /**
+       * The _runImmediately parameter can be set via Cloud Foundry parameters (OSB API) or via the Fabrik framework internally
+       * to control the update of components like SF-MongoDB. The CF parameter model will be set by the integration tests to
+       * ensure that no staggering is done for the test instances
+       */
+      const queueNow = _.get(params.parameters, '_runImmediately', false);
+      const queueNowInternal = _.get(params, '_runImmediately', false);
+      _.unset(params.parameters, '_runImmediately');
+      _.set(params, '_runImmediately', queueNow || queueNowInternal);
       _.set(params, 'scheduled', true);
     }
     return this
@@ -233,6 +242,15 @@ class DirectorInstance extends BaseInstance {
     const token = _.get(params.parameters, 'service-fabrik-operation', null);
     if (token) {
       _.unset(params.parameters, 'service-fabrik-operation');
+      /**
+       * The _runImmediately parameter can be set via Cloud Foundry parameters (OSB API) or via the Fabrik framework internally
+       * to control the update of components like SF-MongoDB. The CF parameter model will be set by the integration tests to
+       * ensure that no staggering is done for the test instances
+       */
+      const queueNow = _.get(params.parameters, '_runImmediately', false);
+      const queueNowInternal = _.get(params, '_runImmediately', false);
+      _.unset(params.parameters, '_runImmediately');
+      _.set(params, '_runImmediately', queueNow || queueNowInternal);
       _.set(params, 'scheduled', true);
     }
     return this

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -175,15 +175,6 @@ class DirectorInstance extends BaseInstance {
     const token = _.get(params.parameters, 'service-fabrik-operation', null);
     if (token) {
       _.unset(params.parameters, 'service-fabrik-operation');
-      /**
-       * The _runImmediately parameter can be set via Cloud Foundry parameters (OSB API) or via the Fabrik framework internally
-       * to control the update of components like SF-MongoDB. The CF parameter model will be set by the integration tests to
-       * ensure that no staggering is done for the test instances
-       */
-      const queueNow = _.get(params.parameters, '_runImmediately', false);
-      const queueNowInternal = _.get(params, '_runImmediately', false);
-      _.unset(params.parameters, '_runImmediately');
-      _.set(params, '_runImmediately', queueNow || queueNowInternal);
       _.set(params, 'scheduled', true);
     }
     return this
@@ -242,15 +233,6 @@ class DirectorInstance extends BaseInstance {
     const token = _.get(params.parameters, 'service-fabrik-operation', null);
     if (token) {
       _.unset(params.parameters, 'service-fabrik-operation');
-      /**
-       * The _runImmediately parameter can be set via Cloud Foundry parameters (OSB API) or via the Fabrik framework internally
-       * to control the update of components like SF-MongoDB. The CF parameter model will be set by the integration tests to
-       * ensure that no staggering is done for the test instances
-       */
-      const queueNow = _.get(params.parameters, '_runImmediately', false);
-      const queueNowInternal = _.get(params, '_runImmediately', false);
-      _.unset(params.parameters, '_runImmediately');
-      _.set(params, '_runImmediately', queueNow || queueNowInternal);
       _.set(params, 'scheduled', true);
     }
     return this

--- a/broker/lib/fabrik/DirectorManager.js
+++ b/broker/lib/fabrik/DirectorManager.js
@@ -316,9 +316,9 @@ class DirectorManager extends BaseManager {
     const previousValues = _.get(params, 'previous_values');
     const action = _.isPlainObject(previousValues) ? CONST.OPERATION_TYPE.UPDATE : CONST.OPERATION_TYPE.CREATE;
     const scheduled = _.get(params, 'scheduled') || false;
-    const runImmediately = _.get(params, '_runImmediately') || false;
+    const runImmediately = _.get(params, 'parameters._runImmediately') || false;
     _.omit(params, 'scheduled');
-    _.omit(params, '_runImmediately');
+    _.omit(params, 'parameters._runImmediately');
 
     if (!config.enable_bosh_rate_limit || runImmediately) {
       return this._createOrUpdateDeployment(deploymentName, params, args, scheduled)

--- a/broker/lib/fabrik/ServiceFabrikOperation.js
+++ b/broker/lib/fabrik/ServiceFabrikOperation.js
@@ -41,6 +41,7 @@ class ServiceFabrikOperation {
     this.useremail = opts.useremail;
     this.arguments = opts.arguments || {};
     this.isOperationSync = opts.isOperationSync ? true : false;
+    this.runImmediately = opts.runImmediately;
     if (opts.instance_id) {
       this.instanceId = opts.instance_id;
     } else if (opts.deployment) {
@@ -69,6 +70,9 @@ class ServiceFabrikOperation {
         'service-fabrik-operation': token
       }
     };
+    if (this.runImmediately) {
+      options.parameters._runImmediately = this.runImmediately;
+    }
     options.isOperationSync = this.isOperationSync;
     if (this.bearer) {
       options.auth = {

--- a/broker/lib/jobs/ServiceInstanceUpdateJob.js
+++ b/broker/lib/jobs/ServiceInstanceUpdateJob.js
@@ -89,7 +89,9 @@ class ServiceInstanceUpdateJob extends BaseJob {
           .updateDeployment(
             instanceDetails.deployment_name,
             diffResults.diff,
-            plan.service.force_update)
+            plan.service.force_update,
+            instanceDetails.run_immediately
+          )
           .then(result => {
             operationResponse.update_init = CONST.OPERATION.SUCCEEDED;
             operationResponse.update_operation_guid = result.guid;
@@ -142,7 +144,7 @@ class ServiceInstanceUpdateJob extends BaseJob {
       );
   }
 
-  static updateDeployment(deploymentName, diff, skipForbiddenCheck) {
+  static updateDeployment(deploymentName, diff, skipForbiddenCheck, runImmediately) {
     return Promise
       .try(() => {
         if (!skipForbiddenCheck) {
@@ -153,7 +155,8 @@ class ServiceInstanceUpdateJob extends BaseJob {
         .createOperation('update', {
           deployment: deploymentName,
           username: 'Auto_Update_Job',
-          arguments: {}
+          arguments: {},
+          runImmediately: runImmediately || false
         })
         .invoke())
       .then(result => ({

--- a/test/test_broker/acceptance/service-fabrik-admin.internal-db.lifecycle.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.internal-db.lifecycle.spec.js
@@ -33,11 +33,13 @@ describe('service-fabrik-admin', function () {
         actions: ['Blueprint', 'ReserveIps'],
         context: {
           params: {
-            '_runImmediately': true,
             context: {
               platform: 'service-fabrik',
               organization_guid: CONST.FABRIK_INTERNAL_MONGO_DB.ORG_ID,
               space_guid: CONST.FABRIK_INTERNAL_MONGO_DB.SPACE_ID
+            },
+            parameters: {
+              '_runImmediately': true,
             },
             network_index: config.mongodb.provision.network_index,
             skip_addons: true,

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -1757,6 +1757,31 @@ describe('service-fabrik-api-sf2.0', function () {
               mocks.verify();
             });
         });
+
+        it('should return 201 OK - when rate limiting against bosh is explicitly not required', function () {
+          mocks.uaa.tokenKey();
+          mocks.cloudController.getServiceInstance(instance_id, {
+            space_guid: space_guid,
+            service_plan_guid: plan_guid
+          });
+          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.director.getDeployments();
+          return chai.request(apps.external)
+            .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
+            .set('Authorization', authHeader)
+            .send({
+              type: 'online',
+              repeatInterval: '*/1 * * * *',
+              runImmediately: 'true'
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(201);
+              expect(res.body).to.eql(getJob(instance_id, CONST.JOB.SERVICE_INSTANCE_UPDATE).value());
+              mocks.verify();
+            });
+        });
       });
       describe('#GetUpdateSchedule', function () {
         it('should return 200 OK', function () {

--- a/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
@@ -1862,6 +1862,30 @@ describe('service-fabrik-api', function () {
               mocks.verify();
             });
         });
+        it('should return 201 OK - when rate limiting against bosh is explicitly not required', function () {
+          mocks.uaa.tokenKey();
+          mocks.cloudController.getServiceInstance(instance_id, {
+            space_guid: space_guid,
+            service_plan_guid: plan_guid
+          });
+          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.director.getDeployments();
+          return chai.request(apps.external)
+            .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
+            .set('Authorization', authHeader)
+            .send({
+              type: 'online',
+              repeatInterval: '*/1 * * * *',
+              runImmediately: 'true'
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(201);
+              expect(res.body).to.eql(getJob(instance_id, CONST.JOB.SERVICE_INSTANCE_UPDATE).value());
+              mocks.verify();
+            });
+        });
       });
       describe('#GetUpdateSchedule', function () {
         it('should return 200 OK', function () {

--- a/test/test_broker/fabrik.DirectorInstance.spec.js
+++ b/test/test_broker/fabrik.DirectorInstance.spec.js
@@ -7,7 +7,6 @@ const _ = require('lodash');
 const guid = 'guid';
 const task_id = 'task_id';
 const params = {
-  _runImmediately: false,
   parameters: {
     key: 'v1'
   },

--- a/test/test_broker/fabrik.DirectorManager.spec.js
+++ b/test/test_broker/fabrik.DirectorManager.spec.js
@@ -388,7 +388,9 @@ describe('fabrik', function () {
       describe('mongodb operation', () => {
         let params = {
           scheduled: true,
-          '_runImmediately': true
+          parameters: {
+            '_runImmediately': true
+          }
         };
         it('should proceed with mongo update without rate limiting', () => {
           currentTasksSpy.returns(Promise.resolve({


### PR DESCRIPTION
- This should allow scheduled updates run as part of integration/scheduled tests to go through successfully without staggering against BOSH
- Use parameters object for runImmediately flag
- Incorporate review comments
- Add test spec for SF 2.0 acceptance
- Modify test specs to consider flag in inner parameters