### PR TITLE
Feature/uaa authentication

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -497,8 +497,10 @@ defaults: &defaults
         - { range: 10.244.11.0/24, az: z2, cloud_properties: { name: random } }
         - { range: 10.244.12.0/24, az: z3, cloud_properties: { name: random } }
     uaa:
-      client_id: admin
-      client_secret: 'h0fixi8cvn512n3lkud8'
+      uaa_auth: false #make it true if bosh uses UAA for authentication
+      uaa_url: '' #provide complete uaa url here.,e.g., https://192.168.48.6:8443
+      client_id: '' #Assuming client credential grant being used, provide client id here
+      client_secret: '' #provide corrsponding client secret 
   - cpi: warden_cpi
     url: https://192.168.50.4:25555
     username: admin

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -154,7 +154,6 @@ defaults: &defaults
   deployment_action_timeout: 80000
   multi_az_enabled: false
   broker_drain_message: 'BROKER_DRAIN_INITIATED'
-  
   ##############################
   # EXTERNAL ENDPOINT SETTINGS #
   ##############################
@@ -497,6 +496,9 @@ defaults: &defaults
         - { range: 10.244.10.0/24, az: z1, cloud_properties: { name: random } }
         - { range: 10.244.11.0/24, az: z2, cloud_properties: { name: random } }
         - { range: 10.244.12.0/24, az: z3, cloud_properties: { name: random } }
+    uaa:
+      client_id: admin
+      client_secret: 'h0fixi8cvn512n3lkud8'
   - cpi: warden_cpi
     url: https://192.168.50.4:25555
     username: admin

--- a/common/HttpServer.js
+++ b/common/HttpServer.js
@@ -70,7 +70,6 @@ class HttpServer {
 
   static immediateShutdown() {
     logger.info('App shutting down now.');
-    pubsub.publish(CONST.TOPIC.APP_SHUTTING_DOWN);
     process.exit(2);
   }
 }

--- a/common/HttpServer.js
+++ b/common/HttpServer.js
@@ -67,6 +67,12 @@ class HttpServer {
       process.exit(2);
     }, 500);
   }
