### PR TITLE
Improving reschedule backup logic to avoid cancelling schedule

### DIFF
--- a/jobs/ScheduleBackupJob.js
+++ b/jobs/ScheduleBackupJob.js
@@ -114,6 +114,8 @@ class ScheduleBackupJob extends BaseJob {
           let backupStartedMillis = new Date(_.get(sortedBackups[latestSuccessIndex], 'started_at')).getTime();
           transactionLogsBefore = new Date(backupStartedMillis - config.backup.transaction_logs_delete_buffer_time * 60 * 1000).toISOString();
         }
+      } else {
+        transactionLogsBefore = new Date(Date.now() - (config.backup.retention_period_in_days + 1) * 24 * 60 * 60 * 1000).toISOString();
       }
       return filteredOldBackups;
     }

--- a/jobs/ScheduleBackupJob.js
+++ b/jobs/ScheduleBackupJob.js
@@ -50,22 +50,21 @@ class ScheduleBackupJob extends BaseJob {
             }
             return this
               .getFabrikClient()
-              .startBackup(_.pick(jobData, 'instance_id', 'type', 'trigger'))
-              .catch(errors.Conflict, errors.UnprocessableEntity, (err) => {
-                logger.error('Some other operation already in progress on this instance:', err);
-                return retry(() => this.reScheduleBackup(job.attrs.data, job.attrs.repeatInterval), {
-                  maxAttempts: 3,
-                  minDelay: 500
-                }).then(() => {
-                  throw err;
-                });
-              });
+              .startBackup(_.pick(jobData, 'instance_id', 'type', 'trigger'));
           })
           .tap(backupResponse => backupRunStatus.start_backup_status = backupResponse)
           .then(() => this.deleteOldBackup(job, instanceDeleted))
           .tap(deleteResponse => backupRunStatus.delete_backup_status = deleteResponse)
           .then(() => this.runSucceeded(backupRunStatus, job, done))
-          .catch((error) => this.runFailed(error, backupRunStatus, job, done));
+          .catch((error) => {
+            this.runFailed(error, backupRunStatus, job, done);
+            if (error instanceof errors.Conflict || error instanceof errors.UnprocessableEntity) {
+              retry(() => this.reScheduleBackup(job.attrs.data, job.attrs.repeatInterval), {
+                maxAttempts: 3,
+                minDelay: 500
+              });
+            }
+          });
       })
       .catch(error => {
         logger.error(`Error occurred while handling failure for job :${job.attrs.data[CONST.JOB_NAME_ATTRIB]}`, error);
@@ -196,6 +195,7 @@ class ScheduleBackupJob extends BaseJob {
       });
   }
 
