### PR TITLE
Fix unbounded runs of update jobs even into next cycle

### DIFF
--- a/jobs/ScheduleManager.js
+++ b/jobs/ScheduleManager.js
@@ -16,10 +16,10 @@ const CONST = require('../common/constants');
 
 class ScheduleManager {
 
-  static runAt(name, jobType, runAt, jobData, user) {
+  static runAt(name, jobType, runAt, jobData, user, avoidDupJobWithSameData) {
     let agendaJob = {};
     return scheduler
-      .runAt(name, jobType, runAt, jobData)
+      .runAt(name, jobType, runAt, jobData, avoidDupJobWithSameData)
       .tap(job => agendaJob = job)
       .then(() => this.saveJob(name, jobType, runAt, jobData, user, true))
       .then(jobInDB => this.getJobAttrs(jobInDB, agendaJob));

--- a/jobs/Scheduler.js
+++ b/jobs/Scheduler.js
@@ -253,11 +253,14 @@ class Scheduler {
         data = data ? _.omit(data, CONST.JOB_NAME_ATTRIB) : {};
         const uniqueCriteria = {};
         if (avoidDupJobWithSameData) {
-          _.each(data, (attrValue, attr) => uniqueCriteria[`data.${attr}`] = attrValue);
+          _.each(data, (attrValue, attr) => {
+            uniqueCriteria[`data.${attr}`] = attrValue;
+            return true;
+          });
         } else {
           uniqueCriteria['data._n_a_m_e_'] = jobName;
         }
-        logger.info(`Setting Job with Unique Criteria : ${JSON.stringify(uniqueCriteria)}`);
+        logger.info('Setting Job with Unique Criteria : ', uniqueCriteria);
         data[CONST.JOB_NAME_ATTRIB] = jobName;
         const job = this.agenda.create(jobType, data);
         job.unique(uniqueCriteria);

--- a/jobs/Scheduler.js
+++ b/jobs/Scheduler.js
@@ -239,7 +239,7 @@ class Scheduler {
       });
   }
 
-  runAt(name, jobType, runAt, data) {
+  runAt(name, jobType, runAt, data, avoidDupJobWithSameData) {
     return Promise
       .try(() => {
         if (this.initialized !== MONGO_INIT_SUCCEEDED) {
@@ -249,13 +249,18 @@ class Scheduler {
         }
         this.isJobTypeEnabled(jobType);
         const jobName = `${name}_${jobType}_${runAt.replace(/\s*/g, '')}_${new Date().getTime()}`;
-        logger.info(`Scheduled Job : ${jobName} to Run @ ${runAt}`);
-        data = data ? data : {};
+        logger.info(`Scheduling Job : ${jobName} to Run @ ${runAt}`);
+        data = data ? _.omit(data, CONST.JOB_NAME_ATTRIB) : {};
+        const uniqueCriteria = {};
+        if (avoidDupJobWithSameData) {
+          _.each(data, (attrValue, attr) => uniqueCriteria[`data.${attr}`] = attrValue);
+        } else {
+          uniqueCriteria['data._n_a_m_e_'] = jobName;
+        }
+        logger.info(`Setting Job with Unique Criteria : ${JSON.stringify(uniqueCriteria)}`);
         data[CONST.JOB_NAME_ATTRIB] = jobName;
         const job = this.agenda.create(jobType, data);
-        job.unique({
-          'data._n_a_m_e_': jobName
-        });
+        job.unique(uniqueCriteria);
         job.schedule(runAt);
         return job
           .saveAsync()
@@ -382,8 +387,7 @@ class Scheduler {
         .runAt(jobName,
           type,
           config.scheduler.jobs.reschedule_delay,
-          jobData,
-          CONST.SYSTEM_USER
+          jobData
         );
     });
   }

--- a/jobs/ServiceInstanceUpdateJob.js
+++ b/jobs/ServiceInstanceUpdateJob.js
@@ -176,13 +176,26 @@ class ServiceInstanceUpdateJob extends BaseJob {
         }
       }
       const RUN_AFTER = _.get(instanceDetails, 'reschedule_delay', config.scheduler.jobs.reschedule_delay);
+      let retryDelayInMinutes;
+      if ((RUN_AFTER.toLowerCase()).indexOf('minutes') !== -1) {
+        retryDelayInMinutes = parseInt(/^[0-9]+/.exec(RUN_AFTER)[0]);
+      }
+      const NUM_MINS_IN_HR = 60;
+      const numberOfRunsPerDay = (NUM_MINS_IN_HR / retryDelayInMinutes) * 24;
+      const maxRunsInXDays = numberOfRunsPerDay * _.get(config, 'scheduler.jobs.service_instance_update.run_every_xdays', 15);
+      if (jobData.attempt >= maxRunsInXDays) {
+        logger.info(`Number of retries(${jobData.attempt}) are spilling over to next update cycle (max runs:${maxRunsInXDays}). Retry of update for ${instanceDetails.instance_id} will stop now.`);
+        return;
+      }
       logger.info(`Schedulding InstanceUpdate Job for ${instanceDetails.instance_name}:${instanceDetails.instance_id} @ ${RUN_AFTER} - Track : ${trackAttempts} - Attempt - ${instanceDetails.attempt}`);
+      const AVOID_DUPLICATE_JOB_WITH_SAME_JOBDATA = true;
       return ScheduleManager
         .runAt(instanceDetails.instance_id,
           CONST.JOB.SERVICE_INSTANCE_UPDATE,
           RUN_AFTER,
           jobData,
-          CONST.SYSTEM_USER
+          CONST.SYSTEM_USER,
+          AVOID_DUPLICATE_JOB_WITH_SAME_JOBDATA
         );
     });
   }

--- a/jobs/ServiceInstanceUpdateJob.js
+++ b/jobs/ServiceInstanceUpdateJob.js
@@ -176,16 +176,18 @@ class ServiceInstanceUpdateJob extends BaseJob {
         }
       }
       const RUN_AFTER = _.get(instanceDetails, 'reschedule_delay', config.scheduler.jobs.reschedule_delay);
