### PR TITLE
Removing request.instance references

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -111,7 +111,6 @@ class ServiceBrokerApiController extends FabrikBaseController {
   patchInstance(req, res) {
     const params = _
       .chain(req.body)
-      // .omit('plan_id', 'service_id') //Not omiting even for restore. will that be a problem?
       .cloneDeep()
       .value();
     //cloning here so that the DirectorInstance.update does not unset the 'service-fabrik-operation' from original req.body object
@@ -206,7 +205,6 @@ class ServiceBrokerApiController extends FabrikBaseController {
       let statusCode = CONST.HTTP_STATUS_CODE.OK;
       const body = {};
       if (plan.manager.async) {
-        // Delete resource from here
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
       }
       res.status(statusCode).send(body);

--- a/broker/lib/fabrik/BaseInstance.js
+++ b/broker/lib/fabrik/BaseInstance.js
@@ -39,10 +39,6 @@ class BaseInstance {
     return this.manager.isUpdatePossible(plan_id);
   }
 
-  get async() {
-    throw new NotImplementedBySubclass('async');
-  }
-
   get platformContext() {
     throw new NotImplementedBySubclass('platformContext');
   }

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -49,10 +49,6 @@ class DirectorInstance extends BaseInstance {
     return this.manager.getDeploymentName(this.guid, this.networkSegmentIndex);
   }
 
-  get async() {
-    return true;
-  }
-
   initialize(operation) {
     return Promise
       .try(() => {

--- a/broker/lib/fabrik/DockerInstance.js
+++ b/broker/lib/fabrik/DockerInstance.js
@@ -46,10 +46,6 @@ class DockerInstance extends BaseInstance {
     return this.manager.getVolumeName(this.guid, volume);
   }
 
-  get async() {
-    return false;
-  }
-
   get platformContext() {
     return this.inspectContainer()
       .then(() => {

--- a/broker/lib/fabrik/VirtualHostInstance.js
+++ b/broker/lib/fabrik/VirtualHostInstance.js
@@ -14,10 +14,6 @@ class VirtualHostInstance extends BaseInstance {
     this.mapper = mapper.VirtualHostRelationMapper;
   }
 
-  get async() {
-    return false;
-  }
-
   initialize() {
     /** Here optimization ca be made by checking if this.deploymentName is present
      *  then only make call getDeploymentNameForInstanceId*/

--- a/test/test_broker/broker.middleware.spec.js
+++ b/test/test_broker/broker.middleware.spec.js
@@ -78,9 +78,9 @@ describe('#checkQuota', () => {
   const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f'; // name: 'v1.0-xsmall'
   const plan_id_update = 'd616b00a-5949-4b1c-bc73-0d3c59f3954a'; // name: 'v1.0-large'
   const organization_guid = 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a';
-  const notEntitledPlanId = 'notEntitledPlanId';
-  const validQuotaPlanId = 'validQuotaPlanId';
-  const invalidQuotaPlanId = 'invalidQuotaPlanId';
+  const notEntitledPlanId = 'bc158c9a-7934-401e-94ab-057082a5073e';
+  const validQuotaPlanId = 'bc158c9a-7934-401e-94ab-057082a5073f';
+  const invalidQuotaPlanId = 'd616b00a-5949-4b1c-bc73-0d3c59f3954a';
   const errQuotaPlanId = 'errQuotaPlanId';
   const err = 'Error in calculating quota';
   const operationParameters = {
@@ -182,14 +182,8 @@ describe('#checkQuota', () => {
       name: 'user',
       pass: 'secret'
     },
-    body: {},
-    instance: {
-      plan: {
-        name: 'some-plan-name'
-      },
-      service: {
-        name: 'some-service-name'
-      }
+    body: {
+      plan_id: 'bc158c9a-7934-401e-94ab-057082a5073f'
     }
   };
   beforeEach(function () {


### PR DESCRIPTION
* Assign instance will ultimately be removed. 

* In this PR cleaning up the references of request.instance from middleware so that assigninstance can be later removed from the lifecycle route.

* Removing couple of stale comments