### PR TITLE
Refactor APIServerClient Class

### DIFF
--- a/api-controllers/ServiceFabrikApiController.js
+++ b/api-controllers/ServiceFabrikApiController.js
@@ -305,18 +305,23 @@ class ServiceFabrikApiController extends FabrikBaseController {
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
             resourceId: req.params.instance_id
           })
-          .catch(() => eventmesh.apiServerClient.createResource({
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            resourceId: req.params.instance_id,
-            parentResourceId: req.params.instance_id,
-            options: {},
-            status: {
-              state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-              lastOperation: {},
-              response: {}
-            }
-          }))
+          /* jshint unused:false */
+          .catch(NotFound, () => {
+            logger.debug(`Resource resourceGroup: ${CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT},` +
+              `resourceType: ${CONST.APISERVER.RESOURCE_TYPES.DIRECTOR}, resourceId: ${req.params.instance_id} not found, Creating now...`);
+            return eventmesh.apiServerClient.createResource({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+              resourceId: req.params.instance_id,
+              parentResourceId: req.params.instance_id,
+              options: {},
+              status: {
+                state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
+                lastOperation: {},
+                response: {}
+              }
+            });
+          })
           .then(() => eventmesh.apiServerClient.updateLastOperation({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,

--- a/broker/lib/fabrik/UnlockResourcePoller.js
+++ b/broker/lib/fabrik/UnlockResourcePoller.js
@@ -15,7 +15,7 @@ class UnlockResourcePoller {
     function poller(object, interval) {
       //TODO-PR - instead of a poller, its better to convert this to a watcher.
       const lockDetails = JSON.parse(object.spec.options);
-      return eventmesh.apiServerClient.getState({
+      return eventmesh.apiServerClient.getResourceState({
           resourceGroup: lockDetails.lockedResourceDetails.resourceGroup,
           resourceType: lockDetails.lockedResourceDetails.resourceType,
           resourceId: lockDetails.lockedResourceDetails.resourceId

--- a/broker/lib/fabrik/UnlockResourcePoller.js
+++ b/broker/lib/fabrik/UnlockResourcePoller.js
@@ -15,13 +15,12 @@ class UnlockResourcePoller {
     function poller(object, interval) {
       //TODO-PR - instead of a poller, its better to convert this to a watcher.
       const lockDetails = JSON.parse(object.spec.options);
-      return eventmesh.apiServerClient.getResource({
+      return eventmesh.apiServerClient.getState({
           resourceGroup: lockDetails.lockedResourceDetails.resourceGroup,
           resourceType: lockDetails.lockedResourceDetails.resourceType,
           resourceId: lockDetails.lockedResourceDetails.resourceId
         })
-        .then((resource) => {
-          const resourceState = resource.status.state;
+        .then((resourceState) => {
           logger.debug(`[Unlock Poller] Got resource ${lockDetails.lockedResourceDetails.resourceId} state as `, resourceState);
           //TODO-PR - reuse util method is operationCompleted.
           if (_.includes([

--- a/broker/lib/fabrik/UnlockResourcePoller.js
+++ b/broker/lib/fabrik/UnlockResourcePoller.js
@@ -15,9 +15,13 @@ class UnlockResourcePoller {
     function poller(object, interval) {
       //TODO-PR - instead of a poller, its better to convert this to a watcher.
       const lockDetails = JSON.parse(object.spec.options);
-      return eventmesh.apiServerClient.getResource(lockDetails.lockedResourceDetails.resourceGroup, lockDetails.lockedResourceDetails.resourceType, lockDetails.lockedResourceDetails.resourceId)
+      return eventmesh.apiServerClient.getResource({
+          resourceGroup: lockDetails.lockedResourceDetails.resourceGroup,
+          resourceType: lockDetails.lockedResourceDetails.resourceType,
+          resourceId: lockDetails.lockedResourceDetails.resourceId
+        })
         .then((resource) => {
-          const resourceState = resource.body.status.state;
+          const resourceState = resource.status.state;
           logger.debug(`[Unlock Poller] Got resource ${lockDetails.lockedResourceDetails.resourceId} state as `, resourceState);
           //TODO-PR - reuse util method is operationCompleted.
           if (_.includes([

--- a/common/constants.js
+++ b/common/constants.js
@@ -233,6 +233,7 @@ module.exports = Object.freeze({
   },
   APISERVER: {
     OPERATION_TIMEOUT_IN_SECS: 60,
+    RETRY_DELAY: 2000,
     WATCHER_ERROR_DELAY: 30000, // in ms (30 seconds)
     WATCHER_REFRESH_INTERVAL: 1200000, // in ms ( 20 minutes )
     VERSION: '1.9',

--- a/common/constants.js
+++ b/common/constants.js
@@ -236,13 +236,12 @@ module.exports = Object.freeze({
     WATCHER_ERROR_DELAY: 30000, // in ms (30 seconds)
     WATCHER_REFRESH_INTERVAL: 1200000, // in ms ( 20 minutes )
     VERSION: '1.9',
-    HOSTNAME: 'servicefabrik.io',
     NAMESPACE: 'default',
     API_VERSION: 'v1alpha1',
     RESOURCE_GROUPS: {
-      LOCK: 'lock',
-      DEPLOYMENT: 'deployment',
-      BACKUP: 'backup'
+      LOCK: 'lock.servicefabrik.io',
+      DEPLOYMENT: 'deployment.servicefabrik.io',
+      BACKUP: 'backup.servicefabrik.io'
     },
     RESOURCE_TYPES: {
       DEPLOYMENT_LOCKS: 'deploymentlocks',
@@ -263,17 +262,6 @@ module.exports = Object.freeze({
       STATE: 'state',
       OPTIONS: 'options',
       LASTOPERATION: 'lastoperation'
-    },
-    ANNOTATION_KEYS: {
-      STATE: 'state',
-      OPTIONS: 'options',
-      RESULT: 'result'
-    },
-    ANNOTATION_NAMES: {
-      BACKUP: 'backup'
-    },
-    ANNOTATION_TYPES: {
-      BACKUP: 'defaultbackups'
     },
     WRITE_OPERATIONS: ['create', 'update', 'delete', 'restore'],
     READ_OPERATIONS: ['backup'],

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -190,7 +190,7 @@ class ApiServerClient {
     assert.ok(opts.resourceType, `Property 'resourceType' is required to create resource`);
     assert.ok(opts.resourceId, `Property 'resourceId' is required to create resource`);
     assert.ok(opts.options, `Property 'options' is required to create resource`);
-    let metadata = {
+    const metadata = {
       name: opts.resourceId
     };
     if (opts.parentResourceId) {
@@ -212,7 +212,7 @@ class ApiServerClient {
         }))
       .then((resource) => {
         if (opts.status) {
-          let statusJson = {};
+          const statusJson = {};
           _.forEach(opts.status, (val, key) => {
             statusJson[key] = _.isObject(val) ? JSON.stringify(val) : val;
           });
@@ -247,7 +247,7 @@ class ApiServerClient {
     assert.ok(opts.resourceId, `Property 'resourceId' is required to update resource`);
     return Promise.try(() => {
         if (opts.options || opts.metadata) {
-          let patchBody = {};
+          const patchBody = {};
           if (opts.metadata) {
             patchBody.metadata = opts.metadata;
           }
@@ -266,7 +266,7 @@ class ApiServerClient {
       })
       .then((resource) => {
         if (opts.status) {
-          let statusJson = {};
+          const statusJson = {};
           _.forEach(opts.status, (val, key) => {
             statusJson[key] = _.isObject(val) ? JSON.stringify(val) : val;
           });
@@ -372,7 +372,7 @@ class ApiServerClient {
     assert.ok(opts.operationName, `Property 'operationName' is required to update lastOperation`);
     assert.ok(opts.operationType, `Property 'operationType' is required to update lastOperation`);
     assert.ok(opts.value, `Property 'value' is required to update lastOperation`);
-    let metadata = {};
+    const metadata = {};
     metadata.labels = {};
     metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = opts.value;
     const options = _.chain(opts)

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -204,7 +204,8 @@ class ApiServerClient {
         'options': JSON.stringify(opts.options)
       },
     };
-    return Promise.try(() => apiserver
+    return Promise.try(() => this.init())
+      .then(() => apiserver
         .apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
         .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType].post({
           body: resourceBody
@@ -215,12 +216,13 @@ class ApiServerClient {
           _.forEach(opts.status, (val, key) => {
             statusJson[key] = _.isObject(val) ? JSON.stringify(val) : val;
           });
-          return apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
-            .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).status.patch({
-              body: {
-                'status': statusJson
-              }
-            });
+          return Promise.try(() => this.init())
+            .then(() => apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+              .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).status.patch({
+                body: {
+                  'status': statusJson
+                }
+              }));
         }
         return resource;
       })
@@ -254,11 +256,12 @@ class ApiServerClient {
               'options': JSON.stringify(opts.options)
             };
           }
-          return apiserver
-            .apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
-            .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).patch({
-              body: patchBody
-            });
+          return Promise.try(() => this.init())
+            .then(() => apiserver
+              .apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+              .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).patch({
+                body: patchBody
+              }));
         }
       })
       .then((resource) => {
@@ -267,12 +270,13 @@ class ApiServerClient {
           _.forEach(opts.status, (val, key) => {
             statusJson[key] = _.isObject(val) ? JSON.stringify(val) : val;
           });
-          return apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
-            .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).status.patch({
-              body: {
-                'status': statusJson
-              }
-            });
+          return Promise.try(() => this.init())
+            .then(() => apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+              .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).status.patch({
+                body: {
+                  'status': statusJson
+                }
+              }));
         }
         return resource;
       })

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -132,6 +132,8 @@ class ApiServerClient {
    * @param {string} callback - Fucntion to call when event is received
    */
   registerWatcher(resourceGroup, resourceType, callback, queryString) {
+    assert.ok(resourceGroup, `Argument 'resourceGroup' is required to register watcher`);
+    assert.ok(resourceType, `Argument 'resourceType' is required to register watcher`);
     return Promise.try(() => this.init())
       .then(() => {
         const stream = apiserver
@@ -200,7 +202,7 @@ class ApiServerClient {
         .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType].post({
           body: resourceBody
         }))
-      .then((resource) => {
+      .then(resource => {
         if (opts.status) {
           const statusJson = {};
           _.forEach(opts.status, (val, key) => {
@@ -254,7 +256,7 @@ class ApiServerClient {
               }));
         }
       })
-      .then((resource) => {
+      .then(resource => {
         if (opts.status) {
           const statusJson = {};
           _.forEach(opts.status, (val, key) => {
@@ -289,7 +291,7 @@ class ApiServerClient {
     assert.ok(opts.resourceId, `Property 'resourceId' is required to patch response`);
     assert.ok(opts.response, `Property 'response' is required to patch response`);
     return this.getResource(opts)
-      .then((resource) => {
+      .then(resource => {
         const oldResponse = resource.status.response;
         const response = _.merge(oldResponse, opts.response);
         const options = _.chain(opts)
@@ -317,7 +319,7 @@ class ApiServerClient {
     assert.ok(opts.resourceId, `Property 'resourceId' is required to patch options`);
     assert.ok(opts.options, `Property 'options' is required to patch options`);
     return this.getResource(opts)
-      .then((resource) => {
+      .then(resource => {
         const oldOptions = resource.spec.options;
         const options = _.merge(oldOptions, opts.options);
         _.set(opts, 'options', options);
@@ -389,7 +391,7 @@ class ApiServerClient {
     return Promise.try(() => this.init())
       .then(() => apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
         .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).get())
-      .then((resource) => {
+      .then(resource => {
         _.forEach(resource.body.spec, (val, key) => {
           try {
             resource.body.spec[key] = JSON.parse(val);

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Promise = require('bluebird');
+const assert = require('assert');
 const config = require('../../common/config');
 const logger = require('../../common/logger');
 const CONST = require('../../common/constants');
@@ -185,6 +186,10 @@ class ApiServerClient {
    */
   createResource(opts) {
     logger.info(`Creating resource with opts: `, opts);
+    assert.ok(opts.resourceGroup, `Property 'resourceGroup' is required to create resource`);
+    assert.ok(opts.resourceType, `Property 'resourceType' is required to create resource`);
+    assert.ok(opts.resourceId, `Property 'resourceId' is required to create resource`);
+    assert.ok(opts.options, `Property 'options' is required to create resource`);
     let metadata = {
       name: opts.resourceId
     };
@@ -235,6 +240,9 @@ class ApiServerClient {
    */
   updateResource(opts) {
     logger.info('Updating resource with opts: ', opts);
+    assert.ok(opts.resourceGroup, `Property 'resourceGroup' is required to update resource`);
+    assert.ok(opts.resourceType, `Property 'resourceType' is required to update resource`);
+    assert.ok(opts.resourceId, `Property 'resourceId' is required to update resource`);
     return Promise.try(() => {
         if (opts.options || opts.metadata) {
           let patchBody = {};
@@ -282,6 +290,10 @@ class ApiServerClient {
    */
   patchResponse(opts) {
     logger.info('Patching resource response with opts: ', opts);
+    assert.ok(opts.resourceGroup, `Property 'resourceGroup' is required to patch response`);
+    assert.ok(opts.resourceType, `Property 'resourceType' is required to patch response`);
+    assert.ok(opts.resourceId, `Property 'resourceId' is required to patch response`);
+    assert.ok(opts.response, `Property 'response' is required to patch response`);
     return this.getResource(opts)
       .then((resource) => {
         const oldResponse = resource.status.response;
@@ -306,6 +318,10 @@ class ApiServerClient {
 
   patchOptions(opts) {
     logger.info('Patching resource options with opts: ', opts);
+    assert.ok(opts.resourceGroup, `Property 'resourceGroup' is required to patch options`);
+    assert.ok(opts.resourceType, `Property 'resourceType' is required to patch options`);
+    assert.ok(opts.resourceId, `Property 'resourceId' is required to patch options`);
+    assert.ok(opts.options, `Property 'options' is required to patch options`);
     return this.getResource(opts)
       .then((resource) => {
         const oldOptions = resource.spec.options;
@@ -324,6 +340,9 @@ class ApiServerClient {
 
   deleteResource(opts) {
     logger.info('Deleting resource with opts: ', opts);
+    assert.ok(opts.resourceGroup, `Property 'resourceGroup' is required to delete resource`);
+    assert.ok(opts.resourceType, `Property 'resourceType' is required to delete resource`);
+    assert.ok(opts.resourceId, `Property 'resourceId' is required to delete resource`);
     return Promise.try(() => this.init())
       .then(() => apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
         .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).delete())
@@ -343,6 +362,12 @@ class ApiServerClient {
    */
   updateLastOperation(opts) {
     logger.info('Updating last operation with opts: ', opts);
+    assert.ok(opts.resourceGroup, `Property 'resourceGroup' is required to update lastOperation`);
+    assert.ok(opts.resourceType, `Property 'resourceType' is required to update lastOperation`);
+    assert.ok(opts.resourceId, `Property 'resourceId' is required to update lastOperation`);
+    assert.ok(opts.operationName, `Property 'operationName' is required to update lastOperation`);
+    assert.ok(opts.operationType, `Property 'operationType' is required to update lastOperation`);
+    assert.ok(opts.value, `Property 'value' is required to update lastOperation`);
     let metadata = {};
     metadata.labels = {};
     metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = opts.value;
@@ -363,6 +388,10 @@ class ApiServerClient {
    */
 
   getResource(opts) {
+    logger.debug('Get resource with opts: ', opts);
+    assert.ok(opts.resourceGroup, `Property 'resourceGroup' is required to get resource`);
+    assert.ok(opts.resourceType, `Property 'resourceType' is required to get resource`);
+    assert.ok(opts.resourceId, `Property 'resourceId' is required to get resource`);
     return Promise.try(() => this.init())
       .then(() => apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
         .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).get())
@@ -397,6 +426,11 @@ class ApiServerClient {
    * @param {string} opts.operationType - Type of operation
    */
   getLastOperation(opts) {
+    assert.ok(opts.resourceGroup, `Property 'resourceGroup' is required to get lastOperation`);
+    assert.ok(opts.resourceType, `Property 'resourceType' is required to get lastOperation`);
+    assert.ok(opts.resourceId, `Property 'resourceId' is required to get lastOperation`);
+    assert.ok(opts.operationName, `Property 'operationName' is required to get lastOperation`);
+    assert.ok(opts.operationType, `Property 'operationType' is required to get lastOperation`);
     let options = _.chain(opts)
       .omit('operationName', 'operationType')
       .value();

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -204,7 +204,7 @@ class ApiServerClient {
         .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType].post({
           body: resourceBody
         }))
-      .then(() => {
+      .then((resource) => {
         if (opts.status) {
           let statusJson = {};
           _.forEach(opts.status, (val, key) => {
@@ -212,9 +212,12 @@ class ApiServerClient {
           });
           return apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
             .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).status.patch({
-              body: statusJson
+              body: {
+                'status': statusJson
+              }
             });
         }
+        return resource;
       })
       .catch(err => {
         return convertToHttpErrorAndThrow(err);
@@ -250,7 +253,7 @@ class ApiServerClient {
             });
         }
       })
-      .then(() => {
+      .then((resource) => {
         if (opts.status) {
           let statusJson = {};
           _.forEach(opts.status, (val, key) => {
@@ -263,6 +266,7 @@ class ApiServerClient {
               }
             });
         }
+        return resource;
       })
       .catch(err => {
         return convertToHttpErrorAndThrow(err);
@@ -397,10 +401,7 @@ class ApiServerClient {
       .omit('operationName', 'operationType')
       .value();
     return this.getResource(options)
-      .then(json => json.metadata.labels[`last_${opts.operationName}_${opts.operationType}`])
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
+      .then(json => json.metadata.labels[`last_${opts.operationName}_${opts.operationType}`]);
   }
 
   /**

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash');
 const Promise = require('bluebird');
-const assert = require('assert');
 const config = require('../../common/config');
 const logger = require('../../common/logger');
 const CONST = require('../../common/constants');
@@ -67,16 +66,15 @@ class ApiServerClient {
         return apiserver.loadSpec()
           .then(() => {
             this.ready = true;
-            logger.info('Loaded Successfully');
+            logger.info('Successfully loaded ApiServer Spec');
           });
       }
     });
   }
-
   /**
    * Poll for Status until opts.start_state changes
    * @param {object} opts - Object containing options
-   * @param {string} opts.operationId - Id of the operation ex. backupGuid
+   * @param {string} opts.resourceId - Id of the operation ex. backupGuid
    * @param {string} opts.start_state - start state of the operation ex. in_queue
    * @param {object} opts.started_at - Date object specifying operation start time
    */
@@ -84,10 +82,10 @@ class ApiServerClient {
     logger.info(`Waiting ${CONST.EVENTMESH_POLLER_DELAY} ms to get the operation state`);
     let finalState;
     return Promise.delay(CONST.EVENTMESH_POLLER_DELAY)
-      .then(() => this.getOperationState({
-        operationName: CONST.OPERATION_TYPE.BACKUP,
-        operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-        operationId: opts.operationId
+      .then(() => this.getState({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+        resourceId: opts.resourceId
       }))
       .then(state => {
         if (state === opts.start_state) {
@@ -97,14 +95,14 @@ class ApiServerClient {
           state === CONST.APISERVER.RESOURCE_STATE.DELETE_FAILED
         ) {
           finalState = state;
-          return this.getOperationStatus({
-              operationName: CONST.OPERATION_TYPE.BACKUP,
-              operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-              operationId: opts.operationId,
+          return this.getResource({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+              resourceId: opts.resourceId
             })
-            .then(status => {
-              if (status.error) {
-                const errorResponse = JSON.parse(status.error);
+            .then(response => {
+              if (response.status.error) {
+                const errorResponse = response.status.error;
                 logger.info('Operation manager reported error', errorResponse);
                 return convertToHttpErrorAndThrow(errorResponse);
               }
@@ -114,13 +112,13 @@ class ApiServerClient {
           const duration = (new Date() - opts.started_at) / 1000;
           logger.info(`Polling for ${opts.start_state} duration: ${duration} `);
           if (duration > CONST.BACKUP.BACKUP_START_TIMEOUT_IN_SECS) {
-            logger.error(`Backup with guid ${opts.operationId} not picked up from the queue`);
-            throw new Timeout(`Backup with guid ${opts.operationId} not picked up from the queue`);
+            logger.error(`Backup with guid ${opts.resourceId} not picked up from the queue`);
+            throw new Timeout(`Backup with guid ${opts.resourceId} not picked up from the queue`);
           }
-          return this.getOperationResponse({
-            operationName: CONST.OPERATION_TYPE.BACKUP,
-            operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-            operationId: opts.operationId,
+          return this.getResponse({
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+            resourceId: opts.resourceId
           });
         }
       })
@@ -135,6 +133,7 @@ class ApiServerClient {
       });
   }
 
+
   /**
    * @description Register watcher for (resourceGroup , resourceType)
    * @param {string} resourceGroup - Name of the resource
@@ -145,7 +144,7 @@ class ApiServerClient {
     return Promise.try(() => this.init())
       .then(() => {
         const stream = apiserver
-          .apis[`${resourceGroup}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
+          .apis[resourceGroup][CONST.APISERVER.API_VERSION]
           .watch.namespaces(CONST.APISERVER.NAMESPACE)[resourceType].getStream({
             qs: {
               labelSelector: queryString ? queryString : ''
@@ -165,279 +164,165 @@ class ApiServerClient {
         return convertToHttpErrorAndThrow(err);
       });
   }
-
   parseResourceDetailsFromSelfLink(selfLink) {
     // self links are typically: /apis/deployment.servicefabrik.io/v1alpha1/namespaces/default/directors/d-7
     const resourceType = _.split(selfLink, '/')[6];
-    const resourceGroup = _.split(_.split(selfLink, '/')[2], '.')[0];
+    const resourceGroup = _.split(selfLink, '/')[2];
     return {
       resourceGroup: resourceGroup,
       resourceType: resourceType
     };
   }
 
-  _createResource(resourceGroup, resourceType, body) {
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${resourceGroup}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[resourceType].post({
-          body: body
-        }));
-  }
-
-  createLock(lockType, body) {
-    return this._createResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, lockType, body)
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  deleteResource(resourceGroup, resourceType, resourceId) {
-    return Promise.try(() => this.init())
-      .then(() => apiserver.apis[`${resourceGroup}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[resourceType](resourceId).delete());
-  }
-
-  patchResource(resourceGroup, resourceType, resourceId, delta) {
-    return Promise.try(() => this.init())
-      .then(() => apiserver.apis[`${resourceGroup}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[resourceType](resourceId).patch({
-          body: delta
-        }));
-  }
-
-  patchResourceStatus(resourceGroup, resourceType, resourceId, statusDelta) {
-    return Promise.try(() => this.init())
-      .then(() => apiserver.apis[`${resourceGroup}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[resourceType](resourceId)
-        .status.patch({
-          body: statusDelta
-        }));
-  }
-
-  deleteLock(resourceType, resourceId) {
-    return this.deleteResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, resourceType, resourceId)
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  updateResource(resourceGroup, resourceType, resourceId, delta) {
-    return this.patchResource(resourceGroup, resourceType, resourceId, delta)
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  getLockDetails(resourceType, resourceId) {
-    return Promise.try(() => this.init())
-      .then(() => apiserver.apis[`${CONST.APISERVER.RESOURCE_GROUPS.LOCK}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[resourceType](resourceId).get())
-      .then(resource => {
-        return JSON.parse(resource.body.spec.options);
+  /**
+   * @description Create Resource in Apiserver with the opts
+   * @param {string} opts.resourceGroup - Name of resource group ex. backup.servicefabrik.io
+   * @param {string} opts.resourceType - Type of resource ex. defaultbackup
+   * @param {string} opts.resourceId - Unique id of resource ex. backup_guid
+   * @param {string} opts.parentResourceId - Id of parent resource to be put in label ex: instance_guid
+   * @param {Object} opts.options - Value to set for spec.options field of resource
+   * @param {string} opts.status - status of the resource
+   */
+  createResource(opts) {
+    logger.info(`Creating resource with opts: `, opts);
+    let metadata = {
+      name: opts.resourceId
+    };
+    if (opts.parentResourceId) {
+      metadata.labels = {
+        instance_guid: opts.parentResourceId
+      };
+    }
+    const resourceBody = {
+      metadata: metadata,
+      spec: {
+        'options': JSON.stringify(opts.options)
+      },
+    };
+    return Promise.try(() => apiserver
+        .apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+        .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType].post({
+          body: resourceBody
+        }))
+      .then(() => {
+        if (opts.status) {
+          let statusJson = {};
+          _.forEach(opts.status, (val, key) => {
+            statusJson[key] = _.isObject(val) ? JSON.stringify(val) : val;
+          });
+          return apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+            .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).status.patch({
+              body: statusJson
+            });
+        }
       })
       .catch(err => {
         return convertToHttpErrorAndThrow(err);
       });
   }
 
-  getResource(resourceGroup, resourceType, resourceId) {
-    logger.debug(`Getting resource ${resourceGroup}/${resourceType}/${resourceId}`);
+  /**
+   * @description Update Resource in Apiserver with the opts
+   * @param {string} opts.resourceGroup - Name of resource group ex. backup.servicefabrik.io
+   * @param {string} opts.resourceType - Type of resource ex. defaultbackup
+   * @param {string} opts.resourceId - Unique id of resource ex. backup_guid
+   * @param {string} opts.metadata - Metadata of resource
+   * @param {Object} opts.options - Value to set for spec.options field of resource
+   * @param {string} opts.status - status of the resource
+   */
+  updateResource(opts) {
+    logger.info('Updating resource with opts: ', opts);
+    return Promise.try(() => {
+        if (opts.options || opts.metadata) {
+          let patchBody = {};
+          if (opts.metadata) {
+            patchBody.metadata = opts.metadata;
+          }
+          if (opts.options) {
+            patchBody.spec = {
+              'options': JSON.stringify(opts.options)
+            };
+          }
+          return apiserver
+            .apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+            .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).patch({
+              body: patchBody
+            });
+        }
+      })
+      .then(() => {
+        if (opts.status) {
+          let statusJson = {};
+          _.forEach(opts.status, (val, key) => {
+            statusJson[key] = _.isObject(val) ? JSON.stringify(val) : val;
+          });
+          return apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+            .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).status.patch({
+              body: {
+                'status': statusJson
+              }
+            });
+        }
+      })
+      .catch(err => {
+        return convertToHttpErrorAndThrow(err);
+      });
+  }
+
+  /**
+   * @description Patch given response fields in status.response
+   * @param {string} opts.resourceGroup - Name of resource group ex. backup.servicefabrik.io
+   * @param {string} opts.resourceType - Type of resource ex. defaultbackup
+   * @param {string} opts.resourceId - Unique id of resource ex. backup_guid
+   * @param {string} opts.response - Value to set for status.response field of resource
+   */
+  patchResponse(opts) {
+    logger.info('Patching resource response with opts: ', opts);
+    return this.getResource(opts)
+      .then((resource) => {
+        const oldResponse = resource.status.response;
+        const response = _.merge(oldResponse, opts.response);
+        const options = _.chain(opts)
+          .omit('response')
+          .set('status', {
+            'response': response
+          })
+          .value();
+        return this.updateResource(options);
+      });
+  }
+
+  /**
+   * @description Patch given options fields in spec.options
+   * @param {string} opts.resourceGroup - Name of resource group ex. backup.servicefabrik.io
+   * @param {string} opts.resourceType - Type of resource ex. defaultbackup
+   * @param {string} opts.resourceId - Unique id of resource ex. backup_guid
+   * @param {string} opts.options - Value to set for spec.options field of resource
+   */
+
+  patchOptions(opts) {
+    logger.info('Patching resource options with opts: ', opts);
+    return this.getResource(opts)
+      .then((resource) => {
+        const oldOptions = resource.spec.options;
+        const options = _.merge(oldOptions, opts.options);
+        _.set(opts, 'options', options);
+        return this.updateResource(opts);
+      });
+  }
+
+  /**
+   * @description Delete Resource in Apiserver with the opts
+   * @param {string} opts.resourceGroup - Name of resource group ex. backup.servicefabrik.io
+   * @param {string} opts.resourceType - Type of resource ex. defaultbackup
+   * @param {string} opts.resourceId - Unique id of resource ex. backup_guid
+   */
+
+  deleteResource(opts) {
+    logger.info('Deleting resource with opts: ', opts);
     return Promise.try(() => this.init())
-      .then(() => apiserver.apis[`${resourceGroup}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[resourceType](resourceId).get())
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  createDeployment(resourceId, val) {
-    const opts = {
-      operationId: resourceId,
-      resourceId: resourceId,
-      operationName: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-      operationType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-      value: val
-    };
-    return this.createOperation(opts);
-  }
-
-  _updateResourceState(resourceType, resourceId, stateValue) {
-    const opts = {
-      operationId: resourceId,
-      resourceId: resourceId,
-      operationName: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-      operationType: resourceType,
-      stateValue: stateValue
-    };
-    return this.updateOperationState(opts);
-  }
-
-  getResourceState(resourceType, resourceId) {
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[resourceType](resourceId)
-        .get())
-      .then(json => json.body.status.state)
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  /**
-   * @description Create Resource in Apiserver with the opts
-   * @param {string} opts.resourceId - Unique id of resource
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   * @param {Object} opts.value - Value to set for spec.options field of resource
-   */
-  createOperation(opts) {
-    const resourceBody = {
-      metadata: {
-        'name': `${opts.operationId}`,
-        'labels': {
-          instance_guid: `${opts.resourceId}`,
-        },
-      },
-      spec: {
-        'options': JSON.stringify(opts.value)
-      },
-    };
-    logger.info(`Creating resource ${resourceBody.metadata.name} with options:`, opts.value);
-    const statusJson = {
-      status: {
-        state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-        lastOperation: 'created',
-        response: JSON.stringify({})
-      }
-    };
-    return this._createResource(opts.operationName, opts.operationType, resourceBody)
-      .then(() => apiserver.apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[opts.operationType](opts.operationId).status.patch({
-          body: statusJson
-        }))
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  /**
-   * @description Function to patch the response filed with opts.value
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   * @param {Object} opts.value - Object to merge with the existing Result object
-   */
-  patchOperationResponse(opts) {
-    logger.info('Patching Operation with :', opts);
-    return this.getOperationResponse(opts)
-      .then(res => {
-        logger.info(`Patching ${JSON.stringify(res)} with ${JSON.stringify(opts.value)}`);
-        opts.value = _.merge(res, opts.value);
-        return this.updateOperationResponse(opts);
-      });
-  }
-
-  /**
-   * @description Function to update the response field
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   * @param {Object} opts.value - Object to be set as status.response
-   */
-  updateOperationResponse(opts) {
-    logger.info('Updating Operation Result with :', opts);
-    const patchedResource = {
-      'status': {
-        'response': JSON.stringify(opts.value),
-      }
-    };
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[opts.operationType](opts.operationId)
-        .status.patch({
-          body: patchedResource
-        }))
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  /**
-   * @description Function to Update the state field
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   * @param {Object} opts.stateValue - Value to set as state
-   */
-  updateOperationState(opts) {
-    logger.info('Updating Operation State with :', opts);
-    assert.ok(opts.operationName, `Property 'operationName' is required to update operation state`);
-    assert.ok(opts.operationType, `Property 'operationType' is required to update operation state`);
-    assert.ok(opts.operationId, `Property 'operationId' is required to update operation state`);
-    assert.ok(opts.stateValue, `Property 'stateValue' is required to update operation state`);
-    const patchedResource = {
-      'status': {
-        'state': opts.stateValue
-      }
-    };
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[opts.operationType](opts.operationId)
-        .status.patch({
-          body: patchedResource
-        }))
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  /**
-   * @description Function to Update the error field
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   * @param {Object} opts.error - Value to set as error
-   */
-  updateOperationError(opts) {
-    const operationStatus = {
-      'status': {
-        'error': JSON.stringify(opts.error)
-      }
-    };
-    return this.patchResourceStatus(opts.operationName, opts.operationType, opts.operationId, operationStatus)
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  /**
-   * @description Function to Update the state field
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   * @param {Object} opts.response - Object to be set as response
-   * @param {string} opts.stateValue - Value to set as state
-   */
-  updateOperationStateAndResponse(opts) {
-    logger.info('Updating Operation status with :', opts);
-    const patchedResource = {
-      'status': {
-        'state': opts.stateValue,
-        'response': JSON.stringify(opts.response)
-      }
-    };
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[opts.operationType](opts.operationId)
-        .status.patch({
-          body: patchedResource
-        }))
+      .then(() => apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+        .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).delete())
       .catch(err => {
         return convertToHttpErrorAndThrow(err);
       });
@@ -445,24 +330,55 @@ class ApiServerClient {
 
   /**
    * @description Update Last Operation to opts.value for resource
-   * @param {string} opts.resourceId - Unique id of resource
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {Object} opts.value - Unique if of the last operation
+   * @param {string} opts.resourceGroup - Name of resource group ex. backup.servicefabrik.io
+   * @param {string} opts.resourceType - Type of resource ex. defaultbackup
+   * @param {string} opts.resourceId - Unique id of resource ex. backup_guid
+   * @param {string} opts.operationName - Name of operation which was last operation
+   * @param {string} opts.operationType - Type of operation which was last operation
+   * @param {Object} opts.value - Unique id of the last operation ex: backup_guid
    */
   updateLastOperation(opts) {
-    logger.debug(`Updating last operation on ${opts.resourceId} with ${opts.value}`);
-    const patchedResource = {};
-    patchedResource.metadata = {};
-    patchedResource.metadata.labels = {};
-    patchedResource.metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = opts.value;
+    logger.info('Updating last operation with opts: ', opts);
+    let metadata = {};
+    metadata.labels = {};
+    metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = opts.value;
+    const options = _.chain(opts)
+      .omit('value', 'operationName', 'operationType')
+      .set('metadata', metadata)
+      .value();
+    return this.updateResource(options);
+  }
+
+
+
+  /**
+   * @description Get Resource in Apiserver with the opts
+   * @param {string} opts.resourceGroup - Unique id of resource
+   * @param {string} opts.resourceType - Name of operation
+   * @param {string} opts.resourceId - Type of operation
+   */
+
+  getResource(opts) {
     return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[CONST.APISERVER.RESOURCE_TYPES.DIRECTOR](opts.resourceId)
-        .patch({
-          body: patchedResource
-        }))
+      .then(() => apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+        .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).get())
+      .then((resource) => {
+        _.forEach(resource.body.spec, (val, key) => {
+          try {
+            resource.body.spec[key] = JSON.parse(val);
+          } catch (err) {
+            resource.body.spec[key] = val;
+          }
+        });
+        _.forEach(resource.body.status, (val, key) => {
+          try {
+            resource.body.status[key] = JSON.parse(val);
+          } catch (err) {
+            resource.body.status[key] = val;
+          }
+        });
+        return resource.body;
+      })
       .catch(err => {
         return convertToHttpErrorAndThrow(err);
       });
@@ -471,167 +387,54 @@ class ApiServerClient {
   /**
    * @description Gets Last Operation
    * @param {string} opts.resourceId - Unique id of resource
+   * @param {string} opts.resourceGroup - Name of operation
+   * @param {string} opts.resourceType - Type of operation
    * @param {string} opts.operationName - Name of operation
    * @param {string} opts.operationType - Type of operation
    */
   getLastOperation(opts) {
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[CONST.APISERVER.RESOURCE_TYPES.DIRECTOR](opts.resourceId)
-        .get())
-      .then(json => json.body.metadata.labels[`last_${opts.operationName}_${opts.operationType}`])
+    let options = _.chain(opts)
+      .omit('operationName', 'operationType')
+      .value();
+    return this.getResource(options)
+      .then(json => json.metadata.labels[`last_${opts.operationName}_${opts.operationType}`])
       .catch(err => {
         return convertToHttpErrorAndThrow(err);
       });
   }
 
   /**
-   * @description Patch Operation Options
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   * @param {Object} opts.value
+   * @description Get resource Options
+   * @param {string} opts.resourceGroup - Name of operation
+   * @param {string} opts.resourceType - Type of operation
+   * @param {string} opts.resourceId - Unique id of resource
    */
-  patchOperationOptions(opts) {
-    return this.getOperationOptions(opts)
-      .then(res => {
-        logger.info(`Patching ${JSON.stringify(res)} with ${JSON.stringify(opts.value)}`);
-        opts.value = _.merge(res, opts.value);
-        return this.updateOperationOptions(opts);
-      });
+  getOptions(opts) {
+    return this.getResource(opts)
+      .then(resource => resource.spec.options);
   }
 
   /**
-   * @description Update Operation Options
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   * @param {Object} opts.value
+   * @description Get resource response
+   * @param {string} opts.resourceGroup - Name of operation
+   * @param {string} opts.resourceType - Type of operation
+   * @param {string} opts.resourceId - Unique id of resource
    */
-  updateOperationOptions(opts) {
-    logger.info('Updating resource with options:', opts.value);
-    const change = {
-      spec: {
-        'options': JSON.stringify(opts.value)
-      },
-    };
-    return this.patchResource(opts.operationName, opts.operationType, opts.operationId, change)
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-  /**
-   * @description Get Operation Options
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   */
-  getOperationOptions(opts) {
-    assert.ok(opts.operationName, `Property 'operationName' is required to get operation state`);
-    assert.ok(opts.operationType, `Property 'operationType' is required to get operation state`);
-    assert.ok(opts.operationId, `Property 'operationId' is required to get operation state`);
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[opts.operationType](opts.operationId)
-        .get())
-      .then(json => JSON.parse(json.body.spec.options))
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
+  getResponse(opts) {
+    return this.getResource(opts)
+      .then(resource => resource.status.response);
   }
 
   /**
-   * @description Get Operation State
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
+   * @description Get resource state
+   * @param {string} opts.resourceGroup - Name of operation
+   * @param {string} opts.resourceType - Type of operation
+   * @param {string} opts.resourceId - Unique id of resource
    */
-  getOperationState(opts) {
-    assert.ok(opts.operationName, `Property 'operationName' is required to get operation state`);
-    assert.ok(opts.operationType, `Property 'operationType' is required to get operation state`);
-    assert.ok(opts.operationId, `Property 'operationId' is required to get operation state`);
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[opts.operationType](opts.operationId)
-        .get())
-      .then(json => json.body.status.state)
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
+  getState(opts) {
+    return this.getResource(opts)
+      .then(resource => resource.status.state);
   }
-
-  /**
-   * @description Get Operation Response
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   */
-  getOperationResponse(opts) {
-    logger.debug('Getting operation response with', opts);
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[opts.operationType](opts.operationId)
-        .get())
-      .then(json => JSON.parse(json.body.status.response))
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  /**
-   * @description Get Operation Status
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   */
-  getOperationStatus(opts) {
-    logger.info('Getting Operation Status with :', opts);
-    return this.getResource(opts.operationName, opts.operationType, opts.operationId)
-      .then(json => json.body.status)
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
-  /**
-   * @description Function to Update the status field
-   * @param {string} opts.operationName - Name of operation
-   * @param {string} opts.operationType - Type of operation
-   * @param {string} opts.operationId - Unique id of operation
-   * @param {Object} opts.stateValue - Value to set as state
-   * @param {Object} opts.error - Value to set as error
-   * @param {Object} opts.response - Value to set as error
-   */
-  updateOperationStatus(opts) {
-    logger.info('Updating Operation Status with :', opts);
-    const patchedResource = {
-      'status': {}
-    };
-    if (opts.stateValue) {
-      patchedResource.status.state = opts.stateValue;
-    }
-    if (opts.error) {
-      patchedResource.status.error = JSON.stringify(opts.error);
-    }
-    if (opts.response) {
-      patchedResource.status.response = JSON.stringify(opts.response);
-    }
-    return Promise.try(() => this.init())
-      .then(() => apiserver
-        .apis[`${opts.operationName}.${CONST.APISERVER.HOSTNAME}`][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE)[opts.operationType](opts.operationId)
-        .status.patch({
-          body: patchedResource
-        }))
-      .catch(err => {
-        return convertToHttpErrorAndThrow(err);
-      });
-  }
-
 }
 
 module.exports = ApiServerClient;

--- a/jobs/BnRStatusPollerJob.js
+++ b/jobs/BnRStatusPollerJob.js
@@ -111,7 +111,7 @@ class BnRStatusPollerJob extends BaseJob {
               }
             });
           })
-          .then(() => eventmesh.apiServerClient.updateLastOperation({
+          .then(() => eventmesh.apiServerClient.updateLastOperationValue({
             resourceId: instance_guid,
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,

--- a/jobs/BnRStatusPollerJob.js
+++ b/jobs/BnRStatusPollerJob.js
@@ -66,35 +66,55 @@ class BnRStatusPollerJob extends BaseJob {
     const plan = catalog.getPlan(instanceInfo.plan_id);
     return Promise
       .try(() => {
-        logger.info(`Check if the backup resouce ${backup_guid} and deployment resource ${instance_guid} already exists`);
+        logger.info(`Check if the backup resource ${backup_guid} and deployment resource ${instance_guid} already exists`);
         // For transition of sf to sfv2 we need to create bakcup and deployment resource
         // if they are not present
         // Can be removed once SFv2 transition is over
         return Promise
-          .try(() => eventmesh.apiServerClient.getResource(
-            CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            instance_guid))
+          .try(() => eventmesh.apiServerClient.getResource({
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            resourceId: instance_guid
+          }))
           .catch(() => {
             logger.info(`Creating missing operation resource for instance ${instance_guid}`);
-            return eventmesh.apiServerClient.createDeployment(instance_guid, {});
+            return eventmesh.apiServerClient.createResource({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+              resourceId: instance_guid,
+              parentResourceId: instance_guid,
+              options: {},
+              status: {
+                state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
+                lastOperation: {},
+                response: {}
+              }
+            });
           })
-          .then(() => eventmesh.apiServerClient.getResource(
-            CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
-            CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-            backup_guid))
+          .then(() => eventmesh.apiServerClient.getResource({
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+            resourceId: backup_guid
+          }))
           .catch(() => {
             logger.info(`Creating missing operation resource for backup ${backup_guid}`);
-            return eventmesh.apiServerClient.createOperation({
-              resourceId: instance_guid,
-              operationName: CONST.OPERATION_TYPE.BACKUP,
-              operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-              operationId: backup_guid,
-              value: job_data.operation_details
+            return eventmesh.apiServerClient.createResource({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+              resourceId: backup_guid,
+              parentResourceId: instance_guid,
+              options: job_data.operation_details,
+              status: {
+                state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
+                lastOperation: {},
+                response: {}
+              }
             });
           })
           .then(() => eventmesh.apiServerClient.updateLastOperation({
             resourceId: instance_guid,
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
             operationName: CONST.OPERATION_TYPE.BACKUP,
             operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
             value: backup_guid
@@ -137,11 +157,11 @@ class BnRStatusPollerJob extends BaseJob {
           return Promise
             .try(() => eventmesh
               .apiServerClient
-              .patchOperationResponse({
-                operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-                operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-                operationId: instanceInfo.backup_guid,
-                value: _.omit(operationStatusResponse, 'jobCancelled', 'operationTimedOut', 'operationFinished')
+              .patchResponse({
+                resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+                resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+                resourceId: instanceInfo.backup_guid,
+                response: _.omit(operationStatusResponse, 'jobCancelled', 'operationTimedOut', 'operationFinished')
               }))
             .then(() => bosh.director.getDirectorConfig(instanceInfo.deployment))
             .then(directorConfig => {
@@ -192,11 +212,13 @@ class BnRStatusPollerJob extends BaseJob {
   }
   static doPostFinishOperation(operationStatusResponse, operationName, instanceInfo) {
     return Promise
-      .try(() => eventmesh.apiServerClient.updateOperationState({
-        operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-        operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-        operationId: instanceInfo.backup_guid,
-        stateValue: operationStatusResponse.state
+      .try(() => eventmesh.apiServerClient.updateResource({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+        resourceId: instanceInfo.backup_guid,
+        status: {
+          'state': operationStatusResponse.state
+        }
       }))
       .then(() => this._logEvent(instanceInfo, operationName, operationStatusResponse))
       .then(() => ScheduleManager.cancelSchedule(`${instanceInfo.deployment}_${operationName}_${instanceInfo.backup_guid}`, CONST.JOB.BNR_STATUS_POLLER))

--- a/jobs/BnRStatusPollerJob.js
+++ b/jobs/BnRStatusPollerJob.js
@@ -158,11 +158,13 @@ class BnRStatusPollerJob extends BaseJob {
           return Promise
             .try(() => eventmesh
               .apiServerClient
-              .patchResponse({
+              .patchResource({
                 resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
                 resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
                 resourceId: instanceInfo.backup_guid,
-                response: _.omit(operationStatusResponse, 'jobCancelled', 'operationTimedOut', 'operationFinished')
+                status: {
+                  response: _.omit(operationStatusResponse, 'jobCancelled', 'operationTimedOut', 'operationFinished')
+                }
               }))
             .then(() => bosh.director.getDirectorConfig(instanceInfo.deployment))
             .then(directorConfig => {

--- a/jobs/BnRStatusPollerJob.js
+++ b/jobs/BnRStatusPollerJob.js
@@ -8,6 +8,7 @@ const ScheduleManager = require('./ScheduleManager');
 const utils = require('../common/utils');
 const logger = require('../common/logger');
 const errors = require('../common/errors');
+const NotFound = errors.NotFound;
 const DeploymentAlreadyLocked = errors.DeploymentAlreadyLocked;
 const config = require('../common/config');
 const bosh = require('../data-access-layer/bosh');
@@ -76,7 +77,7 @@ class BnRStatusPollerJob extends BaseJob {
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
             resourceId: instance_guid
           }))
-          .catch(() => {
+          .catch(NotFound, () => {
             logger.info(`Creating missing operation resource for instance ${instance_guid}`);
             return eventmesh.apiServerClient.createResource({
               resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
@@ -96,7 +97,7 @@ class BnRStatusPollerJob extends BaseJob {
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
             resourceId: backup_guid
           }))
-          .catch(() => {
+          .catch(NotFound, () => {
             logger.info(`Creating missing operation resource for backup ${backup_guid}`);
             return eventmesh.apiServerClient.createResource({
               resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,

--- a/managers/BaseManager.js
+++ b/managers/BaseManager.js
@@ -43,9 +43,8 @@ class BaseManager {
     logger.info('Trying to acquire processing lock for request with options: ', changedOptions);
     // Set lockedManager annotations to true
     const patchBody = _.cloneDeep(changeObjectBody);
-    let metadata = patchBody.metadata;
-    let currentAnnotations = metadata.annotations;
-    let patchAnnotations = currentAnnotations ? currentAnnotations : {};
+    const metadata = patchBody.metadata;
+    const patchAnnotations = metadata.annotations ? metadata.annotations : {};
     patchAnnotations.lockedByManager = config.broker_ip;
     metadata.annotations = patchAnnotations;
     const resourceDetails = eventmesh.apiServerClient.parseResourceDetailsFromSelfLink(changeObjectBody.metadata.selfLink);

--- a/managers/BaseManager.js
+++ b/managers/BaseManager.js
@@ -43,12 +43,18 @@ class BaseManager {
     logger.info('Trying to acquire processing lock for request with options: ', changedOptions);
     // Set lockedManager annotations to true
     const patchBody = _.cloneDeep(changeObjectBody);
-    let currentAnnotations = patchBody.metadata.annotations;
+    let metadata = patchBody.metadata;
+    let currentAnnotations = metadata.annotations;
     let patchAnnotations = currentAnnotations ? currentAnnotations : {};
     patchAnnotations.lockedByManager = config.broker_ip;
-    patchBody.metadata.annotations = patchAnnotations;
+    metadata.annotations = patchAnnotations;
     const resourceDetails = eventmesh.apiServerClient.parseResourceDetailsFromSelfLink(changeObjectBody.metadata.selfLink);
-    return eventmesh.apiServerClient.updateResource(resourceDetails.resourceGroup, resourceDetails.resourceType, changeObjectBody.metadata.name, patchBody)
+    return eventmesh.apiServerClient.updateResource({
+        resourceGroup: resourceDetails.resourceGroup,
+        resourceType: resourceDetails.resourceType,
+        resourceId: metadata.name,
+        metadata: metadata
+      })
       .tap((resource) => logger.info(`Successfully acquired processing lock for request with options: ${JSON.stringify(changedOptions)}\n` +
         `Updated resource with annotations is: `, resource));
   }
@@ -60,15 +66,18 @@ class BaseManager {
   _releaseProcessingLock(changeObjectBody) {
     const changedOptions = JSON.parse(changeObjectBody.spec.options);
     logger.info('Trying to release processing lock for request with options: ', changedOptions);
-    const patchBody = {
-      metadata: {
-        annotations: {
-          lockedByManager: ''
-        }
+    const metadata = {
+      annotations: {
+        lockedByManager: ''
       }
     };
     const resourceDetails = eventmesh.apiServerClient.parseResourceDetailsFromSelfLink(changeObjectBody.metadata.selfLink);
-    return eventmesh.apiServerClient.updateResource(resourceDetails.resourceGroup, resourceDetails.resourceType, changeObjectBody.metadata.name, patchBody)
+    return eventmesh.apiServerClient.updateResource({
+        resourceGroup: resourceDetails.resourceGroup,
+        resourceType: resourceDetails.resourceType,
+        resourceId: changeObjectBody.metadata.name,
+        metadata: metadata
+      })
       .tap((resource) => logger.info(`Successfully released processing lock for the request with options: ${JSON.stringify(changedOptions)}\n` +
         `Updated resource with annotations is: `, resource));
   }

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -296,11 +296,13 @@ class BackupService extends BaseDirectorService {
                   .replace(/\.\d*/, '')
               })
             )
-            .then(patchObj => eventmesh.apiServerClient.patchResponse({
+            .then(patchObj => eventmesh.apiServerClient.patchResource({
               resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
               resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
               resourceId: opts.backup_guid,
-              response: patchObj
+              status: {
+                response: patchObj
+              }
             }));
         }
       });

--- a/managers/backup-manager/BackupService.js
+++ b/managers/backup-manager/BackupService.js
@@ -161,13 +161,14 @@ class BackupService extends BaseDirectorService {
       })
       //TODO-PR - Break it into multiple methods
       .then(backupInfo => {
-        return eventmesh.apiServerClient.updateOperationStateAndResponse({
-            resourceId: opts.instance_guid,
-            operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-            operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-            operationId: result.backup_guid,
-            stateValue: CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS,
-            response: backupInfo
+        return eventmesh.apiServerClient.updateResource({
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+            resourceId: result.backup_guid,
+            status: {
+              'state': CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS,
+              'response': backupInfo
+            }
           })
           .then(() => backupInfo);
       })
@@ -183,13 +184,14 @@ class BackupService extends BaseDirectorService {
                 .catch((err) => logger.error('Error occurred while performing clean up of backup failure operation : ', err));
             }
           })
-          .then(() => eventmesh.apiServerClient.updateOperationStatus({
-            resourceId: opts.instance_guid,
-            operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-            operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-            operationId: result.backup_guid,
-            stateValue: CONST.APISERVER.RESOURCE_STATE.FAILED,
-            error: err
+          .then(() => eventmesh.apiServerClient.updateResource({
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+            resourceId: result.backup_guid,
+            status: {
+              state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+              error: err
+            }
           }))
           .then(() => {
             if (backupStarted) {
@@ -294,12 +296,11 @@ class BackupService extends BaseDirectorService {
                   .replace(/\.\d*/, '')
               })
             )
-            .then(patchObj => eventmesh.apiServerClient.patchOperationResponse({
-              resourceId: options.instance_guid,
-              operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-              operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-              operationId: opts.backup_guid,
-              value: patchObj
+            .then(patchObj => eventmesh.apiServerClient.patchResponse({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+              resourceId: opts.backup_guid,
+              response: patchObj
             }));
         }
       });
@@ -317,23 +318,25 @@ class BackupService extends BaseDirectorService {
     logger.info('Attempting delete with:', options);
     return this.backupStore
       .deleteBackupFile(options)
-      .then(() => eventmesh.apiServerClient.updateOperationState({
-        resourceId: options.instance_guid,
-        operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-        operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-        operationId: options.backup_guid,
-        stateValue: CONST.APISERVER.RESOURCE_STATE.DELETED
+      .then(() => eventmesh.apiServerClient.updateResource({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+        resourceId: options.backup_guid,
+        status: {
+          'state': CONST.APISERVER.RESOURCE_STATE.DELETED
+        }
       }))
       .catch(err => {
         return Promise
           .try(() => logger.error(`Error during delete of backup`, err))
-          .then(() => eventmesh.apiServerClient.updateOperationStatus({
-            resourceId: options.instance_guid,
-            operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-            operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-            operationId: options.backup_guid,
-            stateValue: CONST.APISERVER.RESOURCE_STATE.DELETE_FAILED,
-            error: err
+          .then(() => eventmesh.apiServerClient.updateResource({
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+            resourceId: options.backup_guid,
+            status: {
+              state: CONST.APISERVER.RESOURCE_STATE.DELETE_FAILED,
+              error: err
+            }
           }));
       });
   }
@@ -353,12 +356,13 @@ class BackupService extends BaseDirectorService {
         case 'processing':
           return this.agent
             .abortBackup(metadata.agent_ip)
-            .then(() => eventmesh.apiServerClient.updateOperationState({
-              resourceId: abortOptions.instance_guid,
-              operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-              operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-              operationId: abortOptions.guid,
-              stateValue: CONST.OPERATION.ABORTING
+            .then(() => eventmesh.apiServerClient.updateResource({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+              resourceId: abortOptions.guid,
+              status: {
+                'state': CONST.OPERATION.ABORTING
+              }
             }))
             .return({
               state: CONST.OPERATION.ABORTING

--- a/managers/backup-manager/DefaultBackupManager.js
+++ b/managers/backup-manager/DefaultBackupManager.js
@@ -41,11 +41,10 @@ class DefaultBackupManager extends BaseManager {
 
   static _processAbort(changeObjectBody) {
     const changedOptions = JSON.parse(changeObjectBody.spec.options);
-    return eventmesh.apiServerClient.getOperationOptions({
-        resourceId: changedOptions.instance_guid,
-        operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-        operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-        operationId: changedOptions.guid
+    return eventmesh.apiServerClient.getOptions({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+        resourceId: changedOptions.guid
       })
       .then(options => {
         return Promise.try(() => {
@@ -57,11 +56,10 @@ class DefaultBackupManager extends BaseManager {
 
   static _processDelete(changeObjectBody) {
     const changedOptions = JSON.parse(changeObjectBody.spec.options);
-    return eventmesh.apiServerClient.getOperationOptions({
-        resourceId: changedOptions.instance_guid,
-        operationName: CONST.APISERVER.ANNOTATION_NAMES.BACKUP,
-        operationType: CONST.APISERVER.ANNOTATION_TYPES.BACKUP,
-        operationId: changedOptions.guid
+    return eventmesh.apiServerClient.getOptions({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+        resourceId: changedOptions.guid
       })
       .then(options => {
         return Promise.try(() => {

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
@@ -222,7 +222,7 @@ describe('service-fabrik-api-2.0', function () {
               state: 'deleted',
               response: '{}'
             }
-          }, 3);
+          }, 2);
           mocks.apiServerEventMesh.nockPatchResource('backup', 'defaultbackup', backup_guid, {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
           mocks.apiServerEventMesh.nockDeleteResource('backup', 'defaultbackup', backup_guid);
@@ -251,7 +251,7 @@ describe('service-fabrik-api-2.0', function () {
               state: 'deleted',
               response: '{}'
             }
-          }, 3);
+          }, 2);
           mocks.apiServerEventMesh.nockPatchResource('backup', 'defaultbackup', backup_guid, {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
           mocks.apiServerEventMesh.nockDeleteResource('backup', 'defaultbackup', backup_guid);
@@ -280,7 +280,7 @@ describe('service-fabrik-api-2.0', function () {
               state: 'deleted',
               response: '{}'
             }
-          }, 3);
+          }, 2);
           mocks.apiServerEventMesh.nockPatchResource('backup', 'defaultbackup', backup_guid, {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
           mocks.apiServerEventMesh.nockDeleteResource('backup', 'defaultbackup', backup_guid);

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -213,7 +213,7 @@ describe('service-fabrik-api-sf2.0', function () {
           mocks.apiServerEventMesh.nockPatchResource('lock', 'deploymentlock', instance_id, {});
           mocks.apiServerEventMesh.nockCreateResource('backup', 'defaultbackup', {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
-          mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id);
+          mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource('deployment', 'director', instance_id, {});
           return chai
             .request(apps.external)
@@ -254,7 +254,7 @@ describe('service-fabrik-api-sf2.0', function () {
           mocks.apiServerEventMesh.nockPatchResource('lock', 'deploymentlock', instance_id, {});
           mocks.apiServerEventMesh.nockCreateResource('backup', 'defaultbackup', {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
-          mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id);
+          mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource('deployment', 'director', instance_id, {});
           return chai
             .request(apps.external)
@@ -297,7 +297,7 @@ describe('service-fabrik-api-sf2.0', function () {
           mocks.apiServerEventMesh.nockPatchResource('lock', 'deploymentlock', instance_id, {});
           mocks.apiServerEventMesh.nockCreateResource('backup', 'defaultbackup', {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
-          mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id);
+          mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource('deployment', 'director', instance_id, {});
           return chai
             .request(apps.external)
@@ -398,7 +398,7 @@ describe('service-fabrik-api-sf2.0', function () {
           mocks.apiServerEventMesh.nockPatchResource('lock', 'deploymentlock', instance_id, {});
           mocks.apiServerEventMesh.nockCreateResource('backup', 'defaultbackup', {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
-          mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id);
+          mocks.apiServerEventMesh.nockGetResource('deployment', 'director', instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource('deployment', 'director', instance_id, {});
 
           return chai

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -747,7 +747,7 @@ describe('service-fabrik-api-sf2.0', function () {
               state: 'aborting',
               response: '{"guid": "some_guid"}'
             }
-          }, 2);
+          });
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
           return chai
             .request(apps.external)
@@ -786,7 +786,7 @@ describe('service-fabrik-api-sf2.0', function () {
               state: 'aborted',
               response: '{"guid": "some_guid"}'
             }
-          }, 2);
+          });
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
           return chai
             .request(apps.external)
@@ -825,7 +825,7 @@ describe('service-fabrik-api-sf2.0', function () {
               state: 'aborted',
               response: '{"guid": "some_guid"}'
             }
-          }, 2);
+          });
           return chai
             .request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/backup`)
@@ -1507,7 +1507,7 @@ describe('service-fabrik-api-sf2.0', function () {
               state: 'deleted',
               response: '{}'
             }
-          }, 3);
+          }, 2);
           mocks.apiServerEventMesh.nockPatchResource('backup', 'defaultbackup', backup_guid, {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
           mocks.apiServerEventMesh.nockDeleteResource('backup', 'defaultbackup', backup_guid);
@@ -1534,7 +1534,7 @@ describe('service-fabrik-api-sf2.0', function () {
               state: CONST.APISERVER.RESOURCE_STATE.DELETE_FAILED,
               error: JSON.stringify(new errors.Forbidden('Delete of scheduled backup not permitted within retention period of 14 days'))
             }
-          }, 3);
+          }, 2);
           mocks.apiServerEventMesh.nockPatchResource('backup', 'defaultbackup', backup_guid, {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
           return chai.request(apps.external)
@@ -1559,7 +1559,7 @@ describe('service-fabrik-api-sf2.0', function () {
               state: 'deleted',
               response: '{}'
             }
-          }, 3);
+          }, 2);
           mocks.apiServerEventMesh.nockPatchResource('backup', 'defaultbackup', backup_guid, {});
           mocks.apiServerEventMesh.nockPatchResourceStatus('backup', 'defaultbackup', {});
           mocks.apiServerEventMesh.nockDeleteResource('backup', 'defaultbackup', backup_guid);

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -2,7 +2,7 @@
 
 const nock = require('nock');
 const apiserver = require('../../data-access-layer/eventmesh').apiServerClient;
-const apiServerHost = 'https://10.0.2.2:9443';
+const apiServerHost = 'https://127.0.0.1:9443';
 const CONST = require('../../common/constants');
 const logger = require('../../common/logger');
 
@@ -123,13 +123,13 @@ describe('eventmesh', () => {
         };
         nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload);
         return apiserver.createResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          options: {
-            opts: 'sample_options'
-          }
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            options: {
+              opts: 'sample_options'
+            }
+          })
           .then(res => {
             expect(res.statusCode).to.eql(201);
             expect(res.body).to.eql({});
@@ -153,14 +153,14 @@ describe('eventmesh', () => {
         };
         nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload);
         return apiserver.createResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          parentResourceId: 'deployment1',
-          options: {
-            opts: 'sample_options'
-          }
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            parentResourceId: 'deployment1',
+            options: {
+              opts: 'sample_options'
+            }
+          })
           .then(res => {
             expect(res.statusCode).to.eql(201);
             expect(res.body).to.eql({});
@@ -195,20 +195,20 @@ describe('eventmesh', () => {
         nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, {}, payload1);
         nockPatchResourceStatus(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload2);
         return apiserver.createResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          parentResourceId: 'deployment1',
-          options: {
-            opts: 'sample_options'
-          },
-          status: {
-            state: 'create',
-            response: {
-              resp: 'resp'
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            parentResourceId: 'deployment1',
+            options: {
+              opts: 'sample_options'
+            },
+            status: {
+              state: 'create',
+              response: {
+                resp: 'resp'
+              }
             }
-          }
-        })
+          })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql(expectedResponse);
@@ -235,14 +235,14 @@ describe('eventmesh', () => {
         };
         nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload1, 404);
         return apiserver.createResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          parentResourceId: 'deployment1',
-          options: {
-            opts: 'sample_options'
-          }
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            parentResourceId: 'deployment1',
+            options: {
+              opts: 'sample_options'
+            }
+          })
           .catch(err => {
             expect(err.status).to.eql(404);
             verify();
@@ -262,13 +262,13 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
         return apiserver.updateResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          options: {
-            opts: 'sample_options'
-          }
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            options: {
+              opts: 'sample_options'
+            }
+          })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -293,14 +293,14 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
         return apiserver.updateResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          metadata: payload.metadata,
-          options: {
-            opts: 'sample_options'
-          }
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            metadata: payload.metadata,
+            options: {
+              opts: 'sample_options'
+            }
+          })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -336,20 +336,20 @@ describe('eventmesh', () => {
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', {}, payload1);
         nockPatchResourceStatus(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload2);
         return apiserver.updateResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          metadata: payload1.metadata,
-          options: {
-            opts: 'sample_options'
-          },
-          status: {
-            state: 'create',
-            response: {
-              resp: 'resp'
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            metadata: payload1.metadata,
+            options: {
+              opts: 'sample_options'
+            },
+            status: {
+              state: 'create',
+              response: {
+                resp: 'resp'
+              }
             }
-          }
-        })
+          })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql(expectedResponse);
@@ -370,13 +370,13 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload1, 404);
         return apiserver.updateResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          options: {
-            opts: 'sample_options'
-          }
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            options: {
+              opts: 'sample_options'
+            }
+          })
           .catch(err => {
             expect(err.status).to.eql(404);
             verify();
@@ -405,14 +405,14 @@ describe('eventmesh', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetResponse);
         nockPatchResourceStatus(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
         return apiserver.patchResponse({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          response: {
-            resp: 'resp1',
-            resp2: 'resp2'
-          }
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            response: {
+              resp: 'resp1',
+              resp2: 'resp2'
+            }
+          })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -442,14 +442,14 @@ describe('eventmesh', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetResponse);
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
         return apiserver.patchOptions({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          options: {
-            opt: 'opt1',
-            opt2: 'opt2'
-          }
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            options: {
+              opt: 'opt1',
+              opt2: 'opt2'
+            }
+          })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -463,10 +463,10 @@ describe('eventmesh', () => {
         const expectedResponse = {};
         nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse);
         return apiserver.deleteResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+          })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -476,10 +476,10 @@ describe('eventmesh', () => {
       it('Throws error when delete fails', () => {
         nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', {}, 404);
         return apiserver.deleteResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+          })
           .catch(err => {
             expect(err.status).to.eql(404);
             verify();
@@ -499,13 +499,13 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
         return apiserver.updateLastOperation({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          operationName: CONST.OPERATION_TYPE.BACKUP,
-          operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-          value: 'backup1'
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            operationName: CONST.OPERATION_TYPE.BACKUP,
+            operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+            value: 'backup1'
+          })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -518,10 +518,10 @@ describe('eventmesh', () => {
       it('Gets resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
         return apiserver.getResource({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource);
             verify();
@@ -533,12 +533,12 @@ describe('eventmesh', () => {
       it('Gets last operation on resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
         return apiserver.getLastOperation({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          operationName: CONST.OPERATION_TYPE.BACKUP,
-          operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            operationName: CONST.OPERATION_TYPE.BACKUP,
+            operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP
+          })
           .then(res => {
             expect(res).to.eql('backup1');
             verify();
@@ -550,11 +550,11 @@ describe('eventmesh', () => {
       it('Gets options of resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
         return apiserver.getOptions({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          operationName: CONST.OPERATION_TYPE.BACKUP
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            operationName: CONST.OPERATION_TYPE.BACKUP
+          })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource.spec.options);
             verify();
@@ -566,11 +566,11 @@ describe('eventmesh', () => {
       it('Gets options of resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
         return apiserver.getResponse({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          operationName: CONST.OPERATION_TYPE.BACKUP
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            operationName: CONST.OPERATION_TYPE.BACKUP
+          })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource.status.response);
             verify();
@@ -582,11 +582,11 @@ describe('eventmesh', () => {
       it('Gets options of resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
         return apiserver.getState({
-          resourceId: 'deployment1',
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          operationName: CONST.OPERATION_TYPE.BACKUP
-        })
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            operationName: CONST.OPERATION_TYPE.BACKUP
+          })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource.status.state);
             verify();

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -498,7 +498,7 @@ describe('eventmesh', () => {
           }
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
-        return apiserver.updateLastOperation({
+        return apiserver.updateLastOperationValue({
             resourceId: 'deployment1',
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
@@ -532,7 +532,7 @@ describe('eventmesh', () => {
     describe('getLastOperation', () => {
       it('Gets last operation on resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
-        return apiserver.getLastOperation({
+        return apiserver.getLastOperationValue({
             resourceId: 'deployment1',
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -1,975 +1,997 @@
-'use strict';
+// 'use strict';
 
-const _ = require('lodash');
-const nock = require('nock');
-const apiserver = require('../../data-access-layer/eventmesh').apiServerClient;
-const apiServerHost = 'https://127.0.0.1:9443';
-const CONST = require('../../common/constants');
-const logger = require('../../common/logger');
+// const _ = require('lodash');
+// const nock = require('nock');
+// const apiserver = require('../../data-access-layer/eventmesh').apiServerClient;
+// const apiServerHost = 'https://10.0.2.2:9443';
+// const CONST = require('../../common/constants');
+// const logger = require('../../common/logger');
 
-const sampleLockResource = {
-  kind: 'DeploymentLock',
-  apiVersion: 'lock.servicefabrik.io/v1alpha1',
-  metadata: {
-    name: 'l1',
-    namespace: 'default',
-    selfLink: '/apis/lock.servicefabrik.io/v1alpha1/namespaces/default/deploymentlocks/l1',
-    uid: '54e02d6c-72b6-11e8-80fe-9801a7b45ddd',
-    resourceVersion: '1076',
-    generation: 1,
-    creationTimestamp: '2018-06-18T05:13:26Z'
-  },
-  spec: {
-    options: JSON.stringify({
-      'lockDetails': 'lockdetails'
-    })
-  },
-  status: {}
-};
+// const sampleLockResource = {
+//     kind: 'DeploymentLock',
+//     apiVersion: 'lock.servicefabrik.io/v1alpha1',
+//     metadata: {
+//         name: 'l1',
+//         namespace: 'default',
+//         selfLink: '/apis/lock.servicefabrik.io/v1alpha1/namespaces/default/deploymentlocks/l1',
+//         uid: '54e02d6c-72b6-11e8-80fe-9801a7b45ddd',
+//         resourceVersion: '1076',
+//         generation: 1,
+//         creationTimestamp: '2018-06-18T05:13:26Z'
+//     },
+//     spec: {
+//         options: JSON.stringify({
+//             'lockDetails': 'lockdetails'
+//         })
+//     },
+//     status: {}
+// };
 
-const sampleDeploymentResource = {
-  kind: 'Director',
-  apiVersion: 'deployment.servicefabrik.io/v1alpha1',
-  metadata: {
-    name: 'fakeResourceId',
-    namespace: 'default',
-    selfLink: '/apis/deployment.servicefabrik.io/v1alpha1/namespaces/default/directors/fakeResourceId',
-    uid: '54e02d6c-72b6-11e8-80fe-9801a7b45ddd',
-    resourceVersion: '1076',
-    generation: 1,
-    creationTimestamp: '2018-06-18T05:13:26Z'
-  },
-  spec: {
-    options: 'sample_options'
-  },
-  status: {
-    state: 'in_progress'
-  }
-};
+// const sampleDeploymentResource = {
+//     kind: 'Director',
+//     apiVersion: 'deployment.servicefabrik.io/v1alpha1',
+//     metadata: {
+//         name: 'fakeResourceId',
+//         namespace: 'default',
+//         selfLink: '/apis/deployment.servicefabrik.io/v1alpha1/namespaces/default/directors/fakeResourceId',
+//         uid: '54e02d6c-72b6-11e8-80fe-9801a7b45ddd',
+//         resourceVersion: '1076',
+//         generation: 1,
+//         creationTimestamp: '2018-06-18T05:13:26Z'
+//     },
+//     spec: {
+//         options: 'sample_options'
+//     },
+//     status: {
+//         state: 'in_progress'
+//     }
+// };
 
-const sampleBackupResource = {
-  kind: 'DefaultBackup',
-  apiVersion: 'backup.servicefabrik.io/v1alpha1',
-  metadata: {
-    name: 'fakeOperationId',
-    namespace: 'default',
-    selfLink: '/apis/backup.servicefabrik.io/v1alpha1/namespaces/default/defaultbackups/fakeOperationId',
-    uid: '54e02d6c-72b6-11e8-80fe-9801a7b45ddd',
-    resourceVersion: '1076',
-    generation: 1,
-    creationTimestamp: '2018-06-18T05:13:26Z'
-  },
-  spec: {
-    options: 'sample_options'
-  },
-  status: {
-    state: 'defaultState',
-    error: JSON.stringify({
-      name: 'defaultErrorObj'
-    }),
-    response: JSON.stringify({
-      name: 'defaultResponseObj'
-    }),
-  }
-};
+// const sampleBackupResource = {
+//     kind: 'DefaultBackup',
+//     apiVersion: 'backup.servicefabrik.io/v1alpha1',
+//     metadata: {
+//         name: 'fakeOperationId',
+//         namespace: 'default',
+//         selfLink: '/apis/backup.servicefabrik.io/v1alpha1/namespaces/default/defaultbackups/fakeOperationId',
+//         uid: '54e02d6c-72b6-11e8-80fe-9801a7b45ddd',
+//         resourceVersion: '1076',
+//         generation: 1,
+//         creationTimestamp: '2018-06-18T05:13:26Z'
+//     },
+//     spec: {
+//         options: 'sample_options'
+//     },
+//     status: {
+//         state: 'defaultState',
+//         error: JSON.stringify({
+//             name: 'defaultErrorObj'
+//         }),
+//         response: JSON.stringify({
+//             name: 'defaultResponseObj'
+//         }),
+//     }
+// };
 
-function verify() {
-  /* jshint expr:true */
-  if (!nock.isDone()) {
-    // console.log('pending mocks: %j', nock.pendingMocks());
-    logger.error('pending mocks: %j', nock.pendingMocks());
-  }
-  expect(nock.isDone()).to.be.true;
-}
+// function verify() {
+//     /* jshint expr:true */
+//     if (!nock.isDone()) {
+//         // console.log('pending mocks: %j', nock.pendingMocks());
+//         logger.error('pending mocks: %j', nock.pendingMocks());
+//     }
+//     expect(nock.isDone()).to.be.true;
+// }
 
-function nockGetResource(resourceGroup, resourceType, id, response, expectedExpectedCode) {
-  nock(apiServerHost)
-    .get(`/apis/${resourceGroup}.servicefabrik.io/v1alpha1/namespaces/default/${resourceType}s/${id}`)
-    .reply(expectedExpectedCode || 200, response);
-}
+// function nockGetResource(resourceGroup, resourceType, id, response, expectedExpectedCode) {
+//     nock(apiServerHost)
+//         .get(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s/${id}`)
+//         .reply(expectedExpectedCode || 200, response);
+// }
 
-function nockPatchResourceStatus(resourceGroup, resourceType, id, response, payload, expectedExpectedCode) {
-  nock(apiServerHost)
-    .patch(`/apis/${resourceGroup}.servicefabrik.io/v1alpha1/namespaces/default/${resourceType}s/${id}/status`, payload)
-    .reply(expectedExpectedCode || 200, response);
-}
+// function nockPatchResourceStatus(resourceGroup, resourceType, id, response, payload, expectedExpectedCode) {
+//     nock(apiServerHost)
+//         .patch(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s/${id}/status`, payload)
+//         .reply(expectedExpectedCode || 200, response);
+// }
 
-function nockPatchResource(resourceGroup, resourceType, id, response, payload, expectedExpectedCode) {
-  nock(apiServerHost)
-    .patch(`/apis/${resourceGroup}.servicefabrik.io/v1alpha1/namespaces/default/${resourceType}s/${id}`, payload)
-    .reply(expectedExpectedCode || 200, response);
-}
+// function nockPatchResource(resourceGroup, resourceType, id, response, payload, expectedExpectedCode) {
+//     nock(apiServerHost)
+//         .patch(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s/${id}`, payload)
+//         .reply(expectedExpectedCode || 200, response);
+// }
 
-function nockCreateResource(resourceGroup, resourceType, response, payload, expectedExpectedCode) {
-  nock(apiServerHost)
-    .post(`/apis/${resourceGroup}.servicefabrik.io/v1alpha1/namespaces/default/${resourceType}s`, payload)
-    .reply(expectedExpectedCode || 201, response);
-}
+// function nockCreateResource(resourceGroup, resourceType, response, payload, expectedExpectedCode) {
+//     nock(apiServerHost)
+//         .post(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s`, payload)
+//         .reply(expectedExpectedCode || 201, response);
+// }
 
-function nockDeleteResource(resourceGroup, resourceType, id, response, expectedExpectedCode) {
-  nock(apiServerHost)
-    .delete(`/apis/${resourceGroup}.servicefabrik.io/v1alpha1/namespaces/default/${resourceType}s/${id}`)
-    .reply(expectedExpectedCode || 200, response);
-}
+// function nockDeleteResource(resourceGroup, resourceType, id, response, expectedExpectedCode) {
+//     nock(apiServerHost)
+//         .delete(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s/${id}`)
+//         .reply(expectedExpectedCode || 200, response);
+// }
 
-describe('eventmesh', () => {
-  describe('ApiServerClient', () => {
+// describe('eventmesh', () => {
+//     describe('ApiServerClient', () => {
 
-    afterEach(() => {
-      nock.cleanAll();
-    });
-    describe('parseResourceDetailsFromSelfLink', () => {
-      it('Should parse resource details from selflink', () => {
-        const selfLink = '/apis/deployment.servicefabrik.io/v1alpha1/namespaces/default/directors/sample_director';
-        const resourceDetails = apiserver.parseResourceDetailsFromSelfLink(selfLink);
-        expect(resourceDetails).to.deep.eql({
-          resourceGroup: 'deployment',
-          resourceType: 'directors'
-        });
-      });
-    });
+//         afterEach(() => {
+//             nock.cleanAll();
+//         });
+//         describe('parseResourceDetailsFromSelfLink', () => {
+//             it('Should parse resource details from selflink', () => {
+//                 const selfLink = '/apis/deployment.servicefabrik.io/v1alpha1/namespaces/default/directors/sample_director';
+//                 const resourceDetails = apiserver.parseResourceDetailsFromSelfLink(selfLink);
+//                 expect(resourceDetails).to.deep.eql({
+//                     resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+//                     resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+//                 });
+//             });
+//         });
 
-    describe('createLockResource', () => {
-      it('calls the post rest api to create lock type resource', done => {
-        nockCreateResource('lock', 'deploymentlock', sampleLockResource);
-        apiserver.createLock('deploymentlock', sampleLockResource)
-          .then(res => {
-            expect(res.statusCode).to.eql(201);
-            expect(res.body).to.eql(sampleLockResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockCreateResource('lock', 'deploymentlock', sampleLockResource, undefined, 409);
-        return apiserver.createLock('deploymentlock', sampleLockResource)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('createResource', () => {
+//             it.only('Creates resource without label and status', () => {
+//                 nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, );
+//                 apiserver.createResource('deploymentlock', sampleLockResource)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(201);
+//                         expect(res.body).to.eql(sampleLockResource);
+//                         done();
+//                         verify();
+//                     });
+//             });
 
-    describe('createResource', () => {
-      it('throws error if api call is errored', done => {
-        nockCreateResource('lock', 'deploymentlock', sampleLockResource, undefined, 409);
-        return apiserver._createResource('lock', 'deploymentlock', sampleLockResource)
-          .catch(err => {
-            expect(err.code).to.eql(409);
-            done();
-          });
-      });
-    });
+//             it('throws error if api call is errored', done => {
+//                 nockCreateResource('lock', 'deploymentlock', sampleLockResource, undefined, 409);
+//                 return apiserver._createResource('lock', 'deploymentlock', sampleLockResource)
+//                     .catch(err => {
+//                         expect(err.code).to.eql(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-    describe('deleteLock', () => {
-      const deleteLockResponse = {
-        kind: 'Status',
-        apiVersion: 'v1',
-        metadata: {},
-        status: 'Success',
-        details: {
-          name: 'l1',
-          group: 'lock.servicefabrik.io',
-          kind: 'deploymentlocks',
-          uid: '3576eca0-72b7-11e8-80fe-9801a7b45ddd'
-        }
-      };
-      it('calls the delete rest api to delete lock type resource', done => {
-        nockDeleteResource('lock', 'deploymentlock', 'l1', deleteLockResponse);
-        apiserver.deleteLock('deploymentlock', 'l1')
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(deleteLockResponse);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockDeleteResource('lock', 'deploymentlock', 'l1', deleteLockResponse, 409);
-        return apiserver.deleteLock('deploymentlock', 'l1')
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('createLockResource', () => {
+//             it('calls the post rest api to create lock type resource', done => {
+//                 nockCreateResource('lock', 'deploymentlock', sampleLockResource);
+//                 apiserver.createResource('deploymentlock', sampleLockResource)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(201);
+//                         expect(res.body).to.eql(sampleLockResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockCreateResource('lock', 'deploymentlock', sampleLockResource, undefined, 409);
+//                 return apiserver.createLock('deploymentlock', sampleLockResource)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-    describe('updateResource', () => {
-      it('calls the patch rest api to edit lock type resource', done => {
-        nockPatchResource('lock', 'deploymentlock', 'l1', sampleLockResource);
-        apiserver.updateResource('lock', 'deploymentlock', 'l1', {
-            spec: {
-              options: sampleLockResource.spec.options
-            }
-          })
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(sampleLockResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        const spec = {
-          spec: {
-            options: sampleLockResource.spec.options
-          }
-        };
-        nockPatchResource('lock', 'deploymentlock', 'l1', sampleLockResource, spec, 409);
-        return apiserver.updateResource('lock', 'deploymentlock', 'l1', spec)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('createResource', () => {
+//             it('throws error if api call is errored', done => {
+//                 nockCreateResource('lock', 'deploymentlock', sampleLockResource, undefined, 409);
+//                 return apiserver._createResource('lock', 'deploymentlock', sampleLockResource)
+//                     .catch(err => {
+//                         expect(err.code).to.eql(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-    describe('getLockDetails', () => {
-      it('returns options of the lock resource', done => {
-        nockGetResource('lock', 'deploymentlock', 'l1', sampleLockResource);
-        apiserver.getLockDetails('deploymentlock', 'l1')
-          .then(res => {
-            expect(res).to.eql(JSON.parse(sampleLockResource.spec.options));
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockGetResource('lock', 'deploymentlock', 'l1', sampleLockResource, 409);
-        return apiserver.getLockDetails('deploymentlock', 'l1')
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('deleteLock', () => {
+//             const deleteLockResponse = {
+//                 kind: 'Status',
+//                 apiVersion: 'v1',
+//                 metadata: {},
+//                 status: 'Success',
+//                 details: {
+//                     name: 'l1',
+//                     group: 'lock.servicefabrik.io',
+//                     kind: 'deploymentlocks',
+//                     uid: '3576eca0-72b7-11e8-80fe-9801a7b45ddd'
+//                 }
+//             };
+//             it('calls the delete rest api to delete lock type resource', done => {
+//                 nockDeleteResource('lock', 'deploymentlock', 'l1', deleteLockResponse);
+//                 apiserver.deleteLock('deploymentlock', 'l1')
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(deleteLockResponse);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockDeleteResource('lock', 'deploymentlock', 'l1', deleteLockResponse, 409);
+//                 return apiserver.deleteLock('deploymentlock', 'l1')
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-    describe('getResource', () => {
-      it('returns the specified resource', done => {
-        nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource);
-        apiserver.getResource('deployment', 'director', 'fakeResourceId')
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(sampleDeploymentResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource, 409);
-        return apiserver.getResource('deployment', 'director', 'fakeResourceId')
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('updateResource', () => {
+//             it('calls the patch rest api to edit lock type resource', done => {
+//                 nockPatchResource('lock', 'deploymentlock', 'l1', sampleLockResource);
+//                 apiserver.updateResource('lock', 'deploymentlock', 'l1', {
+//                     spec: {
+//                         options: sampleLockResource.spec.options
+//                     }
+//                 })
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(sampleLockResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 const spec = {
+//                     spec: {
+//                         options: sampleLockResource.spec.options
+//                     }
+//                 };
+//                 nockPatchResource('lock', 'deploymentlock', 'l1', sampleLockResource, spec, 409);
+//                 return apiserver.updateResource('lock', 'deploymentlock', 'l1', spec)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-    describe('createDeployment', () => {
-      const resourceId = 'fakeResourceId';
-      const val = {
-        key: 'value'
-      };
-      const input = {
-        metadata: {
-          name: `${resourceId}`,
-          labels: {
-            instance_guid: `${resourceId}`,
-          }
-        },
-        spec: {
-          options: JSON.stringify(val)
-        },
-      };
+//         describe('getLockDetails', () => {
+//             it('returns options of the lock resource', done => {
+//                 nockGetResource('lock', 'deploymentlock', 'l1', sampleLockResource);
+//                 apiserver.getLockDetails('deploymentlock', 'l1')
+//                     .then(res => {
+//                         expect(res).to.eql(JSON.parse(sampleLockResource.spec.options));
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockGetResource('lock', 'deploymentlock', 'l1', sampleLockResource, 409);
+//                 return apiserver.getLockDetails('deploymentlock', 'l1')
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-      const statusJson = {
-        status: {
-          state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-          lastOperation: 'created',
-          response: JSON.stringify({})
-        }
-      };
-      const finalResource = _.assign({
-        status: {
-          state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-          lastOperation: 'created',
-          response: JSON.stringify({})
-        }
-      }, sampleDeploymentResource);
+//         describe('getResource', () => {
+//             it('returns the specified resource', done => {
+//                 nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource);
+//                 apiserver.getResource('deployment', 'director', 'fakeResourceId')
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(sampleDeploymentResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource, 409);
+//                 return apiserver.getResource('deployment', 'director', 'fakeResourceId')
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-      it('Creates a resource', done => {
-        nockCreateResource('deployment', 'director', sampleDeploymentResource, input);
-        nockPatchResourceStatus('deployment', 'director', 'fakeResourceId', finalResource, statusJson);
-        apiserver.createDeployment(resourceId, val)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockCreateResource('deployment', 'director', sampleDeploymentResource, input, 409);
-        return apiserver.createDeployment(resourceId, val)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('createDeployment', () => {
+//             const resourceId = 'fakeResourceId';
+//             const val = {
+//                 key: 'value'
+//             };
+//             const input = {
+//                 metadata: {
+//                     name: `${resourceId}`,
+//                     labels: {
+//                         instance_guid: `${resourceId}`,
+//                     }
+//                 },
+//                 spec: {
+//                     options: JSON.stringify(val)
+//                 },
+//             };
 
-    describe('_updateResourceState', () => {
-      it('updates the specified resource state', done => {
-        nockPatchResourceStatus('deployment', 'director', 'fakeResourceId', sampleDeploymentResource);
-        apiserver._updateResourceState('director', 'fakeResourceId', sampleDeploymentResource.status.state)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(sampleDeploymentResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockPatchResourceStatus('deployment', 'director', 'fakeResourceId', sampleDeploymentResource, undefined, 409);
-        return apiserver._updateResourceState('director', 'fakeResourceId', sampleDeploymentResource.status.state)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//             const statusJson = {
+//                 status: {
+//                     state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
+//                     lastOperation: 'created',
+//                     response: JSON.stringify({})
+//                 }
+//             };
+//             const finalResource = _.assign({
+//                 status: {
+//                     state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
+//                     lastOperation: 'created',
+//                     response: JSON.stringify({})
+//                 }
+//             }, sampleDeploymentResource);
 
-    describe('getResourceState', () => {
-      it('gets the specified resource state', done => {
-        nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource);
-        apiserver.getResourceState('director', 'fakeResourceId')
-          .then(res => {
-            expect(res).to.eql(sampleDeploymentResource.status.state);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource, 409);
-        return apiserver.getResourceState('director', 'fakeResourceId')
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//             it('Creates a resource', done => {
+//                 nockCreateResource('deployment', 'director', sampleDeploymentResource, input);
+//                 nockPatchResourceStatus('deployment', 'director', 'fakeResourceId', finalResource, statusJson);
+//                 apiserver.createDeployment(resourceId, val)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockCreateResource('deployment', 'director', sampleDeploymentResource, input, 409);
+//                 return apiserver.createDeployment(resourceId, val)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-    describe('createOperation', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackups',
-        operationId: 'fakeOperationId',
-        value: {
-          key: 'value'
-        }
-      };
-      const input = {
-        metadata: {
-          name: `${opts.operationId}`,
-          labels: {
-            instance_guid: `${opts.resourceId}`,
-          },
-        },
-        spec: {
-          options: JSON.stringify(opts.value)
-        },
-      };
+//         describe('_updateResourceState', () => {
+//             it('updates the specified resource state', done => {
+//                 nockPatchResourceStatus('deployment', 'director', 'fakeResourceId', sampleDeploymentResource);
+//                 apiserver._updateResourceState('director', 'fakeResourceId', sampleDeploymentResource.status.state)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(sampleDeploymentResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockPatchResourceStatus('deployment', 'director', 'fakeResourceId', sampleDeploymentResource, undefined, 409);
+//                 return apiserver._updateResourceState('director', 'fakeResourceId', sampleDeploymentResource.status.state)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-      const statusJson = {
-        status: {
-          state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-          lastOperation: 'created',
-          response: JSON.stringify({})
-        }
-      };
-      const finalResource = _.assign({
-        status: {
-          state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-          lastOperation: '',
-          response: ''
-        }
-      }, sampleBackupResource);
-      it('Creates an operation of a resource', done => {
-        nockCreateResource('backup', 'defaultbackup', sampleBackupResource, input);
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, statusJson);
-        apiserver.createOperation(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockCreateResource('backup', 'defaultbackup', sampleBackupResource, input, 409);
-        return apiserver.createOperation(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('getResourceState', () => {
+//             it('gets the specified resource state', done => {
+//                 nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource);
+//                 apiserver.getResourceState('director', 'fakeResourceId')
+//                     .then(res => {
+//                         expect(res).to.eql(sampleDeploymentResource.status.state);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource, 409);
+//                 return apiserver.getResourceState('director', 'fakeResourceId')
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-    describe('updateOperationError', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        operationId: 'fakeOperationId',
-        error: {
-          key: 'value'
-        }
-      };
-      const payload = {
-        status: {
-          error: JSON.stringify(opts.error),
-        }
-      };
-      const response = _.assign({
-        status: {
-          error: JSON.stringify(opts.error)
-        }
-      }, sampleBackupResource);
-      it('patches the operation error', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', response, payload);
-        apiserver.updateOperationError(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(response);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', response, payload, 409);
-        return apiserver.updateOperationError(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('createOperation', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackups',
+//                 operationId: 'fakeOperationId',
+//                 value: {
+//                     key: 'value'
+//                 }
+//             };
+//             const input = {
+//                 metadata: {
+//                     name: `${opts.operationId}`,
+//                     labels: {
+//                         instance_guid: `${opts.resourceId}`,
+//                     },
+//                 },
+//                 spec: {
+//                     options: JSON.stringify(opts.value)
+//                 },
+//             };
 
-    describe('updateOperationResponse', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        operationId: 'fakeOperationId',
-        value: {
-          key: 'value'
-        }
-      };
-      const input = {
-        status: {
-          response: JSON.stringify(opts.value),
-        }
-      };
-      const finalResource = _.assign({
-        status: {
-          response: JSON.stringify(opts.value)
-        }
-      }, sampleBackupResource);
-      it('updates the operation result', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-        apiserver.updateOperationResponse(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input, 409);
-        return apiserver.updateOperationResponse(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//             const statusJson = {
+//                 status: {
+//                     state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
+//                     lastOperation: 'created',
+//                     response: JSON.stringify({})
+//                 }
+//             };
+//             const finalResource = _.assign({
+//                 status: {
+//                     state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
+//                     lastOperation: '',
+//                     response: ''
+//                 }
+//             }, sampleBackupResource);
+//             it('Creates an operation of a resource', done => {
+//                 nockCreateResource('backup', 'defaultbackup', sampleBackupResource, input);
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, statusJson);
+//                 apiserver.createOperation(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockCreateResource('backup', 'defaultbackup', sampleBackupResource, input, 409);
+//                 return apiserver.createOperation(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-    describe('updateOperationStateAndResponse', () => {
-      const opts = {
-        resourceId: 'resource-guid',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        operationId: 'operation-guid',
-        stateValue: 'fakeState',
-        response: {
-          key: 'fakeValue'
-        }
-      };
-      const payload = {
-        status: {
-          state: opts.stateValue,
-          response: JSON.stringify(opts.response),
-        }
-      };
-      const finalResource = _.assign({
-        status: {
-          state: opts.stateValue,
-          response: JSON.stringify(opts.response),
-        }
-      }, sampleBackupResource);
-      it('updates the operation state and response', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', 'operation-guid', finalResource, payload);
-        apiserver.updateOperationStateAndResponse(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', opts.operationId, finalResource, payload, 409);
-        return apiserver.updateOperationStateAndResponse(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('updateOperationError', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 operationId: 'fakeOperationId',
+//                 error: {
+//                     key: 'value'
+//                 }
+//             };
+//             const payload = {
+//                 status: {
+//                     error: JSON.stringify(opts.error),
+//                 }
+//             };
+//             const response = _.assign({
+//                 status: {
+//                     error: JSON.stringify(opts.error)
+//                 }
+//             }, sampleBackupResource);
+//             it('patches the operation error', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', response, payload);
+//                 apiserver.updateOperationError(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(response);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', response, payload, 409);
+//                 return apiserver.updateOperationError(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
+//         describe('updateOperationResponse', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 operationId: 'fakeOperationId',
+//                 value: {
+//                     key: 'value'
+//                 }
+//             };
+//             const input = {
+//                 status: {
+//                     response: JSON.stringify(opts.value),
+//                 }
+//             };
+//             const finalResource = _.assign({
+//                 status: {
+//                     response: JSON.stringify(opts.value)
+//                 }
+//             }, sampleBackupResource);
+//             it('updates the operation result', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
+//                 apiserver.updateOperationResponse(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input, 409);
+//                 return apiserver.updateOperationResponse(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
-    describe('updateOperationState', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        operationId: 'fakeOperationId',
-        stateValue: 'in_progress'
-      };
-      const input = {
-        status: {
-          state: opts.stateValue
-        }
-      };
-      const finalResource = _.assign({
-        status: {
-          state: opts.stateValue
-        }
-      }, sampleBackupResource);
-      it('updates the operation state', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-        apiserver.updateOperationState(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input, 409);
-        return apiserver.updateOperationState(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
-
-    describe('updateLastOperation', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        value: 'fakeOperationId'
-      };
-      const input = {};
-      input.metadata = {};
-      input.metadata.labels = {};
-      input.metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = opts.value;
-      const finalResource = _.cloneDeep(sampleDeploymentResource);
-      _.assign(finalResource, input);
-
-      it('updates the last operation value', done => {
-        nockPatchResource('deployment', 'director', 'fakeResourceId', finalResource, input);
-        apiserver.updateLastOperation(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockPatchResource('deployment', 'director', 'fakeResourceId', finalResource, input, 409);
-        return apiserver.updateLastOperation(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-
-    });
-
-    describe('getLastOperation', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup'
-      };
-      const input = {};
-      input.metadata = {};
-      input.metadata.labels = {};
-      input.metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = 'fakeOperationId';
-      const finalResource = _.cloneDeep(sampleDeploymentResource);
-      _.assign(finalResource, input);
-      it('gets the last operation value', done => {
-        nockGetResource('deployment', 'director', 'fakeResourceId', finalResource);
-        apiserver.getLastOperation(opts)
-          .then(res => {
-            expect(res).to.eql('fakeOperationId');
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockGetResource('deployment', 'director', 'fakeResourceId', finalResource, 409);
-        return apiserver.getLastOperation(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
-
-    describe('getOperationOptions', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        operationId: 'fakeOperationId'
-      };
-      const input = {};
-      input.spec = {};
-      const options = {
-        'options': 'opt'
-      };
-      input.spec.options = JSON.stringify(options);
-      const finalResource = _.cloneDeep(sampleDeploymentResource);
-      _.assign(finalResource, input);
-      it('gets the last operation options', done => {
-        nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
-        apiserver.getOperationOptions(opts)
-          .then(res => {
-            expect(res).to.eql(options);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
-        return apiserver.getOperationOptions(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
-
-    describe('getOperationState', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        operationId: 'fakeOperationId'
-      };
-      const input = {};
-      input.status = {};
-      input.status.state = 'in_progress';
-      const finalResource = _.cloneDeep(sampleDeploymentResource);
-      _.assign(finalResource, input);
-      it('gets the last operation state', done => {
-        nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
-        apiserver.getOperationState(opts)
-          .then(res => {
-            expect(res).to.eql('in_progress');
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
-        return apiserver.getOperationState(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
-
-    describe('getOperationResponse', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        operationId: 'fakeOperationId'
-      };
-      const input = {};
-      input.status = {};
-      const response = {
-        'response': 'res'
-      };
-      input.status.response = JSON.stringify(response);
-      const finalResource = _.cloneDeep(sampleDeploymentResource);
-      _.assign(finalResource, input);
-      it('gets the last operation Result', done => {
-        nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
-        apiserver.getOperationResponse(opts)
-          .then(res => {
-            expect(res).to.eql(response);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
-        return apiserver.getOperationResponse(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
-
-    describe('#getOperationStatus', () => {
-      const opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        operationId: 'fakeOperationId'
-      };
-      const finalResource = _.cloneDeep(sampleDeploymentResource);
-      it('gets the operation status', done => {
-        nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
-        apiserver.getOperationStatus(opts)
-          .then(res => {
-            expect(res).to.eql({
-              state: 'in_progress'
-            });
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
-        return apiserver.getOperationStatus(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
-
-    describe('#updateOperationStatus', () => {
-      let opts = {
-        resourceId: 'fakeResourceId',
-        operationName: 'backup',
-        operationType: 'defaultbackup',
-        operationId: 'fakeOperationId',
-        stateValue: 'in_progress',
-      };
-      let input = {
-        status: {
-          state: opts.stateValue,
-        }
-      };
-      let finalResource = _
-        .chain(sampleBackupResource)
-        .cloneDeep()
-        .value();
-      _.assign(finalResource.status, input.status);
-      it('updates the operation status', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-        apiserver.updateOperationStatus(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            expect(res.body.status.state).to.eql(opts.stateValue);
-            expect(res.body.status.error).to.eql(sampleBackupResource.status.error);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('updates the operation status and error if both are present', done => {
-        opts = {
-          resourceId: 'fakeResourceId',
-          operationName: 'backup',
-          operationType: 'defaultbackup',
-          operationId: 'fakeOperationId',
-          stateValue: 'in_progress',
-          error: {
-            name: 'errorVal'
-          }
-        };
-        input = {
-          status: {
-            state: opts.stateValue,
-            error: JSON.stringify(opts.error)
-          }
-        };
-        finalResource = _
-          .chain(sampleBackupResource)
-          .cloneDeep()
-          .value();
-        _.assign(finalResource.status, input.status);
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-        apiserver.updateOperationStatus(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            expect(res.body.status.state).to.eql(opts.stateValue);
-            expect(res.body.status.error).to.eql(JSON.stringify(opts.error));
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('updates the operation error only and retain state', done => {
-        opts = {
-          resourceId: 'fakeResourceId',
-          operationName: 'backup',
-          operationType: 'defaultbackup',
-          operationId: 'fakeOperationId',
-          error: {
-            name: 'errorVal'
-          }
-        };
-        input = {
-          status: {
-            error: JSON.stringify(opts.error)
-          }
-        };
-        finalResource = _
-          .chain(sampleBackupResource)
-          .cloneDeep()
-          .value();
-        _.assign(finalResource.status, input.status);
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-        apiserver.updateOperationStatus(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            expect(res.body.status.state).to.eql(sampleBackupResource.status.state);
-            expect(res.body.status.error).to.eql(JSON.stringify(opts.error));
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('updates the operation response only and retain state and error', done => {
-        opts = {
-          resourceId: 'fakeResourceId',
-          operationName: 'backup',
-          operationType: 'defaultbackup',
-          operationId: 'fakeOperationId',
-          response: {
-            name: 'fakeResponse'
-          }
-        };
-        input = {
-          status: {
-            response: JSON.stringify(opts.response)
-          }
-        };
-        finalResource = _
-          .chain(sampleBackupResource)
-          .cloneDeep()
-          .value();
-        _.assign(finalResource.status, input.status);
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-        apiserver.updateOperationStatus(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            expect(res.body.status.state).to.eql(sampleBackupResource.status.state);
-            expect(res.body.status.error).to.eql(sampleBackupResource.status.error);
-            expect(res.body.status.response).to.eql(JSON.stringify(opts.response));
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('updates the operation response, state and error', done => {
-        opts = {
-          resourceId: 'fakeResourceId',
-          operationName: 'backup',
-          operationType: 'defaultbackup',
-          operationId: 'fakeOperationId',
-          response: {
-            name: 'fakeResponse'
-          },
-          stateValue: 'fakeState',
-          error: {
-            name: 'errorVal'
-          }
-        };
-        input = {
-          status: {
-            response: JSON.stringify(opts.response),
-            state: opts.stateValue,
-            error: JSON.stringify(opts.error)
-          }
-        };
-        finalResource = _
-          .chain(sampleBackupResource)
-          .cloneDeep()
-          .value();
-        _.assign(finalResource.status, input.status);
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-        apiserver.updateOperationStatus(opts)
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql(finalResource);
-            expect(res.body.status.state).to.eql(input.status.state);
-            expect(res.body.status.error).to.eql(input.status.error);
-            expect(res.body.status.response).to.eql(input.status.response);
-            done();
-            verify();
-          })
-          .catch(done);
-      });
-      it('throws error if api call is errored', done => {
-        nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input, 409);
-        return apiserver.updateOperationStatus(opts)
-          .catch(err => {
-            expect(err).to.have.status(409);
-            done();
-          });
-      });
-    });
+//         describe('updateOperationStateAndResponse', () => {
+//             const opts = {
+//                 resourceId: 'resource-guid',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 operationId: 'operation-guid',
+//                 stateValue: 'fakeState',
+//                 response: {
+//                     key: 'fakeValue'
+//                 }
+//             };
+//             const payload = {
+//                 status: {
+//                     state: opts.stateValue,
+//                     response: JSON.stringify(opts.response),
+//                 }
+//             };
+//             const finalResource = _.assign({
+//                 status: {
+//                     state: opts.stateValue,
+//                     response: JSON.stringify(opts.response),
+//                 }
+//             }, sampleBackupResource);
+//             it('updates the operation state and response', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'operation-guid', finalResource, payload);
+//                 apiserver.updateOperationStateAndResponse(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', opts.operationId, finalResource, payload, 409);
+//                 return apiserver.updateOperationStateAndResponse(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
 
 
-  });
-});
+//         describe('updateOperationState', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 operationId: 'fakeOperationId',
+//                 stateValue: 'in_progress'
+//             };
+//             const input = {
+//                 status: {
+//                     state: opts.stateValue
+//                 }
+//             };
+//             const finalResource = _.assign({
+//                 status: {
+//                     state: opts.stateValue
+//                 }
+//             }, sampleBackupResource);
+//             it('updates the operation state', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
+//                 apiserver.updateOperationState(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input, 409);
+//                 return apiserver.updateOperationState(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
+
+//         describe('updateLastOperation', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 value: 'fakeOperationId'
+//             };
+//             const input = {};
+//             input.metadata = {};
+//             input.metadata.labels = {};
+//             input.metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = opts.value;
+//             const finalResource = _.cloneDeep(sampleDeploymentResource);
+//             _.assign(finalResource, input);
+
+//             it('updates the last operation value', done => {
+//                 nockPatchResource('deployment', 'director', 'fakeResourceId', finalResource, input);
+//                 apiserver.updateLastOperation(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockPatchResource('deployment', 'director', 'fakeResourceId', finalResource, input, 409);
+//                 return apiserver.updateLastOperation(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+
+//         });
+
+//         describe('getLastOperation', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup'
+//             };
+//             const input = {};
+//             input.metadata = {};
+//             input.metadata.labels = {};
+//             input.metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = 'fakeOperationId';
+//             const finalResource = _.cloneDeep(sampleDeploymentResource);
+//             _.assign(finalResource, input);
+//             it('gets the last operation value', done => {
+//                 nockGetResource('deployment', 'director', 'fakeResourceId', finalResource);
+//                 apiserver.getLastOperation(opts)
+//                     .then(res => {
+//                         expect(res).to.eql('fakeOperationId');
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockGetResource('deployment', 'director', 'fakeResourceId', finalResource, 409);
+//                 return apiserver.getLastOperation(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
+
+//         describe('getOperationOptions', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 operationId: 'fakeOperationId'
+//             };
+//             const input = {};
+//             input.spec = {};
+//             const options = {
+//                 'options': 'opt'
+//             };
+//             input.spec.options = JSON.stringify(options);
+//             const finalResource = _.cloneDeep(sampleDeploymentResource);
+//             _.assign(finalResource, input);
+//             it('gets the last operation options', done => {
+//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
+//                 apiserver.getOperationOptions(opts)
+//                     .then(res => {
+//                         expect(res).to.eql(options);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
+//                 return apiserver.getOperationOptions(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
+
+//         describe('getOperationState', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 operationId: 'fakeOperationId'
+//             };
+//             const input = {};
+//             input.status = {};
+//             input.status.state = 'in_progress';
+//             const finalResource = _.cloneDeep(sampleDeploymentResource);
+//             _.assign(finalResource, input);
+//             it('gets the last operation state', done => {
+//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
+//                 apiserver.getOperationState(opts)
+//                     .then(res => {
+//                         expect(res).to.eql('in_progress');
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
+//                 return apiserver.getOperationState(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
+
+//         describe('getOperationResponse', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 operationId: 'fakeOperationId'
+//             };
+//             const input = {};
+//             input.status = {};
+//             const response = {
+//                 'response': 'res'
+//             };
+//             input.status.response = JSON.stringify(response);
+//             const finalResource = _.cloneDeep(sampleDeploymentResource);
+//             _.assign(finalResource, input);
+//             it('gets the last operation Result', done => {
+//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
+//                 apiserver.getOperationResponse(opts)
+//                     .then(res => {
+//                         expect(res).to.eql(response);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
+//                 return apiserver.getOperationResponse(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
+
+//         describe('#getOperationStatus', () => {
+//             const opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 operationId: 'fakeOperationId'
+//             };
+//             const finalResource = _.cloneDeep(sampleDeploymentResource);
+//             it('gets the operation status', done => {
+//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
+//                 apiserver.getOperationStatus(opts)
+//                     .then(res => {
+//                         expect(res).to.eql({
+//                             state: 'in_progress'
+//                         });
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
+//                 return apiserver.getOperationStatus(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
+
+//         describe('#updateOperationStatus', () => {
+//             let opts = {
+//                 resourceId: 'fakeResourceId',
+//                 operationName: 'backup',
+//                 operationType: 'defaultbackup',
+//                 operationId: 'fakeOperationId',
+//                 stateValue: 'in_progress',
+//             };
+//             let input = {
+//                 status: {
+//                     state: opts.stateValue,
+//                 }
+//             };
+//             let finalResource = _
+//                 .chain(sampleBackupResource)
+//                 .cloneDeep()
+//                 .value();
+//             _.assign(finalResource.status, input.status);
+//             it('updates the operation status', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
+//                 apiserver.updateOperationStatus(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         expect(res.body.status.state).to.eql(opts.stateValue);
+//                         expect(res.body.status.error).to.eql(sampleBackupResource.status.error);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('updates the operation status and error if both are present', done => {
+//                 opts = {
+//                     resourceId: 'fakeResourceId',
+//                     operationName: 'backup',
+//                     operationType: 'defaultbackup',
+//                     operationId: 'fakeOperationId',
+//                     stateValue: 'in_progress',
+//                     error: {
+//                         name: 'errorVal'
+//                     }
+//                 };
+//                 input = {
+//                     status: {
+//                         state: opts.stateValue,
+//                         error: JSON.stringify(opts.error)
+//                     }
+//                 };
+//                 finalResource = _
+//                     .chain(sampleBackupResource)
+//                     .cloneDeep()
+//                     .value();
+//                 _.assign(finalResource.status, input.status);
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
+//                 apiserver.updateOperationStatus(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         expect(res.body.status.state).to.eql(opts.stateValue);
+//                         expect(res.body.status.error).to.eql(JSON.stringify(opts.error));
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('updates the operation error only and retain state', done => {
+//                 opts = {
+//                     resourceId: 'fakeResourceId',
+//                     operationName: 'backup',
+//                     operationType: 'defaultbackup',
+//                     operationId: 'fakeOperationId',
+//                     error: {
+//                         name: 'errorVal'
+//                     }
+//                 };
+//                 input = {
+//                     status: {
+//                         error: JSON.stringify(opts.error)
+//                     }
+//                 };
+//                 finalResource = _
+//                     .chain(sampleBackupResource)
+//                     .cloneDeep()
+//                     .value();
+//                 _.assign(finalResource.status, input.status);
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
+//                 apiserver.updateOperationStatus(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         expect(res.body.status.state).to.eql(sampleBackupResource.status.state);
+//                         expect(res.body.status.error).to.eql(JSON.stringify(opts.error));
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('updates the operation response only and retain state and error', done => {
+//                 opts = {
+//                     resourceId: 'fakeResourceId',
+//                     operationName: 'backup',
+//                     operationType: 'defaultbackup',
+//                     operationId: 'fakeOperationId',
+//                     response: {
+//                         name: 'fakeResponse'
+//                     }
+//                 };
+//                 input = {
+//                     status: {
+//                         response: JSON.stringify(opts.response)
+//                     }
+//                 };
+//                 finalResource = _
+//                     .chain(sampleBackupResource)
+//                     .cloneDeep()
+//                     .value();
+//                 _.assign(finalResource.status, input.status);
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
+//                 apiserver.updateOperationStatus(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         expect(res.body.status.state).to.eql(sampleBackupResource.status.state);
+//                         expect(res.body.status.error).to.eql(sampleBackupResource.status.error);
+//                         expect(res.body.status.response).to.eql(JSON.stringify(opts.response));
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('updates the operation response, state and error', done => {
+//                 opts = {
+//                     resourceId: 'fakeResourceId',
+//                     operationName: 'backup',
+//                     operationType: 'defaultbackup',
+//                     operationId: 'fakeOperationId',
+//                     response: {
+//                         name: 'fakeResponse'
+//                     },
+//                     stateValue: 'fakeState',
+//                     error: {
+//                         name: 'errorVal'
+//                     }
+//                 };
+//                 input = {
+//                     status: {
+//                         response: JSON.stringify(opts.response),
+//                         state: opts.stateValue,
+//                         error: JSON.stringify(opts.error)
+//                     }
+//                 };
+//                 finalResource = _
+//                     .chain(sampleBackupResource)
+//                     .cloneDeep()
+//                     .value();
+//                 _.assign(finalResource.status, input.status);
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
+//                 apiserver.updateOperationStatus(opts)
+//                     .then(res => {
+//                         expect(res.statusCode).to.eql(200);
+//                         expect(res.body).to.eql(finalResource);
+//                         expect(res.body.status.state).to.eql(input.status.state);
+//                         expect(res.body.status.error).to.eql(input.status.error);
+//                         expect(res.body.status.response).to.eql(input.status.response);
+//                         done();
+//                         verify();
+//                     })
+//                     .catch(done);
+//             });
+//             it('throws error if api call is errored', done => {
+//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input, 409);
+//                 return apiserver.updateOperationStatus(opts)
+//                     .catch(err => {
+//                         expect(err).to.have.status(409);
+//                         done();
+//                     });
+//             });
+//         });
+
+
+//     });
+// });

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -1,997 +1,599 @@
-// 'use strict';
+'use strict';
 
-// const _ = require('lodash');
-// const nock = require('nock');
-// const apiserver = require('../../data-access-layer/eventmesh').apiServerClient;
-// const apiServerHost = 'https://10.0.2.2:9443';
-// const CONST = require('../../common/constants');
-// const logger = require('../../common/logger');
+const nock = require('nock');
+const apiserver = require('../../data-access-layer/eventmesh').apiServerClient;
+const apiServerHost = 'https://10.0.2.2:9443';
+const CONST = require('../../common/constants');
+const logger = require('../../common/logger');
 
-// const sampleLockResource = {
-//     kind: 'DeploymentLock',
-//     apiVersion: 'lock.servicefabrik.io/v1alpha1',
-//     metadata: {
-//         name: 'l1',
-//         namespace: 'default',
-//         selfLink: '/apis/lock.servicefabrik.io/v1alpha1/namespaces/default/deploymentlocks/l1',
-//         uid: '54e02d6c-72b6-11e8-80fe-9801a7b45ddd',
-//         resourceVersion: '1076',
-//         generation: 1,
-//         creationTimestamp: '2018-06-18T05:13:26Z'
-//     },
-//     spec: {
-//         options: JSON.stringify({
-//             'lockDetails': 'lockdetails'
-//         })
-//     },
-//     status: {}
-// };
+const expectedGetDeploymentResponse = {
+  metadata: {
+    name: 'deployment1',
+    labels: {
+      label1: 'label1',
+      label2: 'label2',
+      last_backup_defaultbackups: 'backup1'
+    }
+  },
+  spec: {
+    options: JSON.stringify({
+      opt1: 'opt1',
+      opt2: 'opt2'
+    }),
+    instanceId: 'deployment1'
+  },
+  status: {
+    state: 'create',
+    response: JSON.stringify({
+      resp: 'resp'
+    })
+  }
+};
 
-// const sampleDeploymentResource = {
-//     kind: 'Director',
-//     apiVersion: 'deployment.servicefabrik.io/v1alpha1',
-//     metadata: {
-//         name: 'fakeResourceId',
-//         namespace: 'default',
-//         selfLink: '/apis/deployment.servicefabrik.io/v1alpha1/namespaces/default/directors/fakeResourceId',
-//         uid: '54e02d6c-72b6-11e8-80fe-9801a7b45ddd',
-//         resourceVersion: '1076',
-//         generation: 1,
-//         creationTimestamp: '2018-06-18T05:13:26Z'
-//     },
-//     spec: {
-//         options: 'sample_options'
-//     },
-//     status: {
-//         state: 'in_progress'
-//     }
-// };
+const sampleDeploymentResource = {
+  metadata: {
+    name: 'deployment1',
+    labels: {
+      label1: 'label1',
+      label2: 'label2',
+      last_backup_defaultbackups: 'backup1'
+    }
+  },
+  spec: {
+    options: {
+      opt1: 'opt1',
+      opt2: 'opt2'
+    },
+    instanceId: 'deployment1'
+  },
+  status: {
+    state: 'create',
+    response: {
+      resp: 'resp'
+    }
+  }
+};
 
-// const sampleBackupResource = {
-//     kind: 'DefaultBackup',
-//     apiVersion: 'backup.servicefabrik.io/v1alpha1',
-//     metadata: {
-//         name: 'fakeOperationId',
-//         namespace: 'default',
-//         selfLink: '/apis/backup.servicefabrik.io/v1alpha1/namespaces/default/defaultbackups/fakeOperationId',
-//         uid: '54e02d6c-72b6-11e8-80fe-9801a7b45ddd',
-//         resourceVersion: '1076',
-//         generation: 1,
-//         creationTimestamp: '2018-06-18T05:13:26Z'
-//     },
-//     spec: {
-//         options: 'sample_options'
-//     },
-//     status: {
-//         state: 'defaultState',
-//         error: JSON.stringify({
-//             name: 'defaultErrorObj'
-//         }),
-//         response: JSON.stringify({
-//             name: 'defaultResponseObj'
-//         }),
-//     }
-// };
+function verify() {
+  /* jshint expr:true */
+  if (!nock.isDone()) {
+    logger.error('pending mocks: %j', nock.pendingMocks());
+  }
+  expect(nock.isDone()).to.be.true;
+}
 
-// function verify() {
-//     /* jshint expr:true */
-//     if (!nock.isDone()) {
-//         // console.log('pending mocks: %j', nock.pendingMocks());
-//         logger.error('pending mocks: %j', nock.pendingMocks());
-//     }
-//     expect(nock.isDone()).to.be.true;
-// }
+function nockGetResource(resourceGroup, resourceType, id, response, expectedExpectedCode) {
+  nock(apiServerHost)
+    .get(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}/${id}`)
+    .reply(expectedExpectedCode || 200, response);
+}
 
-// function nockGetResource(resourceGroup, resourceType, id, response, expectedExpectedCode) {
-//     nock(apiServerHost)
-//         .get(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s/${id}`)
-//         .reply(expectedExpectedCode || 200, response);
-// }
+function nockPatchResourceStatus(resourceGroup, resourceType, id, response, payload, expectedExpectedCode) {
+  nock(apiServerHost)
+    .patch(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}/${id}/status`, JSON.stringify(payload))
+    .reply(expectedExpectedCode || 200, response);
+}
 
-// function nockPatchResourceStatus(resourceGroup, resourceType, id, response, payload, expectedExpectedCode) {
-//     nock(apiServerHost)
-//         .patch(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s/${id}/status`, payload)
-//         .reply(expectedExpectedCode || 200, response);
-// }
+function nockPatchResource(resourceGroup, resourceType, id, response, payload, expectedExpectedCode) {
+  nock(apiServerHost)
+    .patch(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}/${id}`, JSON.stringify(payload))
+    .reply(expectedExpectedCode || 200, response);
+}
 
-// function nockPatchResource(resourceGroup, resourceType, id, response, payload, expectedExpectedCode) {
-//     nock(apiServerHost)
-//         .patch(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s/${id}`, payload)
-//         .reply(expectedExpectedCode || 200, response);
-// }
+function nockCreateResource(resourceGroup, resourceType, response, payload, expectedExpectedCode) {
+  nock(apiServerHost)
+    .post(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}`, JSON.stringify(payload))
+    .reply(expectedExpectedCode || 201, response);
+}
 
-// function nockCreateResource(resourceGroup, resourceType, response, payload, expectedExpectedCode) {
-//     nock(apiServerHost)
-//         .post(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s`, payload)
-//         .reply(expectedExpectedCode || 201, response);
-// }
+function nockDeleteResource(resourceGroup, resourceType, id, response, expectedExpectedCode) {
+  nock(apiServerHost)
+    .delete(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}/${id}`)
+    .reply(expectedExpectedCode || 200, response);
+}
 
-// function nockDeleteResource(resourceGroup, resourceType, id, response, expectedExpectedCode) {
-//     nock(apiServerHost)
-//         .delete(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}s/${id}`)
-//         .reply(expectedExpectedCode || 200, response);
-// }
+describe('eventmesh', () => {
+  describe('ApiServerClient', () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+    describe('parseResourceDetailsFromSelfLink', () => {
+      it('Should parse resource details from selflink', () => {
+        const selfLink = '/apis/deployment.servicefabrik.io/v1alpha1/namespaces/default/directors/sample_director';
+        const resourceDetails = apiserver.parseResourceDetailsFromSelfLink(selfLink);
+        expect(resourceDetails).to.deep.eql({
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+        });
+      });
+    });
 
-// describe('eventmesh', () => {
-//     describe('ApiServerClient', () => {
+    describe('createResource', () => {
+      it('Creates resource without label and status', () => {
+        const expectedResponse = {};
+        const payload = {
+          metadata: {
+            name: 'deployment1'
+          },
+          spec: {
+            options: JSON.stringify({
+              opts: 'sample_options'
+            })
+          }
+        };
+        nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload);
+        return apiserver.createResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          options: {
+            opts: 'sample_options'
+          }
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(201);
+            expect(res.body).to.eql({});
+            verify();
+          });
+      });
+      it('Creates resource without status', () => {
+        const expectedResponse = {};
+        const payload = {
+          metadata: {
+            name: 'deployment1',
+            labels: {
+              instance_guid: 'deployment1'
+            }
+          },
+          spec: {
+            options: JSON.stringify({
+              opts: 'sample_options'
+            })
+          }
+        };
+        nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload);
+        return apiserver.createResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          parentResourceId: 'deployment1',
+          options: {
+            opts: 'sample_options'
+          }
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(201);
+            expect(res.body).to.eql({});
+            verify();
+          });
+      });
+      it('Creates resource with label, options and status', () => {
+        const expectedResponse = {
+          res: 'res'
+        };
+        const payload1 = {
+          metadata: {
+            name: 'deployment1',
+            labels: {
+              instance_guid: 'deployment1'
+            }
+          },
+          spec: {
+            options: JSON.stringify({
+              opts: 'sample_options'
+            })
+          }
+        };
+        const payload2 = {
+          status: {
+            state: 'create',
+            response: JSON.stringify({
+              resp: 'resp'
+            })
+          }
+        };
+        nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, {}, payload1);
+        nockPatchResourceStatus(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload2);
+        return apiserver.createResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          parentResourceId: 'deployment1',
+          options: {
+            opts: 'sample_options'
+          },
+          status: {
+            state: 'create',
+            response: {
+              resp: 'resp'
+            }
+          }
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql(expectedResponse);
+            verify();
+          });
+      });
 
-//         afterEach(() => {
-//             nock.cleanAll();
-//         });
-//         describe('parseResourceDetailsFromSelfLink', () => {
-//             it('Should parse resource details from selflink', () => {
-//                 const selfLink = '/apis/deployment.servicefabrik.io/v1alpha1/namespaces/default/directors/sample_director';
-//                 const resourceDetails = apiserver.parseResourceDetailsFromSelfLink(selfLink);
-//                 expect(resourceDetails).to.deep.eql({
-//                     resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-//                     resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
-//                 });
-//             });
-//         });
+      it('throws error if create api call is errored', () => {
+        const expectedResponse = {
+          res: 'res'
+        };
+        const payload1 = {
+          metadata: {
+            name: 'deployment1',
+            labels: {
+              instance_guid: 'deployment1'
+            }
+          },
+          spec: {
+            options: JSON.stringify({
+              opts: 'sample_options'
+            })
+          }
+        };
+        nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload1, 404);
+        return apiserver.createResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          parentResourceId: 'deployment1',
+          options: {
+            opts: 'sample_options'
+          }
+        })
+          .catch(err => {
+            expect(err.status).to.eql(404);
+            verify();
+          });
+      });
+    });
 
-//         describe('createResource', () => {
-//             it.only('Creates resource without label and status', () => {
-//                 nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, );
-//                 apiserver.createResource('deploymentlock', sampleLockResource)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(201);
-//                         expect(res.body).to.eql(sampleLockResource);
-//                         done();
-//                         verify();
-//                     });
-//             });
+    describe('updateResource', () => {
+      it('Updates resource without label and status', () => {
+        const expectedResponse = {};
+        const payload = {
+          spec: {
+            options: JSON.stringify({
+              opts: 'sample_options'
+            })
+          }
+        };
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
+        return apiserver.updateResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          options: {
+            opts: 'sample_options'
+          }
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql({});
+            verify();
+          });
+      });
 
-//             it('throws error if api call is errored', done => {
-//                 nockCreateResource('lock', 'deploymentlock', sampleLockResource, undefined, 409);
-//                 return apiserver._createResource('lock', 'deploymentlock', sampleLockResource)
-//                     .catch(err => {
-//                         expect(err.code).to.eql(409);
-//                         done();
-//                     });
-//             });
-//         });
+      it('Updates resource without status', () => {
+        const expectedResponse = {};
+        const payload = {
+          metadata: {
+            name: 'deployment1',
+            labels: {
+              instance_guid: 'deployment1'
+            }
+          },
+          spec: {
+            options: JSON.stringify({
+              opts: 'sample_options'
+            })
+          }
+        };
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
+        return apiserver.updateResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          metadata: payload.metadata,
+          options: {
+            opts: 'sample_options'
+          }
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql({});
+            verify();
+          });
+      });
 
-//         describe('createLockResource', () => {
-//             it('calls the post rest api to create lock type resource', done => {
-//                 nockCreateResource('lock', 'deploymentlock', sampleLockResource);
-//                 apiserver.createResource('deploymentlock', sampleLockResource)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(201);
-//                         expect(res.body).to.eql(sampleLockResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockCreateResource('lock', 'deploymentlock', sampleLockResource, undefined, 409);
-//                 return apiserver.createLock('deploymentlock', sampleLockResource)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
+      it('Updates resource with label, options and status', () => {
+        const expectedResponse = {
+          res: 'res'
+        };
+        const payload1 = {
+          metadata: {
+            name: 'deployment1',
+            labels: {
+              instance_guid: 'deployment1'
+            }
+          },
+          spec: {
+            options: JSON.stringify({
+              opts: 'sample_options'
+            })
+          }
+        };
+        const payload2 = {
+          status: {
+            state: 'create',
+            response: JSON.stringify({
+              resp: 'resp'
+            })
+          }
+        };
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', {}, payload1);
+        nockPatchResourceStatus(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload2);
+        return apiserver.updateResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          metadata: payload1.metadata,
+          options: {
+            opts: 'sample_options'
+          },
+          status: {
+            state: 'create',
+            response: {
+              resp: 'resp'
+            }
+          }
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql(expectedResponse);
+            verify();
+          });
+      });
 
-//         describe('createResource', () => {
-//             it('throws error if api call is errored', done => {
-//                 nockCreateResource('lock', 'deploymentlock', sampleLockResource, undefined, 409);
-//                 return apiserver._createResource('lock', 'deploymentlock', sampleLockResource)
-//                     .catch(err => {
-//                         expect(err.code).to.eql(409);
-//                         done();
-//                     });
-//             });
-//         });
+      it('throws error if create api call is errored', () => {
+        const expectedResponse = {
+          res: 'res'
+        };
+        const payload1 = {
+          spec: {
+            options: JSON.stringify({
+              opts: 'sample_options'
+            })
+          }
+        };
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload1, 404);
+        return apiserver.updateResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          options: {
+            opts: 'sample_options'
+          }
+        })
+          .catch(err => {
+            expect(err.status).to.eql(404);
+            verify();
+          });
+      });
+    });
 
-//         describe('deleteLock', () => {
-//             const deleteLockResponse = {
-//                 kind: 'Status',
-//                 apiVersion: 'v1',
-//                 metadata: {},
-//                 status: 'Success',
-//                 details: {
-//                     name: 'l1',
-//                     group: 'lock.servicefabrik.io',
-//                     kind: 'deploymentlocks',
-//                     uid: '3576eca0-72b7-11e8-80fe-9801a7b45ddd'
-//                 }
-//             };
-//             it('calls the delete rest api to delete lock type resource', done => {
-//                 nockDeleteResource('lock', 'deploymentlock', 'l1', deleteLockResponse);
-//                 apiserver.deleteLock('deploymentlock', 'l1')
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(deleteLockResponse);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockDeleteResource('lock', 'deploymentlock', 'l1', deleteLockResponse, 409);
-//                 return apiserver.deleteLock('deploymentlock', 'l1')
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
+    describe('patchResponse', () => {
+      it('Patches response with given fields', () => {
+        const expectedGetResponse = {
+          status: {
+            response: {
+              resp: 'resp'
+            }
+          }
+        };
+        const expectedResponse = {};
+        const payload = {
+          status: {
+            response: JSON.stringify({
+              resp: 'resp1',
+              resp2: 'resp2'
+            })
+          }
+        };
+        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetResponse);
+        nockPatchResourceStatus(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
+        return apiserver.patchResponse({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          response: {
+            resp: 'resp1',
+            resp2: 'resp2'
+          }
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql({});
+            verify();
+          });
+      });
+    });
 
-//         describe('updateResource', () => {
-//             it('calls the patch rest api to edit lock type resource', done => {
-//                 nockPatchResource('lock', 'deploymentlock', 'l1', sampleLockResource);
-//                 apiserver.updateResource('lock', 'deploymentlock', 'l1', {
-//                     spec: {
-//                         options: sampleLockResource.spec.options
-//                     }
-//                 })
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(sampleLockResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 const spec = {
-//                     spec: {
-//                         options: sampleLockResource.spec.options
-//                     }
-//                 };
-//                 nockPatchResource('lock', 'deploymentlock', 'l1', sampleLockResource, spec, 409);
-//                 return apiserver.updateResource('lock', 'deploymentlock', 'l1', spec)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
+    describe('patchOptions', () => {
+      it('Patches options with given fields', () => {
+        const expectedGetResponse = {
+          spec: {
+            options: {
+              opt: 'opt'
+            }
+          }
+        };
+        const expectedResponse = {};
+        const payload = {
+          spec: {
+            options: JSON.stringify({
+              opt: 'opt1',
+              opt2: 'opt2'
+            })
+          }
+        };
+        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetResponse);
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
+        return apiserver.patchOptions({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          options: {
+            opt: 'opt1',
+            opt2: 'opt2'
+          }
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql({});
+            verify();
+          });
+      });
+    });
 
-//         describe('getLockDetails', () => {
-//             it('returns options of the lock resource', done => {
-//                 nockGetResource('lock', 'deploymentlock', 'l1', sampleLockResource);
-//                 apiserver.getLockDetails('deploymentlock', 'l1')
-//                     .then(res => {
-//                         expect(res).to.eql(JSON.parse(sampleLockResource.spec.options));
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockGetResource('lock', 'deploymentlock', 'l1', sampleLockResource, 409);
-//                 return apiserver.getLockDetails('deploymentlock', 'l1')
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
+    describe('deleteResource', () => {
+      it('Deletes resource', () => {
+        const expectedResponse = {};
+        nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse);
+        return apiserver.deleteResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql({});
+            verify();
+          });
+      });
+      it('Throws error when delete fails', () => {
+        nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', {}, 404);
+        return apiserver.deleteResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+        })
+          .catch(err => {
+            expect(err.status).to.eql(404);
+            verify();
+          });
+      });
+    });
 
-//         describe('getResource', () => {
-//             it('returns the specified resource', done => {
-//                 nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource);
-//                 apiserver.getResource('deployment', 'director', 'fakeResourceId')
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(sampleDeploymentResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource, 409);
-//                 return apiserver.getResource('deployment', 'director', 'fakeResourceId')
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
+    describe('updateLastOperation', () => {
+      it('Updates last operation with given value', () => {
+        const expectedResponse = {};
+        const payload = {
+          metadata: {
+            labels: {
+              last_backup_defaultbackups: 'backup1'
+            }
+          }
+        };
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
+        return apiserver.updateLastOperation({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP,
+          operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+          value: 'backup1'
+        })
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql({});
+            verify();
+          });
+      });
+    });
 
-//         describe('createDeployment', () => {
-//             const resourceId = 'fakeResourceId';
-//             const val = {
-//                 key: 'value'
-//             };
-//             const input = {
-//                 metadata: {
-//                     name: `${resourceId}`,
-//                     labels: {
-//                         instance_guid: `${resourceId}`,
-//                     }
-//                 },
-//                 spec: {
-//                     options: JSON.stringify(val)
-//                 },
-//             };
+    describe('getResource', () => {
+      it('Gets resource', () => {
+        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
+        return apiserver.getResource({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+        })
+          .then(res => {
+            expect(res).to.eql(sampleDeploymentResource);
+            verify();
+          });
+      });
+    });
 
-//             const statusJson = {
-//                 status: {
-//                     state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-//                     lastOperation: 'created',
-//                     response: JSON.stringify({})
-//                 }
-//             };
-//             const finalResource = _.assign({
-//                 status: {
-//                     state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-//                     lastOperation: 'created',
-//                     response: JSON.stringify({})
-//                 }
-//             }, sampleDeploymentResource);
+    describe('getLastOperation', () => {
+      it('Gets last operation on resource', () => {
+        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
+        return apiserver.getLastOperation({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP,
+          operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP
+        })
+          .then(res => {
+            expect(res).to.eql('backup1');
+            verify();
+          });
+      });
+    });
 
-//             it('Creates a resource', done => {
-//                 nockCreateResource('deployment', 'director', sampleDeploymentResource, input);
-//                 nockPatchResourceStatus('deployment', 'director', 'fakeResourceId', finalResource, statusJson);
-//                 apiserver.createDeployment(resourceId, val)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockCreateResource('deployment', 'director', sampleDeploymentResource, input, 409);
-//                 return apiserver.createDeployment(resourceId, val)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
+    describe('getOptions', () => {
+      it('Gets options of resource', () => {
+        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
+        return apiserver.getOptions({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP
+        })
+          .then(res => {
+            expect(res).to.eql(sampleDeploymentResource.spec.options);
+            verify();
+          });
+      });
+    });
 
-//         describe('_updateResourceState', () => {
-//             it('updates the specified resource state', done => {
-//                 nockPatchResourceStatus('deployment', 'director', 'fakeResourceId', sampleDeploymentResource);
-//                 apiserver._updateResourceState('director', 'fakeResourceId', sampleDeploymentResource.status.state)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(sampleDeploymentResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockPatchResourceStatus('deployment', 'director', 'fakeResourceId', sampleDeploymentResource, undefined, 409);
-//                 return apiserver._updateResourceState('director', 'fakeResourceId', sampleDeploymentResource.status.state)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
+    describe('getResponse', () => {
+      it('Gets options of resource', () => {
+        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
+        return apiserver.getResponse({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP
+        })
+          .then(res => {
+            expect(res).to.eql(sampleDeploymentResource.status.response);
+            verify();
+          });
+      });
+    });
 
-//         describe('getResourceState', () => {
-//             it('gets the specified resource state', done => {
-//                 nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource);
-//                 apiserver.getResourceState('director', 'fakeResourceId')
-//                     .then(res => {
-//                         expect(res).to.eql(sampleDeploymentResource.status.state);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockGetResource('deployment', 'director', 'fakeResourceId', sampleDeploymentResource, 409);
-//                 return apiserver.getResourceState('director', 'fakeResourceId')
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('createOperation', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackups',
-//                 operationId: 'fakeOperationId',
-//                 value: {
-//                     key: 'value'
-//                 }
-//             };
-//             const input = {
-//                 metadata: {
-//                     name: `${opts.operationId}`,
-//                     labels: {
-//                         instance_guid: `${opts.resourceId}`,
-//                     },
-//                 },
-//                 spec: {
-//                     options: JSON.stringify(opts.value)
-//                 },
-//             };
-
-//             const statusJson = {
-//                 status: {
-//                     state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-//                     lastOperation: 'created',
-//                     response: JSON.stringify({})
-//                 }
-//             };
-//             const finalResource = _.assign({
-//                 status: {
-//                     state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-//                     lastOperation: '',
-//                     response: ''
-//                 }
-//             }, sampleBackupResource);
-//             it('Creates an operation of a resource', done => {
-//                 nockCreateResource('backup', 'defaultbackup', sampleBackupResource, input);
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, statusJson);
-//                 apiserver.createOperation(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockCreateResource('backup', 'defaultbackup', sampleBackupResource, input, 409);
-//                 return apiserver.createOperation(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('updateOperationError', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 operationId: 'fakeOperationId',
-//                 error: {
-//                     key: 'value'
-//                 }
-//             };
-//             const payload = {
-//                 status: {
-//                     error: JSON.stringify(opts.error),
-//                 }
-//             };
-//             const response = _.assign({
-//                 status: {
-//                     error: JSON.stringify(opts.error)
-//                 }
-//             }, sampleBackupResource);
-//             it('patches the operation error', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', response, payload);
-//                 apiserver.updateOperationError(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(response);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', response, payload, 409);
-//                 return apiserver.updateOperationError(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('updateOperationResponse', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 operationId: 'fakeOperationId',
-//                 value: {
-//                     key: 'value'
-//                 }
-//             };
-//             const input = {
-//                 status: {
-//                     response: JSON.stringify(opts.value),
-//                 }
-//             };
-//             const finalResource = _.assign({
-//                 status: {
-//                     response: JSON.stringify(opts.value)
-//                 }
-//             }, sampleBackupResource);
-//             it('updates the operation result', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-//                 apiserver.updateOperationResponse(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input, 409);
-//                 return apiserver.updateOperationResponse(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('updateOperationStateAndResponse', () => {
-//             const opts = {
-//                 resourceId: 'resource-guid',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 operationId: 'operation-guid',
-//                 stateValue: 'fakeState',
-//                 response: {
-//                     key: 'fakeValue'
-//                 }
-//             };
-//             const payload = {
-//                 status: {
-//                     state: opts.stateValue,
-//                     response: JSON.stringify(opts.response),
-//                 }
-//             };
-//             const finalResource = _.assign({
-//                 status: {
-//                     state: opts.stateValue,
-//                     response: JSON.stringify(opts.response),
-//                 }
-//             }, sampleBackupResource);
-//             it('updates the operation state and response', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'operation-guid', finalResource, payload);
-//                 apiserver.updateOperationStateAndResponse(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', opts.operationId, finalResource, payload, 409);
-//                 return apiserver.updateOperationStateAndResponse(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-
-//         describe('updateOperationState', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 operationId: 'fakeOperationId',
-//                 stateValue: 'in_progress'
-//             };
-//             const input = {
-//                 status: {
-//                     state: opts.stateValue
-//                 }
-//             };
-//             const finalResource = _.assign({
-//                 status: {
-//                     state: opts.stateValue
-//                 }
-//             }, sampleBackupResource);
-//             it('updates the operation state', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-//                 apiserver.updateOperationState(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input, 409);
-//                 return apiserver.updateOperationState(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('updateLastOperation', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 value: 'fakeOperationId'
-//             };
-//             const input = {};
-//             input.metadata = {};
-//             input.metadata.labels = {};
-//             input.metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = opts.value;
-//             const finalResource = _.cloneDeep(sampleDeploymentResource);
-//             _.assign(finalResource, input);
-
-//             it('updates the last operation value', done => {
-//                 nockPatchResource('deployment', 'director', 'fakeResourceId', finalResource, input);
-//                 apiserver.updateLastOperation(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockPatchResource('deployment', 'director', 'fakeResourceId', finalResource, input, 409);
-//                 return apiserver.updateLastOperation(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-
-//         });
-
-//         describe('getLastOperation', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup'
-//             };
-//             const input = {};
-//             input.metadata = {};
-//             input.metadata.labels = {};
-//             input.metadata.labels[`last_${opts.operationName}_${opts.operationType}`] = 'fakeOperationId';
-//             const finalResource = _.cloneDeep(sampleDeploymentResource);
-//             _.assign(finalResource, input);
-//             it('gets the last operation value', done => {
-//                 nockGetResource('deployment', 'director', 'fakeResourceId', finalResource);
-//                 apiserver.getLastOperation(opts)
-//                     .then(res => {
-//                         expect(res).to.eql('fakeOperationId');
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockGetResource('deployment', 'director', 'fakeResourceId', finalResource, 409);
-//                 return apiserver.getLastOperation(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('getOperationOptions', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 operationId: 'fakeOperationId'
-//             };
-//             const input = {};
-//             input.spec = {};
-//             const options = {
-//                 'options': 'opt'
-//             };
-//             input.spec.options = JSON.stringify(options);
-//             const finalResource = _.cloneDeep(sampleDeploymentResource);
-//             _.assign(finalResource, input);
-//             it('gets the last operation options', done => {
-//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
-//                 apiserver.getOperationOptions(opts)
-//                     .then(res => {
-//                         expect(res).to.eql(options);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
-//                 return apiserver.getOperationOptions(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('getOperationState', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 operationId: 'fakeOperationId'
-//             };
-//             const input = {};
-//             input.status = {};
-//             input.status.state = 'in_progress';
-//             const finalResource = _.cloneDeep(sampleDeploymentResource);
-//             _.assign(finalResource, input);
-//             it('gets the last operation state', done => {
-//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
-//                 apiserver.getOperationState(opts)
-//                     .then(res => {
-//                         expect(res).to.eql('in_progress');
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
-//                 return apiserver.getOperationState(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('getOperationResponse', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 operationId: 'fakeOperationId'
-//             };
-//             const input = {};
-//             input.status = {};
-//             const response = {
-//                 'response': 'res'
-//             };
-//             input.status.response = JSON.stringify(response);
-//             const finalResource = _.cloneDeep(sampleDeploymentResource);
-//             _.assign(finalResource, input);
-//             it('gets the last operation Result', done => {
-//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
-//                 apiserver.getOperationResponse(opts)
-//                     .then(res => {
-//                         expect(res).to.eql(response);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
-//                 return apiserver.getOperationResponse(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('#getOperationStatus', () => {
-//             const opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 operationId: 'fakeOperationId'
-//             };
-//             const finalResource = _.cloneDeep(sampleDeploymentResource);
-//             it('gets the operation status', done => {
-//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource);
-//                 apiserver.getOperationStatus(opts)
-//                     .then(res => {
-//                         expect(res).to.eql({
-//                             state: 'in_progress'
-//                         });
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockGetResource('backup', 'defaultbackup', 'fakeOperationId', finalResource, 409);
-//                 return apiserver.getOperationStatus(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
-
-//         describe('#updateOperationStatus', () => {
-//             let opts = {
-//                 resourceId: 'fakeResourceId',
-//                 operationName: 'backup',
-//                 operationType: 'defaultbackup',
-//                 operationId: 'fakeOperationId',
-//                 stateValue: 'in_progress',
-//             };
-//             let input = {
-//                 status: {
-//                     state: opts.stateValue,
-//                 }
-//             };
-//             let finalResource = _
-//                 .chain(sampleBackupResource)
-//                 .cloneDeep()
-//                 .value();
-//             _.assign(finalResource.status, input.status);
-//             it('updates the operation status', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-//                 apiserver.updateOperationStatus(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         expect(res.body.status.state).to.eql(opts.stateValue);
-//                         expect(res.body.status.error).to.eql(sampleBackupResource.status.error);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('updates the operation status and error if both are present', done => {
-//                 opts = {
-//                     resourceId: 'fakeResourceId',
-//                     operationName: 'backup',
-//                     operationType: 'defaultbackup',
-//                     operationId: 'fakeOperationId',
-//                     stateValue: 'in_progress',
-//                     error: {
-//                         name: 'errorVal'
-//                     }
-//                 };
-//                 input = {
-//                     status: {
-//                         state: opts.stateValue,
-//                         error: JSON.stringify(opts.error)
-//                     }
-//                 };
-//                 finalResource = _
-//                     .chain(sampleBackupResource)
-//                     .cloneDeep()
-//                     .value();
-//                 _.assign(finalResource.status, input.status);
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-//                 apiserver.updateOperationStatus(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         expect(res.body.status.state).to.eql(opts.stateValue);
-//                         expect(res.body.status.error).to.eql(JSON.stringify(opts.error));
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('updates the operation error only and retain state', done => {
-//                 opts = {
-//                     resourceId: 'fakeResourceId',
-//                     operationName: 'backup',
-//                     operationType: 'defaultbackup',
-//                     operationId: 'fakeOperationId',
-//                     error: {
-//                         name: 'errorVal'
-//                     }
-//                 };
-//                 input = {
-//                     status: {
-//                         error: JSON.stringify(opts.error)
-//                     }
-//                 };
-//                 finalResource = _
-//                     .chain(sampleBackupResource)
-//                     .cloneDeep()
-//                     .value();
-//                 _.assign(finalResource.status, input.status);
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-//                 apiserver.updateOperationStatus(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         expect(res.body.status.state).to.eql(sampleBackupResource.status.state);
-//                         expect(res.body.status.error).to.eql(JSON.stringify(opts.error));
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('updates the operation response only and retain state and error', done => {
-//                 opts = {
-//                     resourceId: 'fakeResourceId',
-//                     operationName: 'backup',
-//                     operationType: 'defaultbackup',
-//                     operationId: 'fakeOperationId',
-//                     response: {
-//                         name: 'fakeResponse'
-//                     }
-//                 };
-//                 input = {
-//                     status: {
-//                         response: JSON.stringify(opts.response)
-//                     }
-//                 };
-//                 finalResource = _
-//                     .chain(sampleBackupResource)
-//                     .cloneDeep()
-//                     .value();
-//                 _.assign(finalResource.status, input.status);
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-//                 apiserver.updateOperationStatus(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         expect(res.body.status.state).to.eql(sampleBackupResource.status.state);
-//                         expect(res.body.status.error).to.eql(sampleBackupResource.status.error);
-//                         expect(res.body.status.response).to.eql(JSON.stringify(opts.response));
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('updates the operation response, state and error', done => {
-//                 opts = {
-//                     resourceId: 'fakeResourceId',
-//                     operationName: 'backup',
-//                     operationType: 'defaultbackup',
-//                     operationId: 'fakeOperationId',
-//                     response: {
-//                         name: 'fakeResponse'
-//                     },
-//                     stateValue: 'fakeState',
-//                     error: {
-//                         name: 'errorVal'
-//                     }
-//                 };
-//                 input = {
-//                     status: {
-//                         response: JSON.stringify(opts.response),
-//                         state: opts.stateValue,
-//                         error: JSON.stringify(opts.error)
-//                     }
-//                 };
-//                 finalResource = _
-//                     .chain(sampleBackupResource)
-//                     .cloneDeep()
-//                     .value();
-//                 _.assign(finalResource.status, input.status);
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input);
-//                 apiserver.updateOperationStatus(opts)
-//                     .then(res => {
-//                         expect(res.statusCode).to.eql(200);
-//                         expect(res.body).to.eql(finalResource);
-//                         expect(res.body.status.state).to.eql(input.status.state);
-//                         expect(res.body.status.error).to.eql(input.status.error);
-//                         expect(res.body.status.response).to.eql(input.status.response);
-//                         done();
-//                         verify();
-//                     })
-//                     .catch(done);
-//             });
-//             it('throws error if api call is errored', done => {
-//                 nockPatchResourceStatus('backup', 'defaultbackup', 'fakeOperationId', finalResource, input, 409);
-//                 return apiserver.updateOperationStatus(opts)
-//                     .catch(err => {
-//                         expect(err).to.have.status(409);
-//                         done();
-//                     });
-//             });
-//         });
+    describe('getState', () => {
+      it('Gets options of resource', () => {
+        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
+        return apiserver.getState({
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP
+        })
+          .then(res => {
+            expect(res).to.eql(sampleDeploymentResource.status.state);
+            verify();
+          });
+      });
+    });
 
 
-//     });
-// });
+  });
+});

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -384,8 +384,8 @@ describe('eventmesh', () => {
       });
     });
 
-    describe('patchResponse', () => {
-      it('Patches response with given fields', () => {
+    describe('patchResource', () => {
+      it('Patches resource with response', () => {
         const expectedGetResponse = {
           status: {
             response: {
@@ -404,13 +404,15 @@ describe('eventmesh', () => {
         };
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetResponse);
         nockPatchResourceStatus(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
-        return apiserver.patchResponse({
+        return apiserver.patchResource({
             resourceId: 'deployment1',
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            response: {
-              resp: 'resp1',
-              resp2: 'resp2'
+            status: {
+              response: {
+                resp: 'resp1',
+                resp2: 'resp2'
+              }
             }
           })
           .then(res => {
@@ -419,10 +421,8 @@ describe('eventmesh', () => {
             verify();
           });
       });
-    });
 
-    describe('patchOptions', () => {
-      it('Patches options with given fields', () => {
+      it('Patches resource with options', () => {
         const expectedGetResponse = {
           spec: {
             options: {
@@ -441,7 +441,7 @@ describe('eventmesh', () => {
         };
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetResponse);
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
-        return apiserver.patchOptions({
+        return apiserver.patchResource({
             resourceId: 'deployment1',
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
@@ -456,6 +456,82 @@ describe('eventmesh', () => {
             verify();
           });
       });
+
+      it('Patches resource with all fields', () => {
+        const expectedGetResponse = {
+          metadata: {
+            name: 'deployment1',
+            labels: {
+              instance_guid: 'deployment1'
+            }
+          },
+          spec: {
+            options: {
+              opt1: 'opt1'
+            }
+          },
+          status: {
+            state: 'in_queue',
+            response: {
+              resp: 'resp',
+              resp1: 'resp1'
+            }
+          }
+        };
+        const expectedResponse = {};
+        const payload1 = {
+          metadata: {
+            labels: {
+              instance_guid: 'deployment1'
+            }
+          },
+          spec: {
+            options: JSON.stringify({
+              opt1: 'opt1',
+              opt2: 'sample_options'
+            })
+          }
+        };
+        const payload = {
+          status: {
+            state: 'in_progress',
+            response: JSON.stringify({
+              resp: 'resp1',
+              resp1: 'resp1',
+              resp2: 'resp2'
+            })
+          }
+        };
+        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetResponse);
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload1);
+        nockPatchResourceStatus(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedResponse, payload);
+        return apiserver.patchResource({
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            metadata: {
+              labels: {
+                instance_guid: 'deployment1'
+              }
+            },
+            options: {
+              opt2: 'sample_options'
+            },
+            status: {
+              state: 'in_progress',
+              response: {
+                resp: 'resp1',
+                resp2: 'resp2'
+              }
+            }
+          })
+          .then(res => {
+            expect(res.statusCode).to.eql(200);
+            expect(res.body).to.eql({});
+            verify();
+          });
+      });
+
     });
 
     describe('deleteResource', () => {
@@ -563,7 +639,7 @@ describe('eventmesh', () => {
     });
 
     describe('getResponse', () => {
-      it('Gets options of resource', () => {
+      it('Gets response of resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
         return apiserver.getResponse({
             resourceId: 'deployment1',
@@ -578,10 +654,10 @@ describe('eventmesh', () => {
       });
     });
 
-    describe('getState', () => {
-      it('Gets options of resource', () => {
+    describe('getResourceState', () => {
+      it('Gets state of resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
-        return apiserver.getState({
+        return apiserver.getResourceState({
             resourceId: 'deployment1',
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,

--- a/test/test_broker/managers.DefaultBackupManager.spec.js
+++ b/test/test_broker/managers.DefaultBackupManager.spec.js
@@ -25,7 +25,7 @@ const resultOptions = {
 const DefaultBackupManager = proxyquire('../../managers/backup-manager/DefaultBackupManager', {
   '../../data-access-layer/eventmesh': {
     'apiServerClient': {
-      'getOperationOptions': function (opts) {
+      'getOptions': function (opts) {
         DefaultBackupManagerDummy.getOperationOptionsDummy(opts);
         return Promise.resolve(resultOptions);
       }

--- a/test/test_broker/reports.BackupReportManager.spec.js
+++ b/test/test_broker/reports.BackupReportManager.spec.js
@@ -204,7 +204,6 @@ describe('BackupReportManager', function () {
       };
       return BackupReportManager.getBackupResult(instanceId, startTime, endTime)
         .then(backups => {
-          // console.log(backups);
           expect(backups).to.deep.eql(resultBackups);
           expect(repoSpy.search.callCount).to.equal(2);
           expect(repoSpy.search.firstCall.args[0][0]).to.be.equal(CONST.DB_MODEL.EVENT_DETAIL);

--- a/test/test_deployment_hooks/mocks/index.js
+++ b/test/test_deployment_hooks/mocks/index.js
@@ -16,7 +16,6 @@ function init() {
 function verify() {
   /* jshint expr:true */
   if (!nock.isDone()) {
-    console.log('pending mocks: %j', nock.pendingMocks());
     logger.error('pending mocks: %j', nock.pendingMocks());
   }
   expect(nock.isDone()).to.be.true;


### PR DESCRIPTION
Removed clutter from APIServerClient Class. Now it has only following basic methods:
* registerWatcher
* createResource
* updateResource
* patchResponse
* patchOptions
* deleteResource
* updateLastOperation
* getResource
* getLastOperation
* getOptions
* getState
* getResponse