### PR TITLE
Fixing delete event logging for 410 Gone response

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -269,7 +269,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
     }
 
     function notFound(err) {
-      if (!operation || (operation && operation.type === 'delete')) {
+      if (_.get(operation, 'type') === 'delete') {
         return gone();
       }
       failed(err);

--- a/common/EventLogInterceptor.js
+++ b/common/EventLogInterceptor.js
@@ -168,6 +168,9 @@ class EventLogInterceptor {
         //the reason which caused the internal server error might get fixed by the cloud controller timeout time,
         //at which time CC will stop polling for status and will mark the operation as failed.
         //Hence keeping in-progress as default state if it is not conclusively success/failure state.
+        if (res.statusCode === 410 && eventConfig.event_name === 'delete_instance') {
+          return this.successState(eventConfig);
+        }
         return this.inProgressState(eventConfig);
       }
     } else if (_.includes(eventConfig.http_success_codes, res.statusCode)) {

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -1146,7 +1146,10 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .query({
               service_id: service_id,
-              plan_id: plan_id
+              plan_id: plan_id,
+              operation: utils.encodeBase64({
+                'type': 'delete'
+              })
             })
             .catch(err => err.response)
             .then(res => {


### PR DESCRIPTION
* Asynchronous Delete response with 410 response were ignored and no event was logged for the same.
* Checking explicitly for event type as delete and statuscode as 410 and sending event info for the same.