+
   static reScheduleBackup(jobOptions, repeatInterval) {
     return Promise.try(() => {
       const jobData = _.cloneDeep(jobOptions);
@@ -206,13 +206,26 @@ class ScheduleBackupJob extends BaseJob {
         // Resetting the number of attempts to 0 and re-creating the schedule with this modified param
         jobData.attempt = 0;
         return Promise.try(() => {
-            return ScheduleManager.cancelSchedule(jobData.instance_id, CONST.JOB.SCHEDULED_BACKUP)
-              .then(() => ScheduleManager.schedule(
-                jobData.instance_id,
-                CONST.JOB.SCHEDULED_BACKUP,
-                repeatInterval,
-                jobData,
-                CONST.SYSTEM_USER));
+            return ScheduleManager.schedule(
+              jobData.instance_id,
+              CONST.JOB.SCHEDULED_BACKUP,
+              repeatInterval,
+              jobData,
+              CONST.SYSTEM_USER);
+          })
+          .then(() => {
+            throw new errors.toManyAttempts(config.scheduler.jobs.scheduled_backup.max_attempts, new Error(`Failed to reschedule backup for ${jobData.instance_id}`));
+          });
+        logger.error(`Scheduled backup for instance  ${jobData.instance_id} has exceeded max configured attempts : ${MAX_ATTEMPTS} - ${jobData.attempt}}. Initial attempt was done @: ${jobData.firstAttemptAt}.`);
+        // Resetting the number of attempts to 0 and re-creating the schedule with this modified param
+        jobData.attempt = 0;
+        return Promise.try(() => {
+            ScheduleManager.schedule(
+              jobData.instance_id,
+              CONST.JOB.SCHEDULED_BACKUP,
+              repeatInterval,
+              jobData,
+              CONST.SYSTEM_USER);
           })
           .then(() => {
             throw new errors.toManyAttempts(config.scheduler.jobs.scheduled_backup.max_attempts, new Error(`Failed to reschedule backup for ${jobData.instance_id}`));
@@ -226,14 +239,12 @@ class ScheduleBackupJob extends BaseJob {
       }
       const plan = catalog.getPlan(jobData.plan_id);
       let retryInterval = utils.getCronWithIntervalAndAfterXminute(plan.service.backup_interval || 'daily', retryDelayInMinutes);
-      return ScheduleManager.cancelSchedule(jobData.instance_id, CONST.JOB.SCHEDULED_BACKUP)
-        .then(() => ScheduleManager.schedule(
-          jobData.instance_id,
-          CONST.JOB.SCHEDULED_BACKUP,
-          retryInterval,
-          jobData,
-          CONST.SYSTEM_USER));
-
+      return ScheduleManager.schedule(
+        jobData.instance_id,
+        CONST.JOB.SCHEDULED_BACKUP,
+        retryInterval,
+        jobData,
+        CONST.SYSTEM_USER);
     });
   }
 }

--- a/jobs/ScheduleBackupJob.js
+++ b/jobs/ScheduleBackupJob.js
@@ -57,13 +57,15 @@ class ScheduleBackupJob extends BaseJob {
           .tap(deleteResponse => backupRunStatus.delete_backup_status = deleteResponse)
           .then(() => this.runSucceeded(backupRunStatus, job, done))
           .catch((error) => {
-            this.runFailed(error, backupRunStatus, job, done);
-            if (error instanceof errors.Conflict || error instanceof errors.UnprocessableEntity) {
-              retry(() => this.reScheduleBackup(job.attrs.data, job.attrs.repeatInterval), {
-                maxAttempts: 3,
-                minDelay: 500
+            return this.runFailed(error, backupRunStatus, job, done)
+              .then(() => {
+                if (error instanceof errors.Conflict || error instanceof errors.UnprocessableEntity) {
+                  return retry(() => this.reScheduleBackup(job.attrs.data, job.attrs.repeatInterval), {
+                    maxAttempts: 3,
+                    minDelay: 500
+                  });
+                }
               });
-            }
           });
       })
       .catch(error => {
@@ -205,14 +207,12 @@ class ScheduleBackupJob extends BaseJob {
         logger.error(`Scheduled backup for instance  ${jobData.instance_id} has exceeded max configured attempts : ${MAX_ATTEMPTS} - ${jobData.attempt}}. Initial attempt was done @: ${jobData.firstAttemptAt}.`);
         // Resetting the number of attempts to 0 and re-creating the schedule with this modified param
         jobData.attempt = 0;
-        return Promise.try(() => {
-            ScheduleManager.schedule(
-              jobData.instance_id,
-              CONST.JOB.SCHEDULED_BACKUP,
-              repeatInterval,
-              jobData,
-              CONST.SYSTEM_USER);
-          })
+        return ScheduleManager.schedule(
+            jobData.instance_id,
+            CONST.JOB.SCHEDULED_BACKUP,
+            repeatInterval,
+            jobData,
+            CONST.SYSTEM_USER)
           .then(() => {
             throw new errors.toManyAttempts(config.scheduler.jobs.scheduled_backup.max_attempts, new Error(`Failed to reschedule backup for ${jobData.instance_id}`));
           });

--- a/jobs/ScheduleBackupJob.js
+++ b/jobs/ScheduleBackupJob.js
@@ -206,20 +206,6 @@ class ScheduleBackupJob extends BaseJob {
         // Resetting the number of attempts to 0 and re-creating the schedule with this modified param
         jobData.attempt = 0;
         return Promise.try(() => {
-            return ScheduleManager.schedule(
-              jobData.instance_id,
-              CONST.JOB.SCHEDULED_BACKUP,
-              repeatInterval,
-              jobData,
-              CONST.SYSTEM_USER);
-          })
-          .then(() => {
-            throw new errors.toManyAttempts(config.scheduler.jobs.scheduled_backup.max_attempts, new Error(`Failed to reschedule backup for ${jobData.instance_id}`));
-          });
-        logger.error(`Scheduled backup for instance  ${jobData.instance_id} has exceeded max configured attempts : ${MAX_ATTEMPTS} - ${jobData.attempt}}. Initial attempt was done @: ${jobData.firstAttemptAt}.`);
-        // Resetting the number of attempts to 0 and re-creating the schedule with this modified param
-        jobData.attempt = 0;
-        return Promise.try(() => {
             ScheduleManager.schedule(
               jobData.instance_id,
               CONST.JOB.SCHEDULED_BACKUP,

--- a/test/test_broker/jobs.ScheduleBackupJob.spec.js
+++ b/test/test_broker/jobs.ScheduleBackupJob.spec.js
@@ -59,8 +59,6 @@ describe('Jobs', function () {
       const transactionLogsPathname19 = `/${serviceContainer}/${transactionLogsFileName19Daysprior}`;
       const transactionLogsPathname16 = `/${serviceContainer}/${transactionLogsFileName16DaysPrior}`;
       const transactionLogsPathname18 = `/${serviceContainer}/${transactionLogsFileName18DaysPrior}`;
-      const transactionLogsPathname14 = `/${serviceContainer}/${transactionLogsFileName14DaysPrior}`;
-      const transactionLogsPathname1 = `/${serviceContainer}/${transactionLogsFileName1Daysprior}`;
       const scheduled_data = {
         trigger: CONST.BACKUP.TRIGGER.SCHEDULED,
         type: 'online',
@@ -183,25 +181,25 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-            file_name: transactionLogsFileName1Daysprior,
-            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName19Daysprior,
-            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //3 mins = buffer time
-          },
-          {
-            file_name: transactionLogsFileName14DaysPrior,
-            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName18DaysPrior,
-            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-          }
+          file_name: transactionLogsFileName1Daysprior,
+          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName19Daysprior,
+          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName16DaysPrior,
+          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //3 mins = buffer time
+        },
+        {
+          file_name: transactionLogsFileName14DaysPrior,
+          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName18DaysPrior,
+          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+        }
         ]);
         //Out of 4 files 1 and 14 day prior is filtered out 
         // & the 18 day prior on demand will not be deleted
@@ -249,25 +247,25 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-            file_name: transactionLogsFileName1Daysprior,
-            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName19Daysprior,
-            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-          },
-          {
-            file_name: transactionLogsFileName14DaysPrior,
-            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName18DaysPrior,
-            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-          }
+          file_name: transactionLogsFileName1Daysprior,
+          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName19Daysprior,
+          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName16DaysPrior,
+          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+        },
+        {
+          file_name: transactionLogsFileName14DaysPrior,
+          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName18DaysPrior,
+          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+        }
         ]);
         //Out of 4 files 1 and 14 day prior is filtered out 
         // & the 18 day prior on demand will not be deleted
@@ -318,25 +316,25 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-            file_name: transactionLogsFileName1Daysprior,
-            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName19Daysprior,
-            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-          },
-          {
-            file_name: transactionLogsFileName14DaysPrior,
-            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName18DaysPrior,
-            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-          }
+          file_name: transactionLogsFileName1Daysprior,
+          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName19Daysprior,
+          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName16DaysPrior,
+          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+        },
+        {
+          file_name: transactionLogsFileName14DaysPrior,
+          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName18DaysPrior,
+          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+        }
         ]);
         //Out of 4 files 1 day prior is filtered out.
         mocks.cloudProvider.download(pathname14,
@@ -384,25 +382,25 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-            file_name: transactionLogsFileName1Daysprior,
-            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName19Daysprior,
-            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-          },
-          {
-            file_name: transactionLogsFileName14DaysPrior,
-            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName18DaysPrior,
-            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-          }
+          file_name: transactionLogsFileName1Daysprior,
+          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName19Daysprior,
+          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName16DaysPrior,
+          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+        },
+        {
+          file_name: transactionLogsFileName14DaysPrior,
+          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName18DaysPrior,
+          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+        }
         ]);
         //Out of 4 files 1 day prior is filtered out.
         mocks.cloudProvider.download(pathname14,
@@ -450,25 +448,25 @@ describe('Jobs', function () {
         }, backupResponse);
         mocks.cloudProvider.list(container, prefix, []);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-            file_name: transactionLogsFileName1Daysprior,
-            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName19Daysprior,
-            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-          },
-          {
-            file_name: transactionLogsFileName14DaysPrior,
-            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName18DaysPrior,
-            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-          }
+          file_name: transactionLogsFileName1Daysprior,
+          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName19Daysprior,
+          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName16DaysPrior,
+          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+        },
+        {
+          file_name: transactionLogsFileName14DaysPrior,
+          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName18DaysPrior,
+          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+        }
         ]);
         //Deletes transactionLogs older than retention period only. Hence, transactionLog older than 1 day is not deleted.
         mocks.cloudProvider.remove(transactionLogsPathname19);
