### PR TITLE
Changing the constant for the apiserver sync resource state timeout

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -233,7 +233,7 @@ module.exports = Object.freeze({
     }
   },
   APISERVER: {
-    OPERATION_TIMEOUT_IN_SECS: 60,
+    OPERATION_TIMEOUT_IN_SECS: 175,
     RETRY_DELAY: 2000,
     WATCHER_ERROR_DELAY: 30000, // in ms (30 seconds)
     WATCHER_REFRESH_INTERVAL: 60000, // in ms ( 1 minute )

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -103,7 +103,7 @@ class ApiServerClient {
         if (state === opts.start_state) {
           const duration = (new Date() - opts.started_at) / 1000;
           logger.debug(`Polling for ${opts.start_state} duration: ${duration} `);
-          if (duration > CONST.BACKUP.BACKUP_START_TIMEOUT_IN_SECS) {
+          if (duration > CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS) {
             logger.error(`Backup with guid ${opts.resourceId} not picked up from the queue`);
             throw new Timeout(`Backup with guid ${opts.resourceId} not picked up from the queue`);
           }

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -1745,15 +1745,6 @@ describe('service-fabrik-api-sf2.0', function () {
             });
             mocks.cloudProvider.headObject(nonPitrRestorePathname);
             mocks.apiServerEventMesh.nockDeleteResource('lock', 'deploymentlock', instance_id);
-            mocks.apiServerEventMesh.nockGetResource('lock', 'deploymentlock', instance_id, {
-              spec: {
-                options: JSON.stringify({
-                  lockTTL: Infinity,
-                  lockTime: new Date(),
-                  lockedResourceDetails: {}
-                })
-              }
-            });
             return chai
               .request(apps.internal)
               .get(`${broker_api_base_url}/service_instances/${instance_id}/last_operation`)


### PR DESCRIPTION
* Changing the constant to make this function generic
* Increasing the value to 175, as default http timeout is 180. Kepping it little lower than that.

The same will be done as part of BOSH manager PR in master branch