### PR TITLE
Fix ongoing backup

### DIFF
--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -570,7 +570,7 @@ class ApiServerClient {
    * @param {string} opts.operationId - Unique id of operation
    */
   getOperationResponse(opts) {
-    logger.debug('Getting operation response with', opts)
+    logger.debug('Getting operation response with', opts);
     return Promise.try(() => this.init())
       .then(() => apiserver
         .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -608,13 +608,10 @@ class ApiServerClient {
    */
   updateOperationStatus(opts) {
     logger.info('Updating Operation Status with :', opts);
-    const patchedResource = {
-      'status': {
-        'state': opts.stateValue ? opts.stateValue : '',
-        'error': opts.error ? JSON.stringify(opts.error) : '',
-        'response': opts.response ? JSON.stringify(opts.response) : '',
-      }
-    };
+    const patchedResource = { 'status': { } };
+    if (opts.stateValue) { patchedResource.status.state = opts.stateValue; }
+    if (opts.error) { patchedResource.status.error = JSON.stringify(opts.error); }
+    if (opts.response){ patchedResource.status.response = JSON.stringify(opts.response); }
     return Promise.try(() => this.init())
       .then(() => apiserver
         .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -608,10 +608,18 @@ class ApiServerClient {
    */
   updateOperationStatus(opts) {
     logger.info('Updating Operation Status with :', opts);
-    const patchedResource = { 'status': { } };
-    if (opts.stateValue) { patchedResource.status.state = opts.stateValue; }
-    if (opts.error) { patchedResource.status.error = JSON.stringify(opts.error); }
-    if (opts.response){ patchedResource.status.response = JSON.stringify(opts.response); }
+    const patchedResource = {
+      'status': {}
+    };
+    if (opts.stateValue) {
+      patchedResource.status.state = opts.stateValue;
+    }
+    if (opts.error) {
+      patchedResource.status.error = JSON.stringify(opts.error);
+    }
+    if (opts.response) {
+      patchedResource.status.response = JSON.stringify(opts.response);
+    }
     return Promise.try(() => this.init())
       .then(() => apiserver
         .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -242,6 +242,7 @@ class ApiServerClient {
   }
 
   getResource(resourceGroup, resourceType, resourceId) {
+    logger.debug(`Getting resource ${resourceGroup}/${resourceType}/${resourceId}`);
     return Promise.try(() => this.init())
       .then(() => apiserver.apis[`${resourceGroup}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
         .namespaces(CONST.APISERVER.NAMESPACE)[resourceType](resourceId).get())
@@ -450,6 +451,7 @@ class ApiServerClient {
    * @param {Object} opts.value - Unique if of the last operation
    */
   updateLastOperation(opts) {
+    logger.debug(`Updating last operation on ${opts.resourceId} with ${opts.value}`);
     const patchedResource = {};
     patchedResource.metadata = {};
     patchedResource.metadata.labels = {};

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -570,6 +570,7 @@ class ApiServerClient {
    * @param {string} opts.operationId - Unique id of operation
    */
   getOperationResponse(opts) {
+    logger.debug('Getting operation response with', opts)
     return Promise.try(() => this.init())
       .then(() => apiserver
         .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -285,9 +285,9 @@ class BackupService extends BaseDirectorService {
                 logs: logs,
                 snapshotId: lastOperation.snapshotId
               })
+              .return(logs);
             )
-            .then(() => this.backupStore.getBackupFile(options))
-            .then(metadata => eventmesh.apiServerClient.updateOperationResponse({
+            .then(metadata => eventmesh.apiServerClient.patchOperationResponse({
               resourceId: options.instance_guid,
               operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
               operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -285,14 +285,16 @@ class BackupService extends BaseDirectorService {
                 logs: logs,
                 snapshotId: lastOperation.snapshotId
               })
-              .return(logs)
+              .return({
+                logs: logs
+              })
             )
-            .then(logs => eventmesh.apiServerClient.patchOperationResponse({
+            .then(logObj => eventmesh.apiServerClient.patchOperationResponse({
               resourceId: options.instance_guid,
               operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
               operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
               operationId: opts.backup_guid,
-              value: logs
+              value: logObj
             }));
         }
       });

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -286,15 +286,20 @@ class BackupService extends BaseDirectorService {
                 snapshotId: lastOperation.snapshotId
               })
               .return({
-                logs: logs
+                state: lastOperation.state,
+                logs: logs,
+                snapshotId: lastOperation.snapshotId,
+                finished_at: new Date(Date.now())
+                  .toISOString()
+                  .replace(/\.\d*/, '')
               })
             )
-            .then(logObj => eventmesh.apiServerClient.patchOperationResponse({
+            .then(patchObj => eventmesh.apiServerClient.patchOperationResponse({
               resourceId: options.instance_guid,
               operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
               operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
               operationId: opts.backup_guid,
-              value: logObj
+              value: patchObj
             }));
         }
       });

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -285,14 +285,14 @@ class BackupService extends BaseDirectorService {
                 logs: logs,
                 snapshotId: lastOperation.snapshotId
               })
-              .return(logs);
+              .return(logs)
             )
-            .then(metadata => eventmesh.apiServerClient.patchOperationResponse({
+            .then(logs => eventmesh.apiServerClient.patchOperationResponse({
               resourceId: options.instance_guid,
               operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
               operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-              operationId: metadata.backup_guid,
-              value: metadata
+              operationId: opts.backup_guid,
+              value: logs
             }));
         }
       });

--- a/test/test_broker/managers.BackupService.spec.js
+++ b/test/test_broker/managers.BackupService.spec.js
@@ -362,7 +362,7 @@ describe('managers', function () {
           expect(parsed.status).to.eql(403);
           expect(parsed.reason).to.eql('Forbidden');
           expect(parsed.message).to.eql(`Delete of scheduled backup not permitted within retention period of ${config.backup.retention_period_in_days} days`);
-          expect(body.status.response).to.eql('');
+          expect(body.status.response).to.eql(undefined);
           return true;
         });
         return manager.deleteBackup({

--- a/test/test_broker/managers.BackupService.spec.js
+++ b/test/test_broker/managers.BackupService.spec.js
@@ -15,7 +15,8 @@ describe('managers', function () {
     const backup_state = {
       state: 'succeeded',
       'stage': 'Backup complete',
-      updated_at: finishDate
+      updated_at: finishDate,
+      snapshotId: 'fakeSnapshotId'
     };
     const backup_logs = ['Starting Backup ... ', 'Backup Complete.'];
     let sandbox, scheduleStub, cancelScheduleStub, getBackupLastOperationStub, getBackupLogsStub, patchBackupFileStub, getFileStub;
@@ -223,12 +224,11 @@ describe('managers', function () {
         mocks.cloudProvider.upload(pathname, undefined);
         mocks.cloudProvider.headObject(pathname);
         mocks.apiServerEventMesh.nockPatchResourceRegex('backup', 'defaultbackup', {}, 1, body => {
-          expect(body.status.response).to.eql(
-            JSON.stringify({
-              body: 'value',
-              logs: [logobj]
-            })
-          );
+          const responseObj = JSON.parse(body.status.response);
+          expect(responseObj.body).to.eql('value');
+          expect(responseObj.logs).to.eql([logobj]);
+          expect(responseObj.state).to.eql('succeeded');
+          expect(responseObj.snapshotId).to.eql('fakeSnapshotId');
           return true;
         });
         mocks.apiServerEventMesh.nockGetResource('backup', 'defaultbackup', backup_guid, {


### PR DESCRIPTION
- Create backup and deployment resources for backups running in background when service-fabrik transitions from v1 to v2
- Avoid call to backupstore while updating apiserver.