-      let retryDelayInMinutes;
+      let retryDelayInMinutes = 0;
       if ((RUN_AFTER.toLowerCase()).indexOf('minutes') !== -1) {
         retryDelayInMinutes = parseInt(/^[0-9]+/.exec(RUN_AFTER)[0]);
       }
-      const NUM_MINS_IN_HR = 60;
-      const numberOfRunsPerDay = (NUM_MINS_IN_HR / retryDelayInMinutes) * 24;
-      const maxRunsInXDays = numberOfRunsPerDay * _.get(config, 'scheduler.jobs.service_instance_update.run_every_xdays', 15);
-      if (jobData.attempt >= maxRunsInXDays) {
-        logger.info(`Number of retries(${jobData.attempt}) are spilling over to next update cycle (max runs:${maxRunsInXDays}). Retry of update for ${instanceDetails.instance_id} will stop now.`);
-        return;
+      if (retryDelayInMinutes > 0) {
+        const NUM_MINS_IN_HR = 60;
+        const numberOfRunsPerDay = (NUM_MINS_IN_HR / retryDelayInMinutes) * 24;
+        const maxRunsInXDays = numberOfRunsPerDay * _.get(config, 'scheduler.jobs.service_instance_update.run_every_xdays', 15);
+        if (jobData.attempt >= maxRunsInXDays) {
+          logger.info(`Number of retries(${jobData.attempt}) are spilling over to next update cycle (max runs:${maxRunsInXDays}). Retry of update for ${instanceDetails.instance_id} will stop now.`);
+          return;
+        }
       }
       logger.info(`Schedulding InstanceUpdate Job for ${instanceDetails.instance_name}:${instanceDetails.instance_id} @ ${RUN_AFTER} - Track : ${trackAttempts} - Attempt - ${instanceDetails.attempt}`);
       const AVOID_DUPLICATE_JOB_WITH_SAME_JOBDATA = true;


### PR DESCRIPTION
If while a job is in flight and before it can commit its state to DB,
if the job crashes due to DB down or any other issue, then its next
run would not be null and agenda re-runs this job. Now this re-run
is a dupe of the same attempt which could create additional retry jobs.

In this fix, putting in a unique constraint on the jobdata which contains
the attempt count. So even if by chance a job reruns when it schedules
a retry job it will only overwrite existing retry job with the next attempt
count. Unique constraint on job is added.

Additionally have not kept retries to run infinitely. If the number of
attempts exceeds the number of attempts in a update window
(ex.reschedule delay of 30 mins -  48 runs per day * 7 = 336),
then next window run anyway runs. So will stop rescheduling in such
cases.