### PR TITLE
Forward prebind action to the agent

### DIFF
--- a/broker/lib/fabrik/DirectorManager.js
+++ b/broker/lib/fabrik/DirectorManager.js
@@ -584,13 +584,14 @@ class DirectorManager extends BaseManager {
       'id': id
     };
     return this.executeActions(CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND, actionContext)
-      .then(() =>
+      .then((preUnbindResponse) =>
         Promise
         .all([
+          Promise.resolve(preUnbindResponse),
           this.getDeploymentIps(deploymentName),
           this.getBindingProperty(deploymentName, id)
         ]))
-      .spread((ips, binding) => this.agent.deleteCredentials(ips, binding.credentials))
+      .spread((preUnbindResponse, ips, binding) => this.agent.deleteCredentials(ips, binding.credentials, preUnbindResponse))
       .then(() => this.deleteBindingProperty(deploymentName, id))
       .tap(() => logger.info('+-> Deleted service binding'))
       .catch(err => {

--- a/broker/lib/fabrik/DirectorManager.js
+++ b/broker/lib/fabrik/DirectorManager.js
@@ -559,8 +559,12 @@ class DirectorManager extends BaseManager {
     };
     _.assign(actionContext, binding);
     return this.executeActions(CONST.SERVICE_LIFE_CYCLE.PRE_BIND, actionContext)
-      .then(() => this.getDeploymentIps(deploymentName))
-      .then(ips => this.agent.createCredentials(ips, binding.parameters))
+      .then((preBindResponse) =>
+        Promise.all([
+          this.getDeploymentIps(deploymentName),
+          Promise.resolve(preBindResponse)
+      ]))
+      .spread((ips, preBindResponse) => this.agent.createCredentials(ips, binding.parameters, preBindResponse))
       .tap(credentials => this.createBindingProperty(deploymentName, binding.id, _.set(binding, 'credentials', credentials)))
       .tap(() => {
         const bindCreds = _.cloneDeep(binding.credentials);

--- a/data-access-layer/service-agent/Agent.js
+++ b/data-access-layer/service-agent/Agent.js
@@ -190,7 +190,7 @@ class Agent extends HttpClient {
   createCredentials(ips, parameters, preBindResponse) {
     const body = {
       parameters: parameters,
-      preBindHook: preBindResponse
+      actions: preBindResponse
     };
     return this
       .getHost(ips, 'credentials')
@@ -200,7 +200,7 @@ class Agent extends HttpClient {
   deleteCredentials(ips, credentials, preUnbindResponse) {
     const body = {
       credentials: credentials,
-      preUnbindHook: preUnbindResponse
+      actions: preUnbindResponse
     };
     return this
       .getHost(ips, 'credentials')

--- a/data-access-layer/service-agent/Agent.js
+++ b/data-access-layer/service-agent/Agent.js
@@ -187,9 +187,10 @@ class Agent extends HttpClient {
       .then(ip => this.post(ip, 'lifecycle/preupdate', context, 200, agentCredsBeforeUpdate));
   }
 
-  createCredentials(ips, parameters) {
+  createCredentials(ips, parameters, preBindResponse) {
     const body = {
-      parameters: parameters
+      parameters: parameters,
+      preBindHook: preBindResponse
     };
     return this
       .getHost(ips, 'credentials')

--- a/data-access-layer/service-agent/Agent.js
+++ b/data-access-layer/service-agent/Agent.js
@@ -197,9 +197,10 @@ class Agent extends HttpClient {
       .then(ip => this.post(ip, 'credentials/create', body, 200));
   }
 
-  deleteCredentials(ips, credentials) {
+  deleteCredentials(ips, credentials, preUnbindResponse) {
     const body = {
-      credentials: credentials
+      credentials: credentials,
+      preUnbindHook: preUnbindResponse
     };
     return this
       .getHost(ips, 'credentials')

--- a/test/test_broker/fabrik.Agent.spec.js
+++ b/test/test_broker/fabrik.Agent.spec.js
@@ -331,12 +331,12 @@ describe('fabrik', function () {
         pathname = 'credentials/create';
         expectedStatus = 200;
         _.set(body, 'parameters', parameters);
-        _.set(body, 'preBindHook', preBindResponse);
+        _.set(body, 'actions', preBindResponse);
       });
 
       after(function () {
         _.unset(body, 'parameters');
-        _.unset(body, 'preBindHook');
+        _.unset(body, 'actions');
       });
 
       it('returns a JSON object', function () {
@@ -354,12 +354,12 @@ describe('fabrik', function () {
         pathname = 'credentials/delete';
         expectedStatus = 200;
         _.set(body, 'credentials', credentials);
-        _.set(body, 'preUnbindHook', preUnbindResponse);
+        _.set(body, 'actions', preUnbindResponse);
       });
 
       after(function () {
         _.unset(body, 'credentials');
-        _.unset(body, 'preUnbindHook');
+        _.unset(body, 'actions');
       });
 
       it('returns a JSON object', function () {

--- a/test/test_broker/fabrik.Agent.spec.js
+++ b/test/test_broker/fabrik.Agent.spec.js
@@ -24,6 +24,8 @@ describe('fabrik', function () {
     const parameters = {
       foo: 'bar'
     };
+    const preBindResponse = {};
+    const preUnbindResponse = {};
     const credentials = {
       password: 'secret'
     };
@@ -329,15 +331,17 @@ describe('fabrik', function () {
         pathname = 'credentials/create';
         expectedStatus = 200;
         _.set(body, 'parameters', parameters);
+        _.set(body, 'preBindHook', preBindResponse);
       });
 
       after(function () {
         _.unset(body, 'parameters');
+        _.unset(body, 'preBindHook');
       });
 
       it('returns a JSON object', function () {
         return agent
-          .createCredentials(ips, parameters)
+          .createCredentials(ips, parameters, preBindResponse)
           .then(body => {
             expect(body).to.equal(response.body);
             expect(requestStub).to.have.been.calledTwice;
@@ -350,15 +354,17 @@ describe('fabrik', function () {
         pathname = 'credentials/delete';
         expectedStatus = 200;
         _.set(body, 'credentials', credentials);
+        _.set(body, 'preUnbindHook', preUnbindResponse);
       });
 
       after(function () {
         _.unset(body, 'credentials');
+        _.unset(body, 'preUnbindHook');
       });
 
       it('returns a JSON object', function () {
         return agent
-          .deleteCredentials(ips, credentials)
+          .deleteCredentials(ips, credentials, preUnbindResponse)
           .then(body => {
             expect(body).to.equal(response.body);
             expect(requestStub).to.have.been.calledTwice;


### PR DESCRIPTION
This pull request adds a forwarding of the action result for the prebind and preunbind actions.
So the agent has an additional body parameter "preUnbindHook" to consume the result of each hook.


Semantically I also changed that the `this.executeActions(CONST.SERVICE_LIFE_CYCLE.PRE_BIND, actionContext)` and `this.executeActions(CONST.SERVICE_LIFE_CYCLE.PRE_BIND, actionContext)` are executed parallel, because the does not seem to have a dependency on each other. I can also revert that change.