### PR TITLE
Dashboard rendering: Fetching current plan of service instance while validation

### DIFF
--- a/api-controllers/DashboardController.js
+++ b/api-controllers/DashboardController.js
@@ -120,13 +120,16 @@ class DashboardController extends FabrikBaseController {
     const instance_id = req.params.instance_id;
     const service_id = req.params.service_id;
     const plan_id = req.params.plan_id;
-    logger.info(`Validating service '${service_id}' and plan '${plan_id}'`);
     const encodedOp = _.get(req, 'query.operation', undefined);
     const operation = encodedOp === undefined ? null : utils.decodeBase64(encodedOp);
     const context = _.get(req, 'body.context') || _.get(operation, 'context');
-    return this.fabrik
-      .createInstance(instance_id, service_id, plan_id, context)
-      .tap(instance => {
+    logger.info(`Validating service '${service_id}' and plan '${plan_id}'`);
+    return this.cloudController.getPlanIdFromInstanceId(instance_id)
+      .then(current_plan_id => {
+        logger.info(`plan_id in Dashboard URL was ${plan_id} and actual plan_id is ${current_plan_id}`);
+        return this.fabrik.createInstance(instance_id, service_id, current_plan_id, context);
+      })
+      .then(instance => {
         req.instance = instance;
         req.manager = instance.manager;
       })

--- a/broker/lib/fabrik/DockerInstance.js
+++ b/broker/lib/fabrik/DockerInstance.js
@@ -6,7 +6,6 @@ const logger = require('../../../common/logger');
 const utils = require('../../../common/utils');
 const docker = require('../../../data-access-layer/docker');
 const BaseInstance = require('./BaseInstance');
-const catalog = require('../../../common/models').catalog;
 const CONST = require('../../../common/constants');
 
 const DockerError = {
@@ -126,16 +125,14 @@ class DockerInstance extends BaseInstance {
           instance,
           this.getDetails(),
           this.getProcesses(),
-          this.getLogs(),
-          this.cloudController.getServicePlan(instance.entity.service_plan_guid, {})
+          this.getLogs()
         ]);
       })
-      .spread((instance, details, processes, logs, planInfo) => {
-        var currentPlan = catalog.getPlan(planInfo.entity.unique_id);
+      .spread((instance, details, processes, logs) => {
         return {
-          title: `${currentPlan.service.metadata.displayName || 'Service'} Dashboard`,
-          plan: currentPlan,
-          service: currentPlan.service,
+          title: `${this.plan.service.metadata.displayName || 'Service'} Dashboard`,
+          plan: this.plan,
+          service: this.plan.service,
           instance: instance,
           details: details,
           processes: processes,

--- a/test/test_broker/acceptance/dashboard.director.spec.js
+++ b/test/test_broker/acceptance/dashboard.director.spec.js
@@ -36,7 +36,7 @@ describe('dashboard', function () {
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
         mocks.cloudController.getServiceInstance(instance_id);
-        mocks.cloudController.getServicePlan(service_plan_guid, plan_id);
+        mocks.cloudController.findServicePlanByInstanceId(instance_id, service_plan_guid, plan_id, undefined, 2);
         mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
           platform: 'cloudfoundry'
         });
@@ -90,7 +90,7 @@ describe('dashboard', function () {
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
         mocks.cloudController.getServiceInstance(instance_id);
-        mocks.cloudController.getServicePlan(service_plan_guid, plan_id);
+        mocks.cloudController.findServicePlanByInstanceId(instance_id, service_plan_guid, plan_id, undefined, 2);
         mocks.director.getCurrentTasks(deployment_name, [{
           'id': 324,
           'description': 'create deployment succeeded'

--- a/test/test_broker/acceptance/dashboard.docker.spec.js
+++ b/test/test_broker/acceptance/dashboard.docker.spec.js
@@ -43,7 +43,7 @@ describe('dashboard', function () {
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
         mocks.cloudController.getServiceInstance(instance_id);
-        mocks.cloudController.getServicePlan(service_plan_guid, plan_id);
+        mocks.cloudController.findServicePlanByInstanceId(instance_id, service_plan_guid, plan_id, undefined, 2);
         mocks.docker.inspectContainer(instance_id);
         mocks.docker.inspectContainer(instance_id);
         mocks.docker.inspectContainer();

--- a/test/test_broker/acceptance/dashboard.virtualHost.spec.js
+++ b/test/test_broker/acceptance/dashboard.virtualHost.spec.js
@@ -51,7 +51,7 @@ describe('dashboard', function () {
         mocks.cloudController.getServiceInstancePermissions(instance_id);
         mocks.cloudController.getServiceInstance(instance_id);
         mocks.cloudController.getServiceInstance(parent_instance_id);
-        mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
+        mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id, undefined, 3);
         mocks.cloudProvider.download(pathname, data);
         return agent
           .get(`/manage/instances/${service_id}/${plan_id}/${instance_id}`)

--- a/test/test_broker/mocks/cloudController.js
+++ b/test/test_broker/mocks/cloudController.js
@@ -311,7 +311,7 @@ function getServiceInstancesInSpaceWithName(instance_name, space_guid, present) 
     });
 }
 
-function findServicePlanByInstanceId(instance_id, plan_guid, plan_unique_id, resources, times = 1) {
+function findServicePlanByInstanceId(instance_id, plan_guid, plan_unique_id, resources, times) {
   const defaultResources = [{
     metadata: {
       guid: plan_guid
@@ -325,7 +325,7 @@ function findServicePlanByInstanceId(instance_id, plan_guid, plan_unique_id, res
     .query({
       q: `service_instance_guid:${instance_id}`
     })
-    .times(times)
+    .times(times || 1)
     .reply(200, {
       resources: resources ? resources : defaultResources
     });

--- a/test/test_broker/mocks/cloudController.js
+++ b/test/test_broker/mocks/cloudController.js
@@ -311,7 +311,7 @@ function getServiceInstancesInSpaceWithName(instance_name, space_guid, present) 
     });
 }
 
-function findServicePlanByInstanceId(instance_id, plan_guid, plan_unique_id, resources) {
+function findServicePlanByInstanceId(instance_id, plan_guid, plan_unique_id, resources, times = 1) {
   const defaultResources = [{
     metadata: {
       guid: plan_guid
@@ -325,6 +325,7 @@ function findServicePlanByInstanceId(instance_id, plan_guid, plan_unique_id, res
     .query({
       q: `service_instance_guid:${instance_id}`
     })
+    .times(times)
     .reply(200, {
       resources: resources ? resources : defaultResources
     });


### PR DESCRIPTION
* Currently, while dashboard rendering, we fetch current plan of the service instance from CC in the getInfo() call. This fix was introduced in an earlier PR https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/277 to handle the case where instance plan was updated. (dashboard URL remains same after plan update)
* Before call to getInfo(), validation process happens in which plan id present in dashboard url is validated against plan ids in service catalog. This validation will therefore fail if plan id in url happens to be so outdated that it got removed from catalog.
* This PR addresses this issue by making call to CC to fetch current plan in the validation itself instead of later point of time, i.e., in getInfo() call.