### PR TITLE
prefix exe name to log file for better seggregation of logs in dev setup

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -4,8 +4,9 @@
 <%
 const path = require('path');
 const os = require('os');
-
-const log_path = path.join(__dirname, '../..', 'logs', `${process.env.NODE_ENV}.log`)
+const exePath = process.argv[1];
+const exeName = exePath.substring(exePath.lastIndexOf('/')+1, exePath.indexOf('.js'));
+const log_path = path.join(__dirname, '../..', 'logs', `${exeName}-${process.env.NODE_ENV}.log`)
 
 const broker_name = 'service-fabrik-broker';
 const ip = '10.0.2.2';

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -4,9 +4,15 @@
 <%
 const path = require('path');
 const os = require('os');
-const exePath = process.argv[1];
-const exeName = exePath.substring(exePath.lastIndexOf('/')+1, exePath.indexOf('.js'));
-const log_path = path.join(__dirname, '../..', 'logs', `${exeName}-${process.env.NODE_ENV}.log`)
+
+let filePrefix = '';
+if(process && process.argv[1] && process.argv[1].indexOf('.js') !== -1){
+  const exeName = process.argv[1].substring(process.argv[1].lastIndexOf('/')+1, process.argv[1].indexOf('.js'));
+  if(exeName && exeName !== ''){
+    filePrefix = `${blah}-`;
+  }
+}
+const log_path = path.join(__dirname, '../..', 'logs', `${filePrefix}${process.env.NODE_ENV}.log`)
 
 const broker_name = 'service-fabrik-broker';
 const ip = '10.0.2.2';


### PR DESCRIPTION
Currently in development setup going through logs is a tedious process as logs from all processes ends up in ${env}.log file. This makes it really difficult to analyze requests and also the size of development logs grows enormously within few hrs of usage. Now each process will get its own log with this PR.