### PR TITLE
Transition sfv2

### DIFF
--- a/api-controllers/ServiceFabrikApiController.js
+++ b/api-controllers/ServiceFabrikApiController.js
@@ -340,7 +340,7 @@ class ServiceFabrikApiController extends FabrikBaseController {
       });
   }
 
-  getPlanIdFromInstanceId(instance_id){
+  getPlanIdFromInstanceId(instance_id) {
     return cf
       .cloudController.findServicePlanByInstanceId(instance_id)
       .then(planDetails => planDetails.entity.unique_id);
@@ -428,15 +428,15 @@ class ServiceFabrikApiController extends FabrikBaseController {
         })
       )
       .catch(NotFound, (err) => {
-        logger.info('Backup metadata not found in apiserver, checking blobstore ', err.message);
+        logger.info('Backup metadata not found in apiserver, checking blobstore. Error message:', err.message);
         const tenantId = _.get(req, 'body.space_guid') ||
           _.get(req, 'query.space_guid') ||
           _.get(req, 'query.tenant_id') ||
           _.get(req, 'body.context.space_guid') ||
           _.get(req, 'body.context.namespace');
         return this.getPlanIdFromInstanceId(req.params.instance_id)
-          .then( plan_id => BackupService.createService(catalog.getPlan(plan_id)))
-          .then(backupService => backupService.getLastBackup(tenant_id, req.params.instance_id ));
+          .then(plan_id => BackupService.createService(catalog.getPlan(plan_id)))
+          .then(backupService => backupService.getLastBackup(tenantId, req.params.instance_id));
       })
       .then(result => res
         .status(CONST.HTTP_STATUS_CODE.OK)
@@ -671,15 +671,15 @@ class ServiceFabrikApiController extends FabrikBaseController {
         value: options
       })
       .catch(NotFound, (err) => {
-        logger.info('Backup metadata not found in apiserver, checking blobstore ', err.message);
+        logger.info('Backup metadata not found in apiserver, checking blobstore. Error message:', err.message);
         const tenantId = _.get(req, 'body.space_guid') ||
           _.get(req, 'query.space_guid') ||
           _.get(req, 'query.tenant_id') ||
           _.get(req, 'body.context.space_guid') ||
           _.get(req, 'body.context.namespace');
         return this.getPlanIdFromInstanceId(req.params.instance_id)
-          .then( plan_id => BackupService.createService(catalog.getPlan(plan_id)))
-          .then(backupService => backupService.deleteBackup(tenant_id, req.params.instance_id ));
+          .then(plan_id => BackupService.createService(catalog.getPlan(plan_id)))
+          .then(backupService => backupService.deleteBackup(tenantId, req.params.instance_id));
       })
       .then(() =>
         eventmesh.apiServerClient.updateOperationState({

--- a/common/constants.js
+++ b/common/constants.js
@@ -105,7 +105,6 @@ module.exports = Object.freeze({
     SHUTDOWN_WAIT_TIME: 5000
   },
   BACKUP: {
-    BACKUP_START_TIMEOUT_IN_SECS: 60, //SECONDS
     TYPE: {
       ONLINE: 'online'
     },
@@ -227,6 +226,7 @@ module.exports = Object.freeze({
     }
   },
   APISERVER: {
+    OPERATION_TIMEOUT_IN_SECS: 60,
     WATCHER_REFRESH_INTERVAL: 1200000, // in ms ( 20 minutes )
     PORT: 9443,
     VERSION: '1.9',

--- a/common/constants.js
+++ b/common/constants.js
@@ -105,7 +105,7 @@ module.exports = Object.freeze({
     SHUTDOWN_WAIT_TIME: 5000
   },
   BACKUP: {
-    BACKUP_START_TIMEOUT: 60, //SECONDS
+    BACKUP_START_TIMEOUT_IN_SECS: 60, //SECONDS
     TYPE: {
       ONLINE: 'online'
     },

--- a/common/constants.js
+++ b/common/constants.js
@@ -105,7 +105,7 @@ module.exports = Object.freeze({
     SHUTDOWN_WAIT_TIME: 5000
   },
   BACKUP: {
-    BACKUP_START_TIMEOUT: 30, //SECONDS
+    BACKUP_START_TIMEOUT: 60, //SECONDS
     TYPE: {
       ONLINE: 'online'
     },

--- a/common/constants.js
+++ b/common/constants.js
@@ -105,7 +105,7 @@ module.exports = Object.freeze({
     SHUTDOWN_WAIT_TIME: 5000
   },
   BACKUP: {
-    BACKUP_START_TIMEOUT: 15, //SECONDS
+    BACKUP_START_TIMEOUT: 30, //SECONDS
     TYPE: {
       ONLINE: 'online'
     },

--- a/data-access-layer/cf/CloudControllerClient.js
+++ b/data-access-layer/cf/CloudControllerClient.js
@@ -126,6 +126,11 @@ class CloudControllerClient extends HttpClient {
     return this.createServicePlanStream(options).all();
   }
 
+  getPlanIdFromInstanceId(instance_id) {
+    return this.findServicePlanByInstanceId(instance_id)
+      .then(planDetails => planDetails.entity.unique_id);
+  }
+
   findServicePlanByInstanceId(instance_id) {
     return this
       .getServicePlans(`service_instance_guid:${instance_id}`)

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -130,6 +130,15 @@ class ApiServerClient {
         }));
   }
 
+  patchResourceStatus(resourceGroup, resourceType, resourceId, statusDelta){
+    return Promise.try(() => this.init())
+      .then(() => apiserver.apis[`${resourceGroup}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
+        .namespaces(CONST.APISERVER.NAMESPACE)[resourceType](resourceId)
+        .status.patch({
+          body: statusDelta
+        }));
+  }
+
   deleteLock(resourceType, resourceId) {
     return this.deleteResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, resourceType, resourceId)
       .catch(err => {
@@ -305,6 +314,25 @@ class ApiServerClient {
         .status.patch({
           body: patchedResource
         }))
+      .catch(err => {
+        return buildErrors(err);
+      });
+  }
+
+  /**
+   * @description Function to Update the error field
+   * @param {string} opts.operationName - Name of operation
+   * @param {string} opts.operationType - Type of operation
+   * @param {string} opts.operationId - Unique id of operation
+   * @param {Object} opts.error - Value to set as error
+   */
+  updateOperationError(opts){
+    const change = {
+      'status': {
+        'error': JSON.stringify(opts.error)
+      }
+    };
+    return this.patchResourceStatus(opts.operationName, opts.operationType, opts.operationId, change)
       .catch(err => {
         return buildErrors(err);
       });

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -130,7 +130,7 @@ class ApiServerClient {
         }));
   }
 
-  patchResourceStatus(resourceGroup, resourceType, resourceId, statusDelta){
+  patchResourceStatus(resourceGroup, resourceType, resourceId, statusDelta) {
     return Promise.try(() => this.init())
       .then(() => apiserver.apis[`${resourceGroup}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
         .namespaces(CONST.APISERVER.NAMESPACE)[resourceType](resourceId)
@@ -326,7 +326,7 @@ class ApiServerClient {
    * @param {string} opts.operationId - Unique id of operation
    * @param {Object} opts.error - Value to set as error
    */
-  updateOperationError(opts){
+  updateOperationError(opts) {
     const change = {
       'status': {
         'error': JSON.stringify(opts.error)

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -92,7 +92,7 @@ class ApiServerClient {
       .then(state => {
         const duration = (new Date() - opts.started_at) / 1000;
         logger.info(`Polling for ${opts.start_state} duration: ${duration} `);
-        if (duration > CONST.BACKUP.BACKUP_START_TIMEOUT_IN_SECS) {
+        if (duration > CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS) {
           logger.error(`Backup with guid ${opts.operationId} not picked up from the queue`);
           throw new Timeout(`Backup with guid ${opts.operationId} not picked up from the queue`);
         }

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -248,7 +248,7 @@ class ApiServerClient {
     logger.info('Patching Operation with :', opts);
     return this.getOperationResponse(opts)
       .then(res => {
-        logger.info(`Patching ${res} with ${opts.value}`);
+        logger.info(`Patching ${JSON.stringify(res)} with ${JSON.stringify(opts.value)}`);
         opts.value = _.merge(res, opts.value);
         return this.updateOperationResponse(opts);
       });
@@ -390,7 +390,7 @@ class ApiServerClient {
   patchOperationOptions(opts) {
     return this.getOperationOptions(opts)
       .then(res => {
-        logger.info(`Patching ${res} with ${opts.value}`);
+        logger.info(`Patching ${JSON.stringify(res)} with ${JSON.stringify(opts.value)}`);
         opts.value = _.merge(res, opts.value);
         return this.updateOperationOptions(opts);
       });

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -249,23 +249,13 @@ class BackupService extends BaseDirectorService {
       });
   }
 
-  getLastBackup(tenant_id, instance_guid, noCache) {
+  getLastBackup(tenant_id, instance_guid) {
     return this.backupStore
       .getBackupFile({
         tenant_id: tenant_id,
         service_id: this.plan.service.id,
         plan_id: this.plan.id,
         instance_guid: instance_guid
-      })
-      .then(metadata => {
-        switch (metadata.state) {
-        case 'processing':
-          return noCache ? this.agent
-            .getBackupLastOperation(metadata.agent_ip)
-            .then(data => _.assign(metadata, _.pick(data, 'state', 'stage'))) : metadata;
-        default:
-          return metadata;
-        }
       });
   }
 

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -277,6 +277,7 @@ class BackupService extends BaseDirectorService {
       plan_id: this.plan.id,
       tenant_id: opts.context ? this.getTenantGuid(opts.context) : opts.tenant_id
     }, opts);
+
     function isFinished(state) {
       return _.includes(['succeeded', 'failed', 'aborted'], state);
     }

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -277,7 +277,6 @@ class BackupService extends BaseDirectorService {
       plan_id: this.plan.id,
       tenant_id: opts.context ? this.getTenantGuid(opts.context) : opts.tenant_id
     }, opts);
-
     function isFinished(state) {
       return _.includes(['succeeded', 'failed', 'aborted'], state);
     }

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -249,6 +249,26 @@ class BackupService extends BaseDirectorService {
       });
   }
 
+  getLastBackup(tenant_id, instance_guid, noCache) {
+    return this.backupStore
+      .getBackupFile({
+        tenant_id: tenant_id,
+        service_id: this.plan.service.id,
+        plan_id: this.plan.id,
+        instance_guid: instance_guid
+      })
+      .then(metadata => {
+        switch (metadata.state) {
+        case 'processing':
+          return noCache ? this.agent
+            .getBackupLastOperation(metadata.agent_ip)
+            .then(data => _.assign(metadata, _.pick(data, 'state', 'stage'))) : metadata;
+        default:
+          return metadata;
+        }
+      });
+  }
+
   getBackupOperationState(opts) {
     logger.debug('Getting Backup operation State for:', opts);
     const agent_ip = opts.agent_ip;

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
@@ -14,8 +14,8 @@ function disableServiceFabrikV2() {
   config.enable_service_fabrik_v2 = false;
 }
 
-describe('service-fabrik-api', function () {
-  describe('backups-v2', function () {
+describe('service-fabrik-api-2.0', function () {
+  describe('backups', function () {
     /* jshint expr:true */
     describe('director', function () {
       const base_url = '/api/v1';
@@ -298,11 +298,13 @@ describe('service-fabrik-api', function () {
               mocks.verify();
             });
         });
-        it('should return 410 Gone', function () {
+        it('should return 410 Gone - when not found in both blobstore and apiserver', function () {
+          const backupPrefix = `${space_guid}/backup`;
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.apiServerEventMesh.nockGetResource('backup', 'defaultbackup',
             '01234567-0000-4000-9000-0123456789ab', {}, 1, 404);
+          mocks.cloudProvider.list(container, backupPrefix, []);
           return chai.request(app)
             .delete(`${base_url}/backups/01234567-0000-4000-9000-0123456789ab`)
             .query({

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -644,11 +644,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 200 Ok - should check blobstore if metadata is not found in apiserver', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.cloudController.findServicePlan(instance_id, plan_id, 2);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id, {
             metadata: {
@@ -672,7 +668,7 @@ describe('service-fabrik-api-sf2.0', function () {
             .get(`${base_url}/service_instances/${instance_id}/backup`)
             .set('Authorization', authHeader)
             .query({
-              plan_id: plan_id,
+              space_guid: space_guid,
             })
             .catch(err => err.response)
             .then(res => {
@@ -683,12 +679,16 @@ describe('service-fabrik-api-sf2.0', function () {
         });
 
         it('should return 404 if Not Found in blobstore and apiserver', function () {
+          const backupPrefix = `${space_guid}/backup/${service_id}.${instance_id}`;
+          const backupFilename = `${space_guid}/backup/${service_id}.${instance_id}.${backup_guid}.${started_at}.json`;
+          const pathname = `/${container}/${backupFilename}`;
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.getServiceInstance(instance_id, {
+          //   space_guid: space_guid,
+          //   service_plan_guid: plan_guid
+          // });
+          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id, {
             metadata: {
@@ -702,16 +702,13 @@ describe('service-fabrik-api-sf2.0', function () {
               response: JSON.stringify(data)
             }
           }, 1, 404);
-          const backupPrefix = `${space_guid}/backup/${service_id}.${instance_id}`;
-          const backupFilename = `${space_guid}/backup/${service_id}.${instance_id}.${backup_guid}.${started_at}.json`;
           mocks.cloudProvider.list(container, backupPrefix, [backupFilename]);
-          const pathname = `/${container}/${backupFilename}`;
           mocks.cloudProvider.download(pathname, new NotFound('not found'));
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/backup`)
             .set('Authorization', authHeader)
             .query({
-              plan_id: plan_id,
+              space_guid: space_guid,
             })
             .catch(err => err.response)
             .then(res => {

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -416,6 +416,47 @@ describe('eventmesh', () => {
       });
     });
 
+    describe('updateOperationError', () => {
+      const opts = {
+        resourceId: 'fakeResourceId',
+        operationName: 'backup',
+        operationType: 'defaultbackup',
+        operationId: 'fakeOperationId',
+        error: {
+          key: 'value'
+        }
+      };
+      const payload = {
+        status: {
+          error: JSON.stringify(opts.error),
+        }
+      };
+      const response = _.assign({
+        status: {
+          error: JSON.stringify(opts.error)
+        }
+      }, sampleBackupResource);
+      it('patches the operation error', done => {
+        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', response, payload);
+        apiserver.updateOperationError(opts)
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql(response);
+            done();
+            verify();
+          })
+          .catch(done);
+      });
+      it('throws error if api call is errored', done => {
+        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', response, payload, 409);
+        return apiserver.updateOperationError(opts)
+          .catch(err => {
+            expect(err).to.have.status(409);
+            done();
+          });
+      });
+    })
+
     describe('updateOperationResponse', () => {
       const opts = {
         resourceId: 'd1',

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -455,7 +455,7 @@ describe('eventmesh', () => {
             done();
           });
       });
-    })
+    });
 
     describe('updateOperationResponse', () => {
       const opts = {

--- a/test/test_broker/managers.BackupService.spec.js
+++ b/test/test_broker/managers.BackupService.spec.js
@@ -88,50 +88,52 @@ describe('managers', function () {
       getFileStub.restore();
     });
 
-    it('Should start backup successfully', function () {
-      const context = {
-        platform: 'cloudfoundry',
-        organization_guid: organization_guid,
-        space_guid: space_guid
-      };
-      const opts = {
-        guid: backup_guid,
-        deployment: deployment_name,
-        instance_guid: instance_id,
-        plan_id: plan_id,
-        service_id: service_id,
-        context: context
-      };
-      // const type = 'online';
-      mocks.director.getDeploymentVms(deployment_name);
-      mocks.director.getDeploymentInstances(deployment_name);
-      mocks.agent.getInfo();
-      mocks.agent.startBackup();
-      mocks.apiServerEventMesh.nockPatchResourceRegex('backup', 'defaultbackup', {
-        status: {
-          state: 'in_progress',
-          response: {}
-        }
-      }, 1, body => {
-        expect(body.status.state).to.eql('in_progress');
-        const resp = JSON.parse(body.status.response);
-        expect(resp.service_id).to.eql(service_id);
-        expect(resp.plan_id).to.eql(plan_id);
-        expect(resp.instance_guid).to.eql(instance_id);
-        expect(resp.operation).to.eql('backup');
-        expect(resp.type).to.eql('online');
-        expect(resp.backup_guid).to.eql(backup_guid);
-        expect(resp.trigger).to.eql('on-demand');
-        expect(resp.state).to.eql('processing');
-        expect(resp.tenant_id).to.eql(space_guid);
-        return true;
-      });
-      return manager.startBackup(opts)
-        .then(() => {
-          expect(scheduleStub.callCount).to.eql(1);
-          mocks.verify();
+    describe('#startBackup', function () {
+      it('Should start backup successfully', function () {
+        const context = {
+          platform: 'cloudfoundry',
+          organization_guid: organization_guid,
+          space_guid: space_guid
+        };
+        const opts = {
+          guid: backup_guid,
+          deployment: deployment_name,
+          instance_guid: instance_id,
+          plan_id: plan_id,
+          service_id: service_id,
+          context: context
+        };
+        // const type = 'online';
+        mocks.director.getDeploymentVms(deployment_name);
+        mocks.director.getDeploymentInstances(deployment_name);
+        mocks.agent.getInfo();
+        mocks.agent.startBackup();
+        mocks.apiServerEventMesh.nockPatchResourceRegex('backup', 'defaultbackup', {
+          status: {
+            state: 'in_progress',
+            response: {}
+          }
+        }, 1, body => {
+          expect(body.status.state).to.eql('in_progress');
+          const resp = JSON.parse(body.status.response);
+          expect(resp.service_id).to.eql(service_id);
+          expect(resp.plan_id).to.eql(plan_id);
+          expect(resp.instance_guid).to.eql(instance_id);
+          expect(resp.operation).to.eql('backup');
+          expect(resp.type).to.eql('online');
+          expect(resp.backup_guid).to.eql(backup_guid);
+          expect(resp.trigger).to.eql('on-demand');
+          expect(resp.state).to.eql('processing');
+          expect(resp.tenant_id).to.eql(space_guid);
+          return true;
         });
-    });
+        return manager.startBackup(opts)
+          .then(() => {
+            expect(scheduleStub.callCount).to.eql(1);
+            mocks.verify();
+          });
+      });
+    })
 
     describe('#backup-state', function () {
       const agent_ip = mocks.agent.ip;

--- a/test/test_broker/mocks/cloudController.js
+++ b/test/test_broker/mocks/cloudController.js
@@ -249,7 +249,7 @@ function getServicePlan(plan_guid, plan_unique_id, entity) {
     });
 }
 
-function findServicePlan(instance_id, plan_unique_id) {
+function findServicePlan(instance_id, plan_unique_id, times) {
   const entity = plan_unique_id ? {
     entity: {
       unique_id: plan_unique_id
@@ -257,6 +257,7 @@ function findServicePlan(instance_id, plan_unique_id) {
   } : '';
   return nock(cloudControllerUrl)
     .get(`/v2/service_plans`)
+    .times(times || 1)
     .query({
       q: `service_instance_guid:${instance_id}`
     })


### PR DESCRIPTION
Handle exiting backups when transitioning to sfv2.
- existing backup metadata is not available in apiserver
- check object store if the metadata is not available in apiserver
- For operations last backup and delete backup