### PR TITLE
[Fix] Event Logging not working for Async operation

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -66,6 +66,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
       };
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
+        body.operation = utils.encodeBase64({
+          'type': 'create'
+        });
       }
       res.status(statusCode).send(body);
     }
@@ -118,6 +121,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
       let body = {};
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
+        body.operation = utils.encodeBase64({
+          'type': 'update'
+        });
       }
       res.status(statusCode).send(body);
     }
@@ -184,6 +190,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
       const body = {};
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
+        body.operation = utils.encodeBase64({
+          'type': 'delete'
+        });
       }
       res.status(statusCode).send(body);
     }

--- a/test/test_broker/EventLogInterceptor.spec.js
+++ b/test/test_broker/EventLogInterceptor.spec.js
@@ -612,9 +612,7 @@ describe('EventLogInterceptor', function () {
         description: `create deployment 234 succeeded at ${timestamp}`
       };
       const op = {
-        type: 'create',
-        parameters: {},
-        task_id: 234
+        type: 'create'
       };
       const query = {
         operation: utils.encodeBase64(op)
@@ -653,9 +651,7 @@ describe('EventLogInterceptor', function () {
         description: `update deployment 244 succeeded at ${timestamp}`
       };
       const op = {
-        type: 'update',
-        parameters: {},
-        task_id: 244
+        type: 'update'
       };
       const query = {
         operation: utils.encodeBase64(op)
@@ -694,9 +690,7 @@ describe('EventLogInterceptor', function () {
         description: `create deployment 254 failed at ${timestamp}`
       };
       const op = {
-        type: 'create',
-        parameters: {},
-        task_id: 254
+        type: 'create'
       };
       const query = {
         operation: utils.encodeBase64(op)
@@ -735,9 +729,7 @@ describe('EventLogInterceptor', function () {
         description: `update deployment 244 failed at ${timestamp}`
       };
       const op = {
-        type: 'update',
-        parameters: {},
-        task_id: 244
+        type: 'update'
       };
       const query = {
         operation: utils.encodeBase64(op)
@@ -776,9 +768,7 @@ describe('EventLogInterceptor', function () {
         description: `Delete deployment 245 succeeded at ${timestamp}`
       };
       const op = {
-        type: 'delete',
-        parameters: {},
-        task_id: 245
+        type: 'delete'
       };
       const query = {
         operation: utils.encodeBase64(op)
@@ -817,9 +807,7 @@ describe('EventLogInterceptor', function () {
         description: `Delete deployment 245 failed at ${timestamp}`
       };
       const op = {
-        type: 'delete',
-        parameters: {},
-        task_id: 245
+        type: 'delete'
       };
       const query = {
         operation: utils.encodeBase64(op)

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -468,7 +468,9 @@ describe('service-broker-api-2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(202);
-              expect(res.body).to.deep.equal({});
+              expect(res.body.operation).to.deep.equal(utils.encodeBase64({
+                'type': 'update'
+              }));
               mocks.verify();
             });
         });
@@ -510,7 +512,9 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .then(res => {
               expect(res).to.have.status(202);
-              expect(res.body).to.deep.equal({});
+              expect(res.body.operation).to.deep.equal(utils.encodeBase64({
+                'type': 'update'
+              }));
               mocks.verify();
             });
         });
@@ -568,7 +572,9 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .then(res => {
               expect(res).to.have.status(202);
-              expect(res.body).to.deep.equal({});
+              expect(res.body.operation).to.deep.equal(utils.encodeBase64({
+                'type': 'update'
+              }));
               mocks.verify();
             });
         });
@@ -689,7 +695,9 @@ describe('service-broker-api-2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(202);
-              expect(res.body).to.deep.equal({});
+              expect(res.body.operation).to.deep.equal(utils.encodeBase64({
+                'type': 'delete'
+              }));
               mocks.verify();
             });
         });
@@ -722,7 +730,9 @@ describe('service-broker-api-2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(202);
-              expect(res.body).to.deep.equal({});
+              expect(res.body.operation).to.deep.equal(utils.encodeBase64({
+                'type': 'delete'
+              }));
               mocks.verify();
             });
         });
@@ -755,7 +765,9 @@ describe('service-broker-api-2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(202);
-              expect(res.body).to.deep.equal({});
+              expect(res.body.operation).to.deep.equal(utils.encodeBase64({
+                'type': 'delete'
+              }));
               mocks.verify();
             });
         });
@@ -787,7 +799,9 @@ describe('service-broker-api-2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(202);
-              expect(res.body).to.deep.equal({});
+              expect(res.body.operation).to.deep.equal(utils.encodeBase64({
+                'type': 'delete'
+              }));
               mocks.verify();
             });
         });


### PR DESCRIPTION

* Sending back operation for async operation
* EventLogInterceptor was not working for the same as it expects the operation as part of last operation.