+
+  static immediateShutdown() {
+    logger.info('App shutting down now.');
+    pubsub.publish(CONST.TOPIC.APP_SHUTTING_DOWN);
+    process.exit(2);
+  }
 }
 module.exports = HttpServer;
 //https://github.com/nodejs/node-v0.x-archive/issues/5054

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -35,8 +35,8 @@ class BoshDirectorClient extends HttpClient {
     this.deploymentIpsCache = {};
     this.cacheLoadInProgressForDeployment = {};
     this.cacheLoadInProgress = false;
-    //populate UAA objects if uaa based auth is being used by any of the dorectors
     this.uaaObjects = {};
+    //populate UAA objects if uaa based auth is being used by any of the directors
     this.determineDirectorAuthenticationMethod();
     this.ready = this.populateConfigCache();
   }

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -48,8 +48,8 @@ class BoshDirectorClient extends HttpClient {
         let directorName = _.get(directorConfig, 'name', undefined);
         logger.info(`Director ${directorName} uses UAA based authentication. Populating UAA objects in directorConfig.`);
         this.populateUAAObjects(directorConfig);
-        if (_.get(this.uaaObjects, `${directorName}.uaaClient`, undefined) instanceof UaaClient && 
-            _.get(this.uaaObjects, `${directorName}.tokenIssuer`, undefined) instanceof TokenIssuer) {
+        if (_.get(this.uaaObjects, `${directorName}.uaaClient`, undefined) instanceof UaaClient &&
+          _.get(this.uaaObjects, `${directorName}.tokenIssuer`, undefined) instanceof TokenIssuer) {
           logger.info(`UAA based authentication enabled successfully for ${directorName}.`);
           _.set(directorConfig, 'uaaEnabled', true);
         } else {

--- a/data-access-layer/cf/TokenIssuer.js
+++ b/data-access-layer/cf/TokenIssuer.js
@@ -64,18 +64,18 @@ class TokenIssuer {
       .then(result => this.updateTokenInfo(result).accessToken);
   }
 
-  scheduleNextRequestAccessToken(clientId, clientSecret){
+  scheduleNextRequestAccessToken(clientId, clientSecret) {
     const delay = this.tokenInfo.accessTokenExpiresIn - 15;
     logger.info('delay: ', delay);
     if (delay > 0 && delay < 2147483647) {
       this.clearTimeoutObject();
-      logger.info('scheduling next request for access token after delay:', delay*1000);
+      logger.info('scheduling next request for access token after delay:', delay * 1000);
       this.timeoutObject = setTimeout(() => {
         logger.info('requesting new access token with client id: ', clientId);
-        return this.uaa.accessWithClientCredentials(clientId,clientSecret)
+        return this.uaa.accessWithClientCredentials(clientId, clientSecret)
           .then(token => {
             this.tokenInfo.update(token);
-            this.scheduleNextRequestAccessToken(clientId,clientSecret);
+            this.scheduleNextRequestAccessToken(clientId, clientSecret);
           })
           .catch(err => logger.error(err.message));
       }, delay * 1000);
@@ -88,12 +88,12 @@ class TokenIssuer {
       return Promise.resolve(this.tokenInfo.accessToken);
     }
     logger.info('explicit request for access token being made.');
-    return Promise.try(() => this.uaa.accessWithClientCredentials(clientId,clientSecret))
-    .then(result => {
-      this.tokenInfo.update(result);
-      this.scheduleNextRequestAccessToken(clientId, clientSecret);
-      return this.tokenInfo.accessToken;
-    });
+    return Promise.try(() => this.uaa.accessWithClientCredentials(clientId, clientSecret))
+      .then(result => {
+        this.tokenInfo.update(result);
+        this.scheduleNextRequestAccessToken(clientId, clientSecret);
+        return this.tokenInfo.accessToken;
+      });
   }
 }
 

--- a/data-access-layer/cf/TokenIssuer.js
+++ b/data-access-layer/cf/TokenIssuer.js
@@ -71,7 +71,7 @@ class TokenIssuer {
       this.clearTimeoutObject();
       logger.info('scheduling next request for access token after delay:', delay*1000);
       this.timeoutObject = setTimeout(() => {
-        logger.debug('requesting new access token with client id: ', clientId);
+        logger.info('requesting new access token with client id: ', clientId);
         return this.uaa.accessWithClientCredentials(clientId,clientSecret)
           .then(token => {
             this.tokenInfo.update(token);
@@ -84,10 +84,10 @@ class TokenIssuer {
 
   getAccessTokenBoshUAA(clientId, clientSecret) {
     if (!this.tokenInfo.accessTokenExpiresSoon) {
-      logger.debug('reusing access token.');
+      logger.info('reusing access token.');
       return Promise.resolve(this.tokenInfo.accessToken);
     }
-    logger.debug('explicit request for access token being made.');
+    logger.info('explicit request for access token being made.');
     return Promise.try(() => this.uaa.accessWithClientCredentials(clientId,clientSecret))
     .then(result => {
       this.tokenInfo.update(result);

--- a/data-access-layer/cf/TokenIssuer.js
+++ b/data-access-layer/cf/TokenIssuer.js
@@ -63,6 +63,14 @@ class TokenIssuer {
       .catch(() => this.login())
       .then(result => this.updateTokenInfo(result).accessToken);
   }
+
+  getAccessTokenBoshUAA(clientId, clientSecret){
+    return Promise.try(() => this.uaa.accessWithClientCredentials(clientId,clientSecret))
+    .then(result => {
+      this.tokenInfo.update(result);
+      return this.tokenInfo.accessToken;
+    });
+  }
 }
 
 module.exports = TokenIssuer;

--- a/data-access-layer/cf/TokenIssuer.js
+++ b/data-access-layer/cf/TokenIssuer.js
@@ -77,8 +77,7 @@ class TokenIssuer {
           .then(token => {
             this.tokenInfo.update(token);
             this.scheduleNextRequestAccessToken(clientId, clientSecret);
-          })
-          .catch(err => logger.error(err.message));
+          });
       }, delay * 1000);
     }
   }

--- a/data-access-layer/cf/TokenIssuer.js
+++ b/data-access-layer/cf/TokenIssuer.js
@@ -83,7 +83,7 @@ class TokenIssuer {
   }
 
   getAccessTokenBoshUAA(clientId, clientSecret) {
-    if (!this.tokenInfo.expiresSoon) {
+    if (!this.tokenInfo.accessTokenExpiresSoon) {
       logger.debug('reusing access token.');
       return Promise.resolve(this.tokenInfo.accessToken);
     }

--- a/data-access-layer/cf/UaaClient.js
+++ b/data-access-layer/cf/UaaClient.js
@@ -6,14 +6,17 @@ const HttpClient = require('../../common/utils').HttpClient;
 const config = require('../../common/config');
 
 class UaaClient extends HttpClient {
-  constructor(options) {
+  constructor(options, baseUrl='') {
+    if(!baseUrl){
+      baseUrl = config.cf.token_endpoint;
+    }
     super(_.defaultsDeep({
       headers: {
         Accept: 'application/json'
       },
       followRedirect: false
     }, options, {
-      baseUrl: config.cf.token_endpoint,
+      baseUrl: baseUrl,
       rejectUnauthorized: !config.skip_ssl_validation
     }));
     this.clientId = config.cf.client_id || 'cf';
@@ -132,6 +135,23 @@ class UaaClient extends HttpClient {
       form: {
         grant_type: 'refresh_token',
         refresh_token: refreshToken
+      }
+    }, 200).then((res) => {
+      return JSON.parse(res.body);
+    });
+  }
+
+  accessWithClientCredentials(clientId,clientSecret){
+    return this.request({
+      method: 'POST',
+      url: '/oauth/token',
+      auth: {
+        user: clientId,
+        pass: clientSecret
+      },
+      form: {
+        grant_type: 'client_credentials',
+        response_type: 'token'
       }
     }, 200).then((res) => {
       return JSON.parse(res.body);

--- a/data-access-layer/cf/UaaClient.js
+++ b/data-access-layer/cf/UaaClient.js
@@ -6,8 +6,8 @@ const HttpClient = require('../../common/utils').HttpClient;
 const config = require('../../common/config');
 
 class UaaClient extends HttpClient {
-  constructor(options, baseUrl='') {
-    if(!baseUrl){
+  constructor(options, baseUrl = '') {
+    if (!baseUrl) {
       baseUrl = config.cf.token_endpoint;
     }
     super(_.defaultsDeep({
@@ -141,7 +141,7 @@ class UaaClient extends HttpClient {
     });
   }
 
-  accessWithClientCredentials(clientId,clientSecret){
+  accessWithClientCredentials(clientId, clientSecret) {
     return this.request({
       method: 'POST',
       url: '/oauth/token',

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -872,7 +872,7 @@ describe('bosh', () => {
             'client_id': 'client_id',
             'client_secret': 'client_secret',
             'uaa_url': 'uaa_url',
-            'uaa_auth': 'true'
+            'uaa_auth': true
           }
         }];
         let mockBoshClient = new MockBoshDirectorClient();
@@ -910,7 +910,7 @@ describe('bosh', () => {
             'client_id': 'client_id',
             'client_secret': 'client_secret',
             'uaa_url': 'uaa_url',
-            'uaa_auth': 'true'
+            'uaa_auth': true
           }
         };
 
@@ -919,15 +919,15 @@ describe('bosh', () => {
 
         //assert whether valid objects were popoulatd or not 
         assert(mockBoshClient.uaaObjects[directorConfig.name] !== undefined);
-        assert(mockBoshClient.uaaObjects[directorConfig.name].client_id === directorConfig.uaa.client_id);
-        assert(mockBoshClient.uaaObjects[directorConfig.name].client_secret === directorConfig.uaa.client_secret);
+        assert(mockBoshClient.uaaObjects[directorConfig.name].clientId === directorConfig.uaa.client_id);
+        assert(mockBoshClient.uaaObjects[directorConfig.name].clientSecret === directorConfig.uaa.client_secret);
         assert(mockBoshClient.uaaObjects[directorConfig.name].uaaClient instanceof UaaClient);
         assert(mockBoshClient.uaaObjects[directorConfig.name].tokenIssuer instanceof TokenIssuer);
       });
 
       it('should not populate UAA objects when invalid information is provided in directorConfig', () => {
         let directorConfig = {
-          'name': 'bosh',
+          'name': 'bosh'
         };
 
         let mockBoshClient = new MockBoshDirectorClient();
@@ -940,7 +940,7 @@ describe('bosh', () => {
           'uaa': {
             'client_id': 'client_id',
             'client_secret': 'client_secret',
-            'uaa_auth': 'true'
+            'uaa_auth': true
           }
         };
 

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -932,7 +932,6 @@ describe('bosh', () => {
 
         let mockBoshClient = new MockBoshDirectorClient();
         mockBoshClient.populateUAAObjects(directorConfig);
-        console.log(config.directors);
         assert(mockBoshClient.uaaObjects[directorConfig.name] === undefined);
 
         //To cover the branch when uaa_url is not provided

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -953,7 +953,8 @@ describe('bosh', () => {
     });
 
     describe('#makeRequestWithConfigWithUAA', () => {
-      it.only('should make request with token based auth', (done) => {
+      it('should make request with token based auth', (done) => {
+        /* jshint expr:true */
         let prevConfigDirectors = config.directors;
         config.directors = [{
           'name': 'bosh',
@@ -985,13 +986,13 @@ describe('bosh', () => {
         let requestStub = sandbox.stub(HttpClient.prototype, 'request');
         getAccessTokenBoshUAAStub.returns(tokenNotExpired);
 
-        dummyBoshDirectorClient.makeRequestWithConfig({},200,directorConfig)
-        .then(() => {
-          expect(requestStub).to.be.calledOnce;
-          sandbox.restore();
-          config.directors = prevConfigDirectors;
-          done();
-        });
+        dummyBoshDirectorClient.makeRequestWithConfig({}, 200, directorConfig)
+          .then(() => {
+            expect(requestStub).to.be.calledOnce;
+            sandbox.restore();
+            config.directors = prevConfigDirectors;
+            done();
+          });
       });
     });
   });

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -14,7 +14,6 @@ const utils = require('../../common/utils');
 const HttpClient = utils.HttpClient;
 const UaaClient = require('../../data-access-layer/cf/UaaClient');
 const TokenIssuer = require('../../data-access-layer/cf/TokenIssuer');
-const HttpServer = require('../../common/HttpServer');
 const yaml = require('js-yaml');
 const assert = require('assert');
 const id = uuid.v4();
@@ -896,7 +895,6 @@ describe('bosh', () => {
           }
         }];
         let sandbox = sinon.sandbox.create();
-        //let immediateShutdownStub = sandbox.stub(HttpServer, 'immediateShutdown');
         let processExitStub = sandbox.stub(process, 'exit');
         let mock = new MockBoshDirectorClient();
         expect(processExitStub).to.be.calledOnce;

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -10,7 +10,11 @@ const logger = require('../../common/logger');
 const NotFound = errors.NotFound;
 const BadRequest = errors.BadRequest;
 const BoshDirectorClient = require('../../data-access-layer/bosh/BoshDirectorClient');
+const UaaClient = require('../../data-access-layer/cf/UaaClient');
+const TokenIssuer = require('../../data-access-layer/cf/TokenIssuer');
+const HttpServer = require('../../common/HttpServer');
 const yaml = require('js-yaml');
+const assert = require('assert');
 const id = uuid.v4();
 const deployment_name = id;
 const taskId = Math.floor(Math.random() * 123456789);
@@ -855,6 +859,95 @@ describe('bosh', () => {
         expect(content).to.be.a('string');
         expect(content).to.equal('path');
         done();
+      });
+    });
+
+    describe('#determineDirectorAuthenticationMethod', () => {
+      it('should set uaaEnabled true when valid config is provided', () => {
+        //inject test config in config.directors
+        let prevConfigDirectors = config.directors;
+        config.directors = [{
+          'name': 'bosh',
+          'uaa': {
+            'client_id': 'client_id',
+            'client_secret': 'client_secret',
+            'uaa_url': 'uaa_url',
+            'uaa_auth': 'true'
+          }
+        }];
+        let mockBoshClient = new MockBoshDirectorClient();
+        //clear uaa objects cache
+        mockBoshClient.uaaObjects = {};
+        mockBoshClient.determineDirectorAuthenticationMethod();
+        assert(config.directors[0].uaaEnabled === true);
+        config.directors = prevConfigDirectors;
+      });
+
+      it('should call shutdown in the event of failure to initialize', () => {
+        /* jshint expr:true */
+        /* jshint unused:false */
+        let prevConfigDirectors = config.directors;
+        config.directors = [{
+          'name': 'bosh',
+          'uaa': {
+            'uaa_auth': true
+          }
+        }];
+        let sandbox = sinon.sandbox.create();
+        let immediateShutdownStub = sandbox.stub(HttpServer, 'immediateShutdown');
+        let mock = new MockBoshDirectorClient();
+        expect(immediateShutdownStub).to.be.calledOnce;
+        config.directors = prevConfigDirectors;
+        sandbox.restore();
+      });
+    });
+
+    describe('#populateUAAObjects', () => {
+      it('should populate valid UAA objects when valid information is provided in directorConfig', () => {
+        let directorConfig = {
+          'name': 'bosh',
+          'uaa': {
+            'client_id': 'client_id',
+            'client_secret': 'client_secret',
+            'uaa_url': 'uaa_url',
+            'uaa_auth': 'true'
+          }
+        };
+
+        let mockBoshClient = new MockBoshDirectorClient();
+        mockBoshClient.populateUAAObjects(directorConfig);
+
+        //assert whether valid objects were popoulatd or not 
+        assert(mockBoshClient.uaaObjects[directorConfig.name] !== undefined);
+        assert(mockBoshClient.uaaObjects[directorConfig.name].client_id === directorConfig.uaa.client_id);
+        assert(mockBoshClient.uaaObjects[directorConfig.name].client_secret === directorConfig.uaa.client_secret);
+        assert(mockBoshClient.uaaObjects[directorConfig.name].uaaClient instanceof UaaClient);
+        assert(mockBoshClient.uaaObjects[directorConfig.name].tokenIssuer instanceof TokenIssuer);
+      });
+
+      it('should not populate UAA objects when invalid information is provided in directorConfig', () => {
+        let directorConfig = {
+          'name': 'bosh',
+        };
+
+        let mockBoshClient = new MockBoshDirectorClient();
+        mockBoshClient.populateUAAObjects(directorConfig);
+        console.log(config.directors);
+        assert(mockBoshClient.uaaObjects[directorConfig.name] === undefined);
+
+        //To cover the branch when uaa_url is not provided
+        directorConfig = {
+          'name': 'bosh',
+          'uaa': {
+            'client_id': 'client_id',
+            'client_secret': 'client_secret',
+            'uaa_auth': 'true'
+          }
+        };
+
+        mockBoshClient.populateUAAObjects(directorConfig);
+        assert(mockBoshClient.uaaObjects[directorConfig.name] === undefined);
+
       });
     });
   });

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -896,9 +896,10 @@ describe('bosh', () => {
           }
         }];
         let sandbox = sinon.sandbox.create();
-        let immediateShutdownStub = sandbox.stub(HttpServer, 'immediateShutdown');
+        //let immediateShutdownStub = sandbox.stub(HttpServer, 'immediateShutdown');
+        let processExitStub = sandbox.stub(process, 'exit');
         let mock = new MockBoshDirectorClient();
-        expect(immediateShutdownStub).to.be.calledOnce;
+        expect(processExitStub).to.be.calledOnce;
         config.directors = prevConfigDirectors;
         sandbox.restore();
       });

--- a/test/test_broker/cf.TokenIssuer.spec.js
+++ b/test/test_broker/cf.TokenIssuer.spec.js
@@ -181,11 +181,11 @@ describe('cf', () => {
         //setup stubs
         this.clock = sinon.useFakeTimers(Date.now());
         tokenIssuer.scheduleNextRequestAccessToken('dummy', 'dummy');
-        this.clock.tick(delay*1000);
+        this.clock.tick(delay * 1000);
         this.clock.restore();
 
         setTimeout(() => {
-          assert(tokenIssuer.tokenInfo.accessToken == tokenNotExpired);
+          assert(tokenIssuer.tokenInfo.accessToken === tokenNotExpired);
         }, 2000);
       }).timeout(4000);
     });

--- a/test/test_broker/cf.TokenIssuer.spec.js
+++ b/test/test_broker/cf.TokenIssuer.spec.js
@@ -30,6 +30,11 @@ describe('cf', () => {
         } else {
           return Promise.reject(tokenInfoExpired);
         }
+      },
+      accessWithClientCredentials: function (client_id, client_secret){
+        return Promise.try(() => {
+          return tokenInfoNotExpired;
+        });
       }
     };
     let tokenIssuer = new TokenIssuer(uaa);
@@ -118,6 +123,45 @@ describe('cf', () => {
           expect(content).to.eql(expiredToken);
           done();
         }).catch(done);
+      });
+    });
+    describe('getAccessTokenBoshUAA', () => {
+      it('should return existing access token (accessToken does not expire soon)', (done) => {
+        tokenIssuer.updateTokenInfo(tokenInfoNotExpired);
+        tokenIssuer.getAccessTokenBoshUAA().then((content) => {
+          expect(content).to.eql(tokenNotExpired);
+          done();
+        }).catch(done);
+      });
+
+      it('should make explicit request for access token (access token expires soon)', (done) => {
+        tokenIssuer.updateTokenInfo(tokenInfoExpired);
+        let sandbox = sinon.sandbox.create();
+        let scheduleAccessTokenStub = sandbox.stub(tokenIssuer, 'scheduleNextRequestAccessToken');
+        tokenIssuer.getAccessTokenBoshUAA().then((content) => {
+          expect(content).to.eql(tokenNotExpired);
+          expect(scheduleAccessTokenStub).to.be.calledOnce;
+          sandbox.restore();
+          done();
+        }).catch(done);
+      });
+    });
+
+    describe('scheduleNextRequestAccessToken', () => {
+      it('should create a valid timeout object', () => {
+        //IST: Sunday, August 25, 2086 3:36:08 AM. Delay < 2147483647, as per condition in this function.
+        let tokenExpiresSpecificDate = 'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjM2ODEwNjUxNjh9';
+        let tokenInfoSpecific = {
+          access_token: tokenExpiresSpecificDate,
+          refresh_token: tokenExpiresSpecificDate,
+          token_type: 'bearer'
+        };
+        tokenIssuer.updateTokenInfo(tokenInfoSpecific);
+        let sandbox = sinon.sandbox.create();
+        let setTimeoutStub = sandbox.stub(global, 'setTimeout')
+        tokenIssuer.scheduleNextRequestAccessToken();
+        expect(setTimeoutStub).to.be.calledOnce;
+        sandbox.restore();
       });
     });
   });

--- a/test/test_broker/cf.TokenIssuer.spec.js
+++ b/test/test_broker/cf.TokenIssuer.spec.js
@@ -31,7 +31,8 @@ describe('cf', () => {
           return Promise.reject(tokenInfoExpired);
         }
       },
-      accessWithClientCredentials: function (client_id, client_secret){
+      accessWithClientCredentials: function (client_id, client_secret) {
+        /* jshint unused:false */
         return Promise.try(() => {
           return tokenInfoNotExpired;
         });
@@ -135,6 +136,7 @@ describe('cf', () => {
       });
 
       it('should make explicit request for access token (access token expires soon)', (done) => {
+        /* jshint expr:true */
         tokenIssuer.updateTokenInfo(tokenInfoExpired);
         let sandbox = sinon.sandbox.create();
         let scheduleAccessTokenStub = sandbox.stub(tokenIssuer, 'scheduleNextRequestAccessToken');
@@ -149,6 +151,7 @@ describe('cf', () => {
 
     describe('scheduleNextRequestAccessToken', () => {
       it('should create a valid timeout object', () => {
+        /* jshint expr:true */
         //IST: Sunday, August 25, 2086 3:36:08 AM. Delay < 2147483647, as per condition in this function.
         let tokenExpiresSpecificDate = 'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjM2ODEwNjUxNjh9';
         let tokenInfoSpecific = {
@@ -158,7 +161,7 @@ describe('cf', () => {
         };
         tokenIssuer.updateTokenInfo(tokenInfoSpecific);
         let sandbox = sinon.sandbox.create();
-        let setTimeoutStub = sandbox.stub(global, 'setTimeout')
+        let setTimeoutStub = sandbox.stub(global, 'setTimeout');
         tokenIssuer.scheduleNextRequestAccessToken();
         expect(setTimeoutStub).to.be.calledOnce;
         sandbox.restore();

--- a/test/test_broker/cf.TokenIssuer.spec.js
+++ b/test/test_broker/cf.TokenIssuer.spec.js
@@ -114,6 +114,7 @@ describe('cf', () => {
         tokenIssuer.updateTokenInfo(tokenInfoNotExpired);
         tokenIssuer.getAccessToken().then((content) => {
           expect(content).to.eql(expiredToken);
+          tokenInfoNotExpired.access_token = tokenNotExpired;
           done();
         }).catch(done);
       });
@@ -126,10 +127,11 @@ describe('cf', () => {
         }).catch(done);
       });
     });
+
     describe('getAccessTokenBoshUAA', () => {
       it('should return existing access token (accessToken does not expire soon)', (done) => {
-        tokenIssuer.updateTokenInfo(tokenInfoNotExpired);
-        tokenIssuer.getAccessTokenBoshUAA().then((content) => {
+        tokenIssuer.tokenInfo.update(tokenInfoNotExpired);
+        tokenIssuer.getAccessTokenBoshUAA().then(content => {
           expect(content).to.eql(tokenNotExpired);
           done();
         }).catch(done);
@@ -137,10 +139,10 @@ describe('cf', () => {
 
       it('should make explicit request for access token (access token expires soon)', (done) => {
         /* jshint expr:true */
-        tokenIssuer.updateTokenInfo(tokenInfoExpired);
+        tokenIssuer.tokenInfo.update(tokenInfoExpired);
         let sandbox = sinon.sandbox.create();
         let scheduleAccessTokenStub = sandbox.stub(tokenIssuer, 'scheduleNextRequestAccessToken');
-        tokenIssuer.getAccessTokenBoshUAA().then((content) => {
+        tokenIssuer.getAccessTokenBoshUAA().then(content => {
           expect(content).to.eql(tokenNotExpired);
           expect(scheduleAccessTokenStub).to.be.calledOnce;
           sandbox.restore();

--- a/test/test_broker/cf.TokenIssuer.spec.js
+++ b/test/test_broker/cf.TokenIssuer.spec.js
@@ -169,7 +169,7 @@ describe('cf', () => {
         sandbox.restore();
       });
 
-      it('should make correct requests after timeout', () => {
+      it('should make correct requests after timeout', (done) => {
         let tokenExpiresSpecificDate = 'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjM2ODEwNjUxNjh9';
         let tokenInfoSpecific = {
           access_token: tokenExpiresSpecificDate,
@@ -186,6 +186,8 @@ describe('cf', () => {
 
         setTimeout(() => {
           assert(tokenIssuer.tokenInfo.accessToken === tokenNotExpired);
+          console.log('here');
+          done();
         }, 2000);
       }).timeout(4000);
     });

--- a/test/test_broker/cf.UaaClient.spec.js
+++ b/test/test_broker/cf.UaaClient.spec.js
@@ -109,5 +109,18 @@ describe('cf', () => {
         }).catch(done);
       });
     });
+
+    describe('#accessWithClientCredentials', () => {
+      it('returns a JSON object', (done) => {
+        let body = {
+          uuid: uuid.v4()
+        };
+
+        new MockUaaClient(JSON.stringify(body), 200).accessWithClientCredentials('client_id', 'client_secret').then((content) => {
+          expect(content).to.eql(body);
+          done();
+        }).catch(done);
+      });
+    });
   });
 });


### PR DESCRIPTION
* Concerned issue is: https://github.com/cloudfoundry-incubator/service-fabrik-broker/issues/353
* Based on information provided in the settings.yml, required objects for UAA based authentication are populated for each bosh director while creating BoshDirectorClient.
* Also added method to access UAA server with client credentials grant.
* Finally, added methods for contacting to Bosh UAA for access token and periodic request for the same.
* Currently, some of the integration tests are failing as test scripts themselves don't support token based authentication while contacting Bosh. I will continue to work on same and update here, adding  'DO NOT MERGE' tag till then. **UPDATE: Lifecycle test green on dev landscape.**