@@ -500,8 +498,8 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-          status: 500
-        });
+            status: 500
+          });
         mocks.cloudController.findServicePlan(instance_id, plan_id);
         return ScheduleBackupJob.run(job, () => {
           mocks.verify();
@@ -523,10 +521,10 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-          status: 409
-        });
+            status: 409
+          });
         mocks.cloudController.findServicePlanByInstanceId(instance_id);
-        return ScheduleBackupJob.run(job, () => {})
+        return ScheduleBackupJob.run(job, () => { })
           .then(() => {
             mocks.verify();
             const errStatusCode = 409;
@@ -557,10 +555,10 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-          status: 409
-        });
+            status: 409
+          });
         mocks.cloudController.findServicePlan(failed_instance_id, plan_id);
-        return ScheduleBackupJob.run(_.chain(_.cloneDeep(job)).set('attrs.data.attempt', max_attmpts).value(), () => {})
+        return ScheduleBackupJob.run(_.chain(_.cloneDeep(job)).set('attrs.data.attempt', max_attmpts).value(), () => { })
           .then(() => {
             mocks.verify();
             const backupRunStatus = {
@@ -583,10 +581,10 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-          status: 409
-        });
+            status: 409
+          });
         mocks.cloudController.findServicePlan(failed_instance_id, plan_id);
