### PR TITLE
Clear Unlock intervals on watch refresh

### DIFF
--- a/broker/lib/fabrik/UnlockResourcePoller.js
+++ b/broker/lib/fabrik/UnlockResourcePoller.js
@@ -21,7 +21,8 @@ class UnlockResourcePoller {
           resourceId: lockDetails.lockedResourceDetails.resourceId
         })
         .then((resourceState) => {
-          logger.debug(`[Unlock Poller] Got resource ${lockDetails.lockedResourceDetails.resourceId} state as `, resourceState);
+          logger.debug(`[Unlock Poller] Got resource ${lockDetails.lockedResourceDetails.resourceId} state of ${lockDetails.lockedResourceDetails.operation}` +
+            ` operation for deployment ${object.metadata.name} as`, resourceState);
           //TODO-PR - reuse util method is operationCompleted.
           if (_.includes([
               CONST.APISERVER.RESOURCE_STATE.SUCCEEDED,

--- a/data-access-layer/eventmesh/LockManager.js
+++ b/data-access-layer/eventmesh/LockManager.js
@@ -109,7 +109,7 @@ class LockManager {
     _.extend(opts, {
       'lockTime': opts.lockTime ? opts.lockTime : currentTime
     });
-    logger.debug(`Attempting to acquire lock on resource with resourceId: ${resourceId} `);
+    logger.info(`Attempting to acquire lock on resource with resourceId: ${resourceId} `);
     return eventmesh.apiServerClient.getResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.LOCK,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS,
@@ -135,7 +135,7 @@ class LockManager {
           });
         }
       })
-      .tap(() => logger.debug(`Successfully acquired lock on resource with resourceId: ${resourceId}`))
+      .tap(() => logger.info(`Successfully acquired lock on resource with resourceId: ${resourceId}`))
       .catch(NotFound, () => {
         return eventmesh.apiServerClient.createResource({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.LOCK,
@@ -143,7 +143,7 @@ class LockManager {
             resourceId: resourceId,
             options: opts
           })
-          .tap(() => logger.debug(`Successfully acquired lock on resource with resourceId: ${resourceId} `));
+          .tap(() => logger.info(`Successfully acquired lock on resource with resourceId: ${resourceId} `));
       })
       .catch(Conflict, () => {
         return eventmesh.apiServerClient.getResource({
@@ -174,7 +174,7 @@ class LockManager {
     assert.ok(resourceId, `Parameter 'resourceId' is required to release lock`);
     maxRetryCount = maxRetryCount || CONST.ETCD.MAX_RETRY_UNLOCK;
     retryDelay = retryDelay || CONST.APISERVER.RETRY_DELAY;
-    logger.debug(`Attempting to unlock resource ${resourceId}`);
+    logger.info(`Attempting to unlock resource ${resourceId}`);
     return utils.retry(tries => {
       logger.info(`+-> Attempt ${tries + 1} to unlock resource ${resourceId}`);
       return eventmesh.apiServerClient.deleteResource({
@@ -182,10 +182,10 @@ class LockManager {
           resourceType: CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS,
           resourceId: resourceId
         })
-        .tap(() => logger.debug(`Successfully unlocked resource ${resourceId} `))
+        .tap(() => logger.info(`Successfully unlocked resource ${resourceId} `))
         .catch(err => {
           if (err instanceof NotFound) {
-            logger.debug(`Successfully Unlocked resource ${resourceId} `);
+            logger.info(`Successfully Unlocked resource ${resourceId} `);
             return;
           }
           logger.error(`Could not unlock resource ${resourceId} even after ${tries + 1} retries`);

--- a/test/test_broker/eventmesh.LockManager.spec.js
+++ b/test/test_broker/eventmesh.LockManager.spec.js
@@ -289,6 +289,18 @@ describe('eventmesh', () => {
             });
           });
       });
+      it('should successfully unlock resource in first try if lock does not exist', () => {
+        const lockManager = new apiServerLockManager();
+        return lockManager.unlock('lockId4')
+          .then(() => {
+            expect(deleteResourceSpy.callCount).to.equal(1);
+            expect(deleteResourceSpy.firstCall.args[0]).to.eql({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.LOCK,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS,
+              resourceId: 'lockId4'
+            });
+          });
+      });
       it('should fail to unlock resource after multiple retries', () => {
         const lockManager = new apiServerLockManager();
         return lockManager.unlock('lockId5', 3, 100)

--- a/test/test_broker/fabrik.UnlockResourcePoller.js
+++ b/test/test_broker/fabrik.UnlockResourcePoller.js
@@ -1,0 +1,255 @@
+'use strict';
+
+const proxyquire = require('proxyquire');
+const JSONStream = require('json-stream');
+const Promise = require('bluebird');
+const _ = require('lodash');
+const CONST = require('../../common/constants');
+const eventmesh = require('../../data-access-layer/eventmesh/ApiServerClient');
+const errors = require('../../common/errors');
+const InternalServerError = errors.InternalServerError;
+
+const CONSTANTS = {
+  UNLOCK_RESOURCE_POLLER_INTERVAL: 200,
+  APISERVER: {
+    RESOURCE_GROUPS: {
+      LOCK: 'lock.servicefabrik.io',
+      BACKUP: 'backup.servicefabrik.io'
+    },
+    RESOURCE_TYPES: {
+      DEPLOYMENT_LOCKS: 'deploymentlocks',
+      DEFAULT_BACKUP: 'defaultbackups'
+    },
+    RESOURCE_STATE: {
+      SUCCEEDED: 'succeeded',
+      FAILED: 'failed',
+      DELETE_FAILED: 'delete_failed',
+      ABORTED: 'aborted',
+    },
+    WATCHER_REFRESH_INTERVAL: 1200000,
+    WATCHER_ERROR_DELAY: 1200000
+  }
+};
+const UnlockResourcePoller = proxyquire('../../broker/lib/fabrik/UnlockResourcePoller', {
+  '../../../common/constants': CONSTANTS
+});
+
+describe('fabrik', function () {
+  describe('UnlockResourcePoller', function () {
+    let sandbox, registerWatcherStub;
+    before(function () {
+      sandbox = sinon.sandbox.create();
+    });
+    after(function () {
+      sandbox.restore();
+    });
+
+    it('Should start unlock resource poller successfully and register watch', (done) => {
+      const jsonStream = new JSONStream();
+      const registerWatcherFake = function (resourceGroup, resourceType, callback) {
+        return Promise.try(() => {
+          jsonStream.on('data', callback);
+          return jsonStream;
+        });
+      };
+      registerWatcherStub = sandbox.stub(eventmesh.prototype, 'registerWatcher', registerWatcherFake);
+      UnlockResourcePoller.start();
+      expect(registerWatcherStub.callCount).to.equal(1);
+      expect(registerWatcherStub.firstCall.args[0]).to.eql(CONST.APISERVER.RESOURCE_GROUPS.LOCK);
+      expect(registerWatcherStub.firstCall.args[1]).to.eql(CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS);
+      expect(registerWatcherStub.firstCall.args[2].name).to.eql('startPoller');
+      expect(_.size(UnlockResourcePoller.pollers)).to.eql(0);
+      registerWatcherStub.reset();
+      registerWatcherStub.restore();
+      done();
+    });
+
+    it('Should finish polling for lock if operation succeeded after receiving event', (done) => {
+      const options = {
+        lockedResourceDetails: {
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+          resourceId: 'backup1',
+          operation: 'backup'
+        }
+      };
+      const changeObject = {
+        type: 'ADDED',
+        object: {
+          metadata: {
+            name: 'lockid1'
+          },
+          spec: {
+            options: JSON.stringify(options)
+          }
+        }
+      };
+      mocks.apiServerEventMesh.nockGetResource('backup', 'defaultbackup', 'backup1', {
+        status: {
+          state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
+        }
+      });
+      mocks.apiServerEventMesh.nockDeleteResource('lock', 'deploymentlock', 'lockid1');
+      const jsonStream = new JSONStream();
+      const registerWatcherFake = function (resourceGroup, resourceType, callback) {
+        return Promise.try(() => {
+          jsonStream.on('data', callback);
+          return jsonStream;
+        });
+      };
+      registerWatcherStub = sandbox.stub(eventmesh.prototype, 'registerWatcher', registerWatcherFake);
+      UnlockResourcePoller.start();
+      return Promise.try(() => jsonStream.write(JSON.stringify(changeObject)))
+        .delay(500).then(() => {
+          expect(registerWatcherStub.callCount).to.equal(1);
+          expect(registerWatcherStub.firstCall.args[0]).to.eql(CONST.APISERVER.RESOURCE_GROUPS.LOCK);
+          expect(registerWatcherStub.firstCall.args[1]).to.eql(CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS);
+          expect(registerWatcherStub.firstCall.args[2].name).to.eql('startPoller');
+          mocks.verify();
+          expect(_.size(UnlockResourcePoller.pollers)).to.eql(0);
+          registerWatcherStub.reset();
+          registerWatcherStub.restore();
+          done();
+        });
+    });
+
+    it('Should continue polling for lock if operation not finished after receiving event', (done) => {
+      const options = {
+        lockedResourceDetails: {
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+          resourceId: 'backup1',
+          operation: 'backup'
+        }
+      };
+      const changeObject = {
+        type: 'ADDED',
+        object: {
+          metadata: {
+            name: 'lockid1'
+          },
+          spec: {
+            options: JSON.stringify(options)
+          }
+        }
+      };
+      mocks.apiServerEventMesh.nockGetResource('backup', 'defaultbackup', 'backup1', {
+        status: {
+          state: CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS
+        }
+      }, 2);
+      const jsonStream = new JSONStream();
+      const registerWatcherFake = function (resourceGroup, resourceType, callback) {
+        return Promise.try(() => {
+          jsonStream.on('data', callback);
+          return jsonStream;
+        });
+      };
+      registerWatcherStub = sandbox.stub(eventmesh.prototype, 'registerWatcher', registerWatcherFake);
+      UnlockResourcePoller.start();
+      return Promise.try(() => jsonStream.write(JSON.stringify(changeObject)))
+        .delay(500).then(() => {
+          expect(registerWatcherStub.callCount).to.equal(1);
+          expect(registerWatcherStub.firstCall.args[0]).to.eql(CONST.APISERVER.RESOURCE_GROUPS.LOCK);
+          expect(registerWatcherStub.firstCall.args[1]).to.eql(CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS);
+          expect(registerWatcherStub.firstCall.args[2].name).to.eql('startPoller');
+          mocks.verify();
+          expect(_.size(UnlockResourcePoller.pollers)).to.eql(1);
+          UnlockResourcePoller.clearPoller('lockid1', UnlockResourcePoller.pollers.lockid1);
+          registerWatcherStub.reset();
+          registerWatcherStub.restore();
+          done();
+        });
+    });
+
+    it('Should finish polling for lock if operation resource is not found after receiving event', (done) => {
+      const options = {
+        lockedResourceDetails: {
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+          resourceId: 'backup1',
+          operation: 'backup'
+        }
+      };
+      const changeObject = {
+        type: 'ADDED',
+        object: {
+          metadata: {
+            name: 'lockid1'
+          },
+          spec: {
+            options: JSON.stringify(options)
+          }
+        }
+      };
+      mocks.apiServerEventMesh.nockGetResource('backup', 'defaultbackup', 'backup1', {}, 1, 404);
+      mocks.apiServerEventMesh.nockDeleteResource('lock', 'deploymentlock', 'lockid1');
+      const jsonStream = new JSONStream();
+      const registerWatcherFake = function (resourceGroup, resourceType, callback) {
+        return Promise.try(() => {
+          jsonStream.on('data', callback);
+          return jsonStream;
+        });
+      };
+      registerWatcherStub = sandbox.stub(eventmesh.prototype, 'registerWatcher', registerWatcherFake);
+      UnlockResourcePoller.start();
+      return Promise.try(() => jsonStream.write(JSON.stringify(changeObject)))
+        .delay(500).then(() => {
+          expect(registerWatcherStub.callCount).to.equal(1);
+          expect(registerWatcherStub.firstCall.args[0]).to.eql(CONST.APISERVER.RESOURCE_GROUPS.LOCK);
+          expect(registerWatcherStub.firstCall.args[1]).to.eql(CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS);
+          expect(registerWatcherStub.firstCall.args[2].name).to.eql('startPoller');
+          mocks.verify();
+          expect(_.size(UnlockResourcePoller.pollers)).to.eql(0);
+          registerWatcherStub.reset();
+          registerWatcherStub.restore();
+          done();
+        });
+    });
+
+    it('Should retry register watch in case of error', (done) => {
+      const NEWCONST = {
+        APISERVER: {
+          RESOURCE_GROUPS: {
+            LOCK: 'lock.servicefabrik.io',
+          },
+          RESOURCE_TYPES: {
+            DEPLOYMENT_LOCKS: 'deploymentlocks',
+          },
+          WATCHER_REFRESH_INTERVAL: 1200000,
+          WATCHER_ERROR_DELAY: 300
+        }
+      };
+      const UnlockResourcePollerNew = proxyquire('../../broker/lib/fabrik/UnlockResourcePoller', {
+        '../../../common/constants': NEWCONST
+      });
+
+      const jsonStream = new JSONStream();
+      let i = 0;
+      const registerWatcherFake = function (resourceGroup, resourceType, callback) {
+        return Promise.try(() => {
+          i++;
+          if (i === 2) {
+            jsonStream.on('data', callback);
+            return jsonStream;
+          } else {
+            throw new InternalServerError('Internal Server Error');
+          }
+        });
+      };
+      registerWatcherStub = sandbox.stub(eventmesh.prototype, 'registerWatcher', registerWatcherFake);
+      UnlockResourcePollerNew.start();
+      return Promise.delay(700)
+        .then(() => {
+          expect(registerWatcherStub.callCount).to.equal(2);
+          expect(registerWatcherStub.firstCall.args[0]).to.eql(CONST.APISERVER.RESOURCE_GROUPS.LOCK);
+          expect(registerWatcherStub.firstCall.args[1]).to.eql(CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS);
+          expect(registerWatcherStub.firstCall.args[2].name).to.eql('startPoller');
+          expect(_.size(UnlockResourcePoller.pollers)).to.eql(0);
+          registerWatcherStub.reset();
+          registerWatcherStub.restore();
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
fixes #350 
Changes done as part of PR:
* Whenever a new event is received for lock resource which already has a poller running, old interval is cleared and new interval is created
* Changes some log levels to info