### PR TITLE
Deleting Transaction Logs after successful backup

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -379,6 +379,7 @@ defaults: &defaults
     num_of_allowed_restores: 10 # Number of allowed restores in restore_history_days
     restore_history_days: 30 # Max allowed restores  10 in 30 days
     reschedule_backup_delay_after_restore: 3 #(minute)
+    transaction_logs_delete_buffer_time: 10 #(minute)
 
     provider:
       name: openstack

--- a/data-access-layer/iaas/BackupStore.js
+++ b/data-access-layer/iaas/BackupStore.js
@@ -34,8 +34,7 @@ class BackupStore {
 
   listFilenames(prefix, predicate, iteratees, container, dontParseFilename) {
     const options = {
-      prefix: prefix,
-      container: container
+      prefix: prefix
     };
 
     const self = this;
@@ -46,8 +45,7 @@ class BackupStore {
       level++;
       logger.debug(`Fetching recursively at level : ${level}`);
       const promise = new Promise(function (resolve, reject) {
-        self.cloudProvider
-          .list(options)
+        Promise.try(() => container ? self.cloudProvider.list(container, options) : self.cloudProvider.list(options))
           .then(files => {
             logger.debug('list of files recieved - ', files);
             if (files && files.length > 0) {

--- a/data-access-layer/iaas/BackupStore.js
+++ b/data-access-layer/iaas/BackupStore.js
@@ -277,7 +277,7 @@ class BackupStore {
       .then(isoDate => this.listBackupFiles(options, getPredicate(isoDate), iteratees));
   }
 
-  listTransactionLogsOlderThan(options, dateOlderThan, container) {
+  listFilesOlderThan(options, dateOlderThan, container) {
     const iteratees = ['lastModified'];
     let prefix = options.prefix;
 

--- a/data-access-layer/iaas/BackupStore.js
+++ b/data-access-layer/iaas/BackupStore.js
@@ -32,9 +32,10 @@ class BackupStore {
     return _.nth(/^(.+)-broker$/.exec(this.containerName), 1);
   }
 
-  listFilenames(prefix, predicate, iteratees, dontParseFilename) {
+  listFilenames(prefix, predicate, iteratees, container, dontParseFilename) {
     const options = {
-      prefix: prefix
+      prefix: prefix,
+      container: container
     };
 
     const self = this;
@@ -276,20 +277,20 @@ class BackupStore {
       .then(isoDate => this.listBackupFiles(options, getPredicate(isoDate), iteratees));
   }
 
-  listTransactionLogsOlderThan(options, dateOlderThan) {
+  listTransactionLogsOlderThan(options, dateOlderThan, container) {
     const iteratees = ['lastModified'];
     let prefix = options.prefix;
 
     function getPredicate(isoDate) {
       return function predicate(filenameobject) {
         //transactionLogsDeletionStartDate defaults to current timestamp as part of isoDate function.
-        return _.lt(filenameobject.lastModified, isoDate);
+        return _.lt(new Date(filenameobject.lastModified).toISOString(), isoDate);
       };
     }
 
     return Promise
       .try(() => this.filename.isoDate(dateOlderThan))
-      .then(isoDate => this.listFilenames(prefix, getPredicate(isoDate), iteratees, true));
+      .then(isoDate => this.listFilenames(prefix, getPredicate(isoDate), iteratees, container, true));
   }
 }
 

--- a/data-access-layer/iaas/CloudProviderClient.js
+++ b/data-access-layer/iaas/CloudProviderClient.js
@@ -61,10 +61,10 @@ class CloudProviderClient extends BaseCloudClient {
   list(container, options) {
     if (arguments.length < 2) {
       options = container;
-      container = _.get(options, 'container') || this.containerName;
+      container = this.containerName;
     }
     return this.storage
-      .getFilesAsync(container, _.omit(options, 'container'))
+      .getFilesAsync(container, options)
       .then(listOfFiles => {
         let list = [];
         let isTruncated = false;

--- a/data-access-layer/iaas/CloudProviderClient.js
+++ b/data-access-layer/iaas/CloudProviderClient.js
@@ -61,10 +61,10 @@ class CloudProviderClient extends BaseCloudClient {
   list(container, options) {
     if (arguments.length < 2) {
       options = container;
-      container = this.containerName;
+      container = _.get(options, 'container') || this.containerName;
     }
     return this.storage
-      .getFilesAsync(container, options)
+      .getFilesAsync(container, _.omit(options, 'container'))
       .then(listOfFiles => {
         let list = [];
         let isTruncated = false;
@@ -75,7 +75,7 @@ class CloudProviderClient extends BaseCloudClient {
           list = listOfFiles;
         }
         const files = [];
-        _.each(list, file =>  files.push(_
+        _.each(list, file => files.push(_
           .chain(file)
           .pick('name', 'lastModified')
           .set('isTruncated', isTruncated)

--- a/test/test_broker/jobs.ScheduleBackupJob.spec.js
+++ b/test/test_broker/jobs.ScheduleBackupJob.spec.js
@@ -222,7 +222,7 @@ describe('Jobs', function () {
         ]);
         mocks.cloudProvider.list(serviceContainer, transactionLogsPrefix, [
           transactionLogsFileName14Daysprior
-        ]);
+        ], undefined, undefined, new Date() - (config.backup.retention_period_in_days + 5) * 60 * 60 * 24 * 1000);
         //Out of 4 files 1 and 14 day prior is filtered out 
         // & the 18 day prior on demand will not be deleted
         mocks.cloudProvider.download(pathname14,

--- a/test/test_broker/jobs.ScheduleBackupJob.spec.js
+++ b/test/test_broker/jobs.ScheduleBackupJob.spec.js
@@ -184,7 +184,8 @@ describe('Jobs', function () {
             delete_backup_status: {
               deleted_guids: [backup_guid16, undefined],
               job_cancelled: false,
-              instance_deleted: false
+              instance_deleted: false,
+              deleted_transaction_log_files_count: 0
             }
           };
           expect(baseJobLogRunHistoryStub).to.be.calledTwice;
@@ -227,11 +228,12 @@ describe('Jobs', function () {
             },
             delete_backup_status: {
               deleted_guids: [backup_guid2],
+              deleted_transaction_log_files_count: 0,
               job_cancelled: false,
               instance_deleted: false
             }
           };
-          expect(baseJobLogRunHistoryStub).to.be.calledOnce;
+          expect(baseJobLogRunHistoryStub).to.be.calledTwice;
           expect(baseJobLogRunHistoryStub.firstCall.args[0]).to.eql(undefined);
           expect(baseJobLogRunHistoryStub.firstCall.args[1]).to.deep.equal(expectedBackupResponse);
           expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
@@ -269,6 +271,7 @@ describe('Jobs', function () {
             },
             delete_backup_status: {
               deleted_guids: [],
+              deleted_transaction_log_files_count: 0,
               job_cancelled: false,
               instance_deleted: false
             }
@@ -280,7 +283,7 @@ describe('Jobs', function () {
           expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
         });
       });
-
+      //modify this to add op-logs.
       it('should initiate backup, should  delete backups older than 15 days when unsuccessful', function () {
         const backupResponse = {
           backup_guid: backup_guid
@@ -315,6 +318,7 @@ describe('Jobs', function () {
             },
             delete_backup_status: {
               deleted_guids: [backup_guid, backup_guid16, backup_guid2],
+              deleted_transaction_log_files_count: 0,
               job_cancelled: false,
               instance_deleted: false
             }
@@ -458,6 +462,7 @@ describe('Jobs', function () {
           expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
         });
       });
+      //modify this to add op-logs deletion too.
       it('should delete scheduled backup & any on-demand backups even when service instance is deleted', function () {
         mocks.cloudController.findServicePlan(instance_id);
         mocks.cloudProvider.list(container, prefix, [
@@ -481,6 +486,7 @@ describe('Jobs', function () {
             start_backup_status: 'instance_deleted',
             delete_backup_status: {
               deleted_guids: [backup_guid16, backup_guid2],
+              deleted_transaction_log_files_count: 0,
               job_cancelled: false,
               instance_deleted: true
             }
@@ -502,6 +508,7 @@ describe('Jobs', function () {
             start_backup_status: 'instance_deleted',
             delete_backup_status: {
               deleted_guids: [],
+              deleted_transaction_log_files_count: 0,
               job_cancelled: true,
               instance_deleted: true
             }
@@ -527,6 +534,7 @@ describe('Jobs', function () {
             start_backup_status: 'instance_deleted',
             delete_backup_status: {
               deleted_guids: [],
+              deleted_transaction_log_files_count: 0,
               job_cancelled: false,
               instance_deleted: true
             }

--- a/test/test_broker/jobs.ScheduleBackupJob.spec.js
+++ b/test/test_broker/jobs.ScheduleBackupJob.spec.js
@@ -190,7 +190,7 @@ describe('Jobs', function () {
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //3 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,
@@ -256,7 +256,7 @@ describe('Jobs', function () {
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,
@@ -325,7 +325,7 @@ describe('Jobs', function () {
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,
@@ -333,7 +333,7 @@ describe('Jobs', function () {
           },
           {
             file_name: transactionLogsFileName18DaysPrior,
-            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
           }
         ]);
         //Out of 4 files 1 day prior is filtered out.
@@ -391,7 +391,7 @@ describe('Jobs', function () {
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,
@@ -587,7 +587,7 @@ describe('Jobs', function () {
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,

--- a/test/test_broker/jobs.ScheduleBackupJob.spec.js
+++ b/test/test_broker/jobs.ScheduleBackupJob.spec.js
@@ -59,7 +59,6 @@ describe('Jobs', function () {
       const transactionLogsPathname19 = `/${serviceContainer}/${transactionLogsFileName19Daysprior}`;
       const transactionLogsPathname16 = `/${serviceContainer}/${transactionLogsFileName16DaysPrior}`;
       const transactionLogsPathname18 = `/${serviceContainer}/${transactionLogsFileName18DaysPrior}`;
-      const transactionLogsPathname14 = `/${serviceContainer}/${transactionLogsFileName14DaysPrior}`;
       const scheduled_data = {
         trigger: CONST.BACKUP.TRIGGER.SCHEDULED,
         type: 'online',
@@ -183,23 +182,23 @@ describe('Jobs', function () {
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
             file_name: transactionLogsFileName1Daysprior,
-            last_modified: new Date() - 1 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName19Daysprior,
-            last_modified: new Date() - 19 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: new Date() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,
-            last_modified: new Date() - 14 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName18DaysPrior,
-            last_modified: new Date() - 18 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
           }
         ]);
         //Out of 4 files 1 and 14 day prior is filtered out 
@@ -249,23 +248,23 @@ describe('Jobs', function () {
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
             file_name: transactionLogsFileName1Daysprior,
-            last_modified: new Date() - 1 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName19Daysprior,
-            last_modified: new Date() - 19 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: new Date() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,
-            last_modified: new Date() - 14 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName18DaysPrior,
-            last_modified: new Date() - 18 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
           }
         ]);
         //Out of 4 files 1 and 14 day prior is filtered out 
@@ -318,23 +317,23 @@ describe('Jobs', function () {
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
             file_name: transactionLogsFileName1Daysprior,
-            last_modified: new Date() - 1 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName19Daysprior,
-            last_modified: new Date() - 19 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: new Date() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,
-            last_modified: new Date() - 14 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName18DaysPrior,
-            last_modified: new Date() - 18 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
           }
         ]);
         //Out of 4 files 1 day prior is filtered out.
@@ -367,7 +366,6 @@ describe('Jobs', function () {
           expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
         });
       });
-      //modify this to add op-logs.
       it('should initiate backup, should  delete backups and transaction logs older than 15 days when unsuccessful', function () {
         const backupResponse = {
           backup_guid: backup_guid
@@ -385,23 +383,23 @@ describe('Jobs', function () {
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
             file_name: transactionLogsFileName1Daysprior,
-            last_modified: new Date() - 1 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName19Daysprior,
-            last_modified: new Date() - 19 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: new Date() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,
-            last_modified: new Date() - 14 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName18DaysPrior,
-            last_modified: new Date() - 18 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
           }
         ]);
         //Out of 4 files 1 day prior is filtered out.
@@ -417,7 +415,6 @@ describe('Jobs', function () {
         //Deletes transactionLogs older than retention period only. Hence, transactionLog older than 1 day is not deleted.
         mocks.cloudProvider.remove(transactionLogsPathname19);
         mocks.cloudProvider.remove(transactionLogsPathname18);
-        mocks.cloudProvider.remove(transactionLogsPathname14);
         mocks.cloudProvider.remove(transactionLogsPathname16);
         return ScheduleBackupJob.run(job, () => {
           mocks.verify();
@@ -428,7 +425,7 @@ describe('Jobs', function () {
             },
             delete_backup_status: {
               deleted_guids: [backup_guid, backup_guid16, backup_guid2],
-              deleted_transaction_log_files_count: 4,
+              deleted_transaction_log_files_count: 3,
               job_cancelled: false,
               instance_deleted: false
             }
@@ -582,33 +579,33 @@ describe('Jobs', function () {
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
             file_name: transactionLogsFileName1Daysprior,
-            last_modified: new Date() - 1 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName19Daysprior,
-            last_modified: new Date() - 19 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName16DaysPrior,
-            last_modified: new Date() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 3000 * 60 //3 mins = buffer time
           },
           {
             file_name: transactionLogsFileName14DaysPrior,
-            last_modified: new Date() - 14 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName18DaysPrior,
-            last_modified: new Date() - 18 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
           }
         ]);
         // This list method will be invoked after the deletion. The transaction logs which are not older than 14 days should remain.
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
             file_name: transactionLogsFileName14DaysPrior,
-            last_modified: new Date() - 14 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
           },
           {
             file_name: transactionLogsFileName1Daysprior,
-            last_modified: new Date() - 1 * 60 * 60 * 24 * 1000
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
           }
         ]);
         mocks.cloudProvider.download(pathname14, scheduled_data);

--- a/test/test_broker/jobs.ScheduleBackupJob.spec.js
+++ b/test/test_broker/jobs.ScheduleBackupJob.spec.js
@@ -49,7 +49,7 @@ describe('Jobs', function () {
       const fileName16DaysPrior = `${prefix}.${backup_guid16}.${started16DaysPrior}.json`;
       const fileName18DaysPrior = `${prefix}.${backup_guid2}.${started18DaysPrior}.json`;
       const transactionLogsFileName1Daysprior = `${transactionLogsPrefix}.bson`;
-      const transactionLogsFileName14Daysprior = `${transactionLogsPrefix}.bson`;
+      const transactionLogsFileName19Daysprior = `${transactionLogsPrefix}.bson`;
       const transactionLogsFileName16DaysPrior = `${transactionLogsPrefix}.bson`;
       const transactionLogsFileName18DaysPrior = `${transactionLogsPrefix}.bson`;
       const pathname14 = `/${container}/${fileName14Daysprior}`;
@@ -205,7 +205,7 @@ describe('Jobs', function () {
           expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
         });
       });
-      it('should initiate backup, should delete scheduled backup older than 15 days only beyond one successful backup', function () {
+      it('should initiate backup, should delete scheduled backup older than 15 days and transaction logs older than the latest successful backup before retention-period, beyond one successful backup', function () {
         const backupResponse = {
           backup_guid: backup_guid
         };
@@ -220,9 +220,15 @@ describe('Jobs', function () {
           fileName18DaysPrior,
           fileName1Daysprior
         ]);
-        mocks.cloudProvider.list(serviceContainer, transactionLogsPrefix, [
-          transactionLogsFileName14Daysprior
-        ], undefined, undefined, new Date() - (config.backup.retention_period_in_days + 5) * 60 * 60 * 24 * 1000);
+        mocks.cloudProvider.listTransactionLogs(serviceContainer, transactionLogsPrefix, [{
+            file_name: transactionLogsFileName1Daysprior,
+            last_modified: new Date() - 1 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName19Daysprior,
+            last_modified: new Date() - (config.backup.retention_period_in_days + 3) * 60 * 60 * 24 * 1000
+          }
+        ]);
         //Out of 4 files 1 and 14 day prior is filtered out 
         // & the 18 day prior on demand will not be deleted
         mocks.cloudProvider.download(pathname14,

--- a/test/test_broker/mocks/cloudProvider.js
+++ b/test/test_broker/mocks/cloudProvider.js
@@ -107,7 +107,7 @@ function list(containerName, prefix, filenames, responseStatusCode, times) {
     .chain(filenames)
     .map(name => ({
       name: name,
-      lastModified: new Date().toISOString()
+      last_modified: new Date('2018-07-01T15:57:11.037Z').toISOString()
     }))
     .value();
   const qs = {

--- a/test/test_broker/mocks/cloudProvider.js
+++ b/test/test_broker/mocks/cloudProvider.js
@@ -13,6 +13,7 @@ exports.upload = upload;
 exports.headObject = headObject;
 exports.getContainer = getContainer;
 exports.list = list;
+exports.listTransactionLogs = listTransactionLogs;
 exports.remove = remove;
 
 function auth(times) {
@@ -123,6 +124,29 @@ function list(containerName, prefix, filenames, responseStatusCode, times, lastM
     .query(qs)
     .times(times || 1)
     .reply(responseStatusCode || 200, files, {
+      'X-Container-Object-Count': '42'
+    });
+}
+
+function listTransactionLogs(containerName, prefix, fileObjects) {
+  const files = _
+    .chain(fileObjects)
+    .map(fileObject => ({
+      name: fileObject.file_name,
+      last_modified: new Date(fileObject.last_modified).toISOString()
+    }))
+    .value();
+  const qs = {
+    format: 'json'
+  };
+  if (prefix) {
+    qs.prefix = prefix;
+  }
+  return nock(objectStoreUrl)
+    .replyContentLength()
+    .get(`/${containerName}`)
+    .query(qs)
+    .reply(200, files, {
       'X-Container-Object-Count': '42'
     });
 }

--- a/test/test_broker/mocks/cloudProvider.js
+++ b/test/test_broker/mocks/cloudProvider.js
@@ -102,12 +102,13 @@ function getContainer(containerName) {
     });
 }
 
-function list(containerName, prefix, filenames, responseStatusCode, times) {
+function list(containerName, prefix, filenames, responseStatusCode, times, lastModifiedDate) {
+  const lastModifiedDateISO = lastModifiedDate ? new Date(lastModifiedDate).toISOString() : new Date().toISOString();
   const files = _
     .chain(filenames)
     .map(name => ({
       name: name,
-      last_modified: new Date('2018-07-01T15:57:11.037Z').toISOString()
+      last_modified: lastModifiedDateISO
     }))
     .value();
   const qs = {

--- a/test/test_broker/mocks/cloudProvider.js
+++ b/test/test_broker/mocks/cloudProvider.js
@@ -13,7 +13,7 @@ exports.upload = upload;
 exports.headObject = headObject;
 exports.getContainer = getContainer;
 exports.list = list;
-exports.listTransactionLogs = listTransactionLogs;
+exports.listBlobs = listBlobs;
 exports.remove = remove;
 
 function auth(times) {
@@ -128,7 +128,7 @@ function list(containerName, prefix, filenames, responseStatusCode, times, lastM
     });
 }
 
-function listTransactionLogs(containerName, prefix, fileObjects) {
+function listBlobs(containerName, prefix, fileObjects, times) {
   const files = _
     .chain(fileObjects)
     .map(fileObject => ({
@@ -146,6 +146,7 @@ function listTransactionLogs(containerName, prefix, fileObjects) {
     .replyContentLength()
     .get(`/${containerName}`)
     .query(qs)
+    .times(times || 1)
     .reply(200, files, {
       'X-Container-Object-Count': '42'
     });


### PR DESCRIPTION
Changes include:
1. Adding feature of Transcation-Logs cleanup. (Delete transaction logs taken after the latest successful backup)
a. As part of this, we look for successful backup beyond the retention period and delete transaction logs from that backup time onwards in the past.
e.g. suppose u have a successful backup on 15th day.. it will delete transaction logs from 15th day onwards till the past
b. If there is no successful backup found, we delete the transaction logs older than retention period(+1day), (comparing the retention period from today).
e.g. If today is the 17th day, we will delete all transaction logs older than 15 days (taken on 1st & 2nd day). 
Assuming retention period is 14days here.
2. Modifying existing UTs to also handle transaction-logs cleanup
3. Adding new UTs to cover various scenarios of transaction-logs cleanup 


Related service-fabrik-boshrelease PR:
https://github.com/cloudfoundry-incubator/service-fabrik-boshrelease/pull/112