-        return ScheduleBackupJob.run(job, () => {})
+        return ScheduleBackupJob.run(job, () => { })
           .then(() => {
             mocks.verify();
             const backupRunStatus = {
@@ -639,35 +637,35 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-            file_name: transactionLogsFileName1Daysprior,
-            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName19Daysprior,
-            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName16DaysPrior,
-            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-          },
-          {
-            file_name: transactionLogsFileName14DaysPrior,
-            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName18DaysPrior,
-            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-          }
+          file_name: transactionLogsFileName1Daysprior,
+          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName19Daysprior,
+          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName16DaysPrior,
+          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+        },
+        {
+          file_name: transactionLogsFileName14DaysPrior,
+          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName18DaysPrior,
+          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+        }
         ]);
         // This list method will be invoked after the deletion. The transaction logs which are not older than 14 days should remain.
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-            file_name: transactionLogsFileName14DaysPrior,
-            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-          },
-          {
-            file_name: transactionLogsFileName1Daysprior,
-            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-          }
+          file_name: transactionLogsFileName14DaysPrior,
+          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+        },
+        {
+          file_name: transactionLogsFileName1Daysprior,
+          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+        }
         ]);
         mocks.cloudProvider.download(pathname14, scheduled_data);
         mocks.cloudProvider.download(pathname16, scheduled_data16);
