### PR TITLE
Support fabrik-internal services

### DIFF
--- a/common/models/catalog.js
+++ b/common/models/catalog.js
@@ -31,7 +31,7 @@ class Catalog {
 
   toJSON() {
     return {
-      services: this.services
+      services: _.filter(this.services, service => service.name.indexOf('-fabrik-internal') === -1)
     };
   }
 }


### PR DESCRIPTION
The service fabrik currently supports internal [service plans](https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/2018.T07b/common/models/Service.js#L40), but not internal services. 

This is used to define a different plan for the mongodb, which is used by the service fabrik, than for mongodbs provided by the service fabrik via the catalog. However if the service fabrik does not provide a mongodb service this mechanism does not work. Hence this adds an internal service in the same manner as the internal service plans.