### PR TITLE
Add functions for stopping and starting BOSH deployments

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -3,6 +3,13 @@
 module.exports = Object.freeze({
   NETWORK_SEGMENT_LENGTH: 4,
   BOSH_POLL_MAX_ATTEMPTS: 3,
+  BOSH_DEPLOYMENT_ACTIONS: {
+    STOPPED: 'stopped',
+    STARTED: 'started',
+    DETACHED: 'detached',
+    RESTART: 'restart',
+    RECREATE: 'recreate'
+  },
   BOSH_RATE_LIMITS: {
     BOSH_CONTEXT_ID: 'X-Bosh-Context-Id',
     BOSH_FABRIK_OP: 'Fabrik::Operation::',

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -771,6 +771,41 @@ class BoshDirectorClient extends HttpClient {
       );
   }
 
+  startDeployment(deploymentName) {
+    return Promise.try(() => {
+        return this
+          .getDirectorConfig(deploymentName);
+      })
+      .then(config => this.invokeDeploymentJobAction(config, deploymentName, CONST.BOSH_DEPLOYMENT_ACTIONS.STARTED));
+  }
+
+  stopDeployment(deploymentName) {
+    return Promise.try(() => {
+        return this
+          .getDirectorConfig(deploymentName);
+      })
+      .then(config => this.invokeDeploymentJobAction(config, deploymentName, CONST.BOSH_DEPLOYMENT_ACTIONS.STOPPED));
+  }
+
+  invokeDeploymentJobAction(directorConfig, deploymentName, expectedState) {
+    return this
+      .makeRequestWithConfig({
+        method: 'PUT',
+        url: `/deployments/${deploymentName}/jobs/*`,
+        headers: {
+          'content-type': 'text/yaml'
+        },
+        qs: {
+          'state': expectedState
+        }
+      }, 302, directorConfig)
+      .then(res => {
+        const taskId = this.lastSegment(res.headers.location);
+        logger.info(`Sent signal to ${deploymentName} for result state ${expectedState}, BOSH task ID: ${taskId}`);
+        return taskId;
+      });
+  }
+
   getTaskEvents(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -601,6 +601,46 @@ describe('bosh', () => {
       });
     });
 
+    describe('#startDeployment', () => {
+      let sandbox, getDirectorConfigStub, request, response;
+      let mockBoshDirectorClient;
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        request = {
+          method: 'PUT',
+          url: `/deployments/${id}/jobs/*`,
+          qs: {
+            state: 'started'
+          },
+          headers: {
+            'content-type': 'text/yaml'
+          }
+        };
+        response = {
+          statusCode: 302,
+          headers: {
+            location: '/tasks/taskId'
+          }
+        };
+        mockBoshDirectorClient = new MockBoshDirectorClient(request, response);
+        getDirectorConfigStub = sandbox.stub(mockBoshDirectorClient, 'getDirectorConfig');
+        getDirectorConfigStub
+          .withArgs(deployment_name)
+          .returns(Promise.try(() => {
+            return {
+              key: 1234
+            };
+          }));
+      });
+      it('sends start signal for deployment', (done) => {
+        return mockBoshDirectorClient.startDeployment(id)
+          .then(taskId => {
+            expect(taskId).to.equal('taskId');
+            done();
+          });
+      });
+    });
+
     describe('#createOrUpdateDeploymentProperty', () => {
       it('returns correct status code', (done) => {
         let request = {

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -601,6 +601,45 @@ describe('bosh', () => {
       });
     });
 
+    describe('#stopDeployment', () => {
+      let sandbox, getDirectorConfigStub, request, response;
+      let mockBoshDirectorClient;
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        request = {
+          method: 'PUT',
+          url: `/deployments/${deployment_name}/jobs/*`,
+          qs: {
+            state: 'stopped'
+          },
+          headers: {
+            'content-type': 'text/yaml'
+          }
+        };
+        response = {
+          statusCode: 302,
+          headers: {
+            location: '/tasks/taskId'
+          }
+        };
+        mockBoshDirectorClient = new MockBoshDirectorClient(request, response);
+        getDirectorConfigStub = sandbox.stub(mockBoshDirectorClient, 'getDirectorConfig');
+        getDirectorConfigStub
+          .withArgs(deployment_name)
+          .returns(Promise.try(() => {
+            return {
+              key: 1234
+            };
+          }));
+      });
+      it('sends start signal for deployment', () => {
+        return mockBoshDirectorClient.stopDeployment(id)
+          .then(taskId => {
+            expect(taskId).to.equal('taskId');
+          });
+      });
+    });
+
     describe('#startDeployment', () => {
       let sandbox, getDirectorConfigStub, request, response;
       let mockBoshDirectorClient;
@@ -608,7 +647,7 @@ describe('bosh', () => {
         sandbox = sinon.sandbox.create();
         request = {
           method: 'PUT',
-          url: `/deployments/${id}/jobs/*`,
+          url: `/deployments/${deployment_name}/jobs/*`,
           qs: {
             state: 'started'
           },
@@ -632,11 +671,10 @@ describe('bosh', () => {
             };
           }));
       });
-      it('sends start signal for deployment', (done) => {
+      it('sends start signal for deployment', () => {
         return mockBoshDirectorClient.startDeployment(id)
           .then(taskId => {
             expect(taskId).to.equal('taskId');
-            done();
           });
       });
     });


### PR DESCRIPTION
- This is required for the upcoming restore hooks flow where these functions would be invoked as part of the recovery process to speed up recovery time. As of now, these functions are not invoked. The start and stop functions start and stop all jobs of the provided BOSH deployment and returns a composite task ID for the operation. Callers must poll for the task operation status.