@@ -705,7 +703,7 @@ describe('Jobs', function () {
         mocks.cloudProvider.list(container, prefix, []);
         //Since, all the backups are deleted the list is returning empty.
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [], 2);
-        return ScheduleBackupJob.run(job, () => {}).then(() => {
+        return ScheduleBackupJob.run(job, () => { }).then(() => {
           mocks.verify();
           const expectedJobResponse = {
             start_backup_status: 'instance_deleted',
@@ -732,7 +730,7 @@ describe('Jobs', function () {
         mocks.cloudProvider.list(container, failed_prefix, []);
         mocks.cloudProvider.list(container, failed_prefix, []);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefixFailedInstance, [], 2);
-        return ScheduleBackupJob.run(job, () => {}).then(() => {
+        return ScheduleBackupJob.run(job, () => { }).then(() => {
           mocks.verify();
           const expectedJobResponse = {
             start_backup_status: 'instance_deleted',
@@ -777,8 +775,8 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-          status: 500
-        });
+            status: 500
+          });
         mocks.cloudController.findServicePlan(instance_id, plan_id);
         return ScheduleBackupJob.run(job, () => {
           expect(baseJobLogRunHistoryStub).not.to.be.called;

--- a/test/test_broker/jobs.ScheduleBackupJob.spec.js
+++ b/test/test_broker/jobs.ScheduleBackupJob.spec.js
@@ -181,25 +181,25 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-          file_name: transactionLogsFileName1Daysprior,
-          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName19Daysprior,
-          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName16DaysPrior,
-          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //3 mins = buffer time
-        },
-        {
-          file_name: transactionLogsFileName14DaysPrior,
-          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName18DaysPrior,
-          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-        }
+            file_name: transactionLogsFileName1Daysprior,
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName19Daysprior,
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName16DaysPrior,
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //3 mins = buffer time
+          },
+          {
+            file_name: transactionLogsFileName14DaysPrior,
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName18DaysPrior,
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+          }
         ]);
         //Out of 4 files 1 and 14 day prior is filtered out 
         // & the 18 day prior on demand will not be deleted
@@ -247,25 +247,25 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-          file_name: transactionLogsFileName1Daysprior,
-          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName19Daysprior,
-          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName16DaysPrior,
-          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-        },
-        {
-          file_name: transactionLogsFileName14DaysPrior,
-          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName18DaysPrior,
-          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-        }
+            file_name: transactionLogsFileName1Daysprior,
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName19Daysprior,
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName16DaysPrior,
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+          },
+          {
+            file_name: transactionLogsFileName14DaysPrior,
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName18DaysPrior,
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+          }
         ]);
         //Out of 4 files 1 and 14 day prior is filtered out 
         // & the 18 day prior on demand will not be deleted
@@ -316,25 +316,25 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-          file_name: transactionLogsFileName1Daysprior,
-          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName19Daysprior,
-          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName16DaysPrior,
-          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-        },
-        {
-          file_name: transactionLogsFileName14DaysPrior,
-          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName18DaysPrior,
-          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-        }
+            file_name: transactionLogsFileName1Daysprior,
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName19Daysprior,
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName16DaysPrior,
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+          },
+          {
+            file_name: transactionLogsFileName14DaysPrior,
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName18DaysPrior,
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+          }
         ]);
         //Out of 4 files 1 day prior is filtered out.
         mocks.cloudProvider.download(pathname14,
@@ -382,25 +382,25 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-          file_name: transactionLogsFileName1Daysprior,
-          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName19Daysprior,
-          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName16DaysPrior,
-          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-        },
-        {
-          file_name: transactionLogsFileName14DaysPrior,
-          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName18DaysPrior,
-          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-        }
+            file_name: transactionLogsFileName1Daysprior,
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName19Daysprior,
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName16DaysPrior,
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+          },
+          {
+            file_name: transactionLogsFileName14DaysPrior,
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName18DaysPrior,
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+          }
         ]);
         //Out of 4 files 1 day prior is filtered out.
         mocks.cloudProvider.download(pathname14,
@@ -448,25 +448,25 @@ describe('Jobs', function () {
         }, backupResponse);
         mocks.cloudProvider.list(container, prefix, []);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-          file_name: transactionLogsFileName1Daysprior,
-          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName19Daysprior,
-          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName16DaysPrior,
-          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-        },
-        {
-          file_name: transactionLogsFileName14DaysPrior,
-          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName18DaysPrior,
-          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-        }
+            file_name: transactionLogsFileName1Daysprior,
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName19Daysprior,
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName16DaysPrior,
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+          },
+          {
+            file_name: transactionLogsFileName14DaysPrior,
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName18DaysPrior,
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+          }
         ]);
         //Deletes transactionLogs older than retention period only. Hence, transactionLog older than 1 day is not deleted.
         mocks.cloudProvider.remove(transactionLogsPathname19);
@@ -498,8 +498,8 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-            status: 500
-          });
+          status: 500
+        });
         mocks.cloudController.findServicePlan(instance_id, plan_id);
         return ScheduleBackupJob.run(job, () => {
           mocks.verify();
@@ -521,10 +521,10 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-            status: 409
-          });
+          status: 409
+        });
         mocks.cloudController.findServicePlanByInstanceId(instance_id);
-        return ScheduleBackupJob.run(job, () => { })
+        return ScheduleBackupJob.run(job, () => {})
           .then(() => {
             mocks.verify();
             const errStatusCode = 409;
@@ -555,10 +555,10 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-            status: 409
-          });
+          status: 409
+        });
         mocks.cloudController.findServicePlan(failed_instance_id, plan_id);
-        return ScheduleBackupJob.run(_.chain(_.cloneDeep(job)).set('attrs.data.attempt', max_attmpts).value(), () => { })
+        return ScheduleBackupJob.run(_.chain(_.cloneDeep(job)).set('attrs.data.attempt', max_attmpts).value(), () => {})
           .then(() => {
             mocks.verify();
             const backupRunStatus = {
@@ -581,10 +581,10 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-            status: 409
-          });
+          status: 409
+        });
         mocks.cloudController.findServicePlan(failed_instance_id, plan_id);
-        return ScheduleBackupJob.run(job, () => { })
+        return ScheduleBackupJob.run(job, () => {})
           .then(() => {
             mocks.verify();
             const backupRunStatus = {
@@ -637,35 +637,35 @@ describe('Jobs', function () {
           fileName1Daysprior
         ]);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-          file_name: transactionLogsFileName1Daysprior,
-          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName19Daysprior,
-          last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName16DaysPrior,
-          last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
-        },
-        {
-          file_name: transactionLogsFileName14DaysPrior,
-          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName18DaysPrior,
-          last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
-        }
+            file_name: transactionLogsFileName1Daysprior,
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName19Daysprior,
+            last_modified: Date.now() - 19 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName16DaysPrior,
+            last_modified: Date.now() - 16 * 60 * 60 * 24 * 1000 - 30 * 60 * 1000 //30 mins = buffer time
+          },
+          {
+            file_name: transactionLogsFileName14DaysPrior,
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName18DaysPrior,
+            last_modified: Date.now() - 18 * 60 * 60 * 24 * 1000
+          }
         ]);
         // This list method will be invoked after the deletion. The transaction logs which are not older than 14 days should remain.
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [{
-          file_name: transactionLogsFileName14DaysPrior,
-          last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
-        },
-        {
-          file_name: transactionLogsFileName1Daysprior,
-          last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
-        }
+            file_name: transactionLogsFileName14DaysPrior,
+            last_modified: Date.now() - 14 * 60 * 60 * 24 * 1000
+          },
+          {
+            file_name: transactionLogsFileName1Daysprior,
+            last_modified: Date.now() - 1 * 60 * 60 * 24 * 1000
+          }
         ]);
         mocks.cloudProvider.download(pathname14, scheduled_data);
         mocks.cloudProvider.download(pathname16, scheduled_data16);
@@ -703,7 +703,7 @@ describe('Jobs', function () {
         mocks.cloudProvider.list(container, prefix, []);
         //Since, all the backups are deleted the list is returning empty.
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefix, [], 2);
-        return ScheduleBackupJob.run(job, () => { }).then(() => {
+        return ScheduleBackupJob.run(job, () => {}).then(() => {
           mocks.verify();
           const expectedJobResponse = {
             start_backup_status: 'instance_deleted',
@@ -730,7 +730,7 @@ describe('Jobs', function () {
         mocks.cloudProvider.list(container, failed_prefix, []);
         mocks.cloudProvider.list(container, failed_prefix, []);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefixFailedInstance, [], 2);
-        return ScheduleBackupJob.run(job, () => { }).then(() => {
+        return ScheduleBackupJob.run(job, () => {}).then(() => {
           mocks.verify();
           const expectedJobResponse = {
             start_backup_status: 'instance_deleted',
@@ -775,8 +775,8 @@ describe('Jobs', function () {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
         }, {
-            status: 500
-          });
+          status: 500
+        });
         mocks.cloudController.findServicePlan(instance_id, plan_id);
         return ScheduleBackupJob.run(job, () => {
           expect(baseJobLogRunHistoryStub).not.to.be.called;


### PR DESCRIPTION
Earlier, the logic for rescheduling backup was to cancel the ongoing schedule and creating a new schedule with the modified parameters. This approach was taken since the logic of modifying schedule while the job is running used to fail. 
Now, we have modified the approach such that once the job is `done` and if the job is failed, then we reschedule the backup. Since, the job is already done, we can now modify the parameters in the function and hence, cancelling the schedule is not needed.

Additional Bug Fix:
As part of this same PR, we aim to fix a bug in PITR logic. If there are no backups present for an instance or no backups present which are older than 14 days, current logic used to delete transaction logs older than the current time onwards. Fixing this bug to delete transaction logs older than retention-period(+1 day) if no backups are present older than 14 days. 
Adding relevant unit test case for this too.