### PR TITLE
Remove error event on stream

### DIFF
--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -159,12 +159,6 @@ class ApiServerClient {
               timeoutSeconds: CONST.APISERVER.WATCH_TIMEOUT
             }
           });
-        // Removed this piece of code as watch is being refreshed every WATCHER_REFRESH_INTERVAL: 60000 (1 minute)
-        // stream.on('error', err => {
-        //   logger.error(`Error occured during watching for resource ${resourceGroup}, ${resourceType}`, err);
-        //   this.registerWatcher(resourceGroup, resourceType, callback, queryString);
-        //   //throw err;
-        // });
         const jsonStream = new JSONStream();
         stream.pipe(jsonStream);
         jsonStream.on('data', callback);

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -159,11 +159,12 @@ class ApiServerClient {
               timeoutSeconds: CONST.APISERVER.WATCH_TIMEOUT
             }
           });
-        stream.on('error', err => {
-          logger.error(`Error occured during watching for resource ${resourceGroup}, ${resourceType}`, err);
-          this.registerWatcher(resourceGroup, resourceType, callback, queryString);
-          //throw err;
-        });
+        // Removed this piece of code as watch is being refreshed every WATCHER_REFRESH_INTERVAL: 60000 (1 minute)
+        // stream.on('error', err => {
+        //   logger.error(`Error occured during watching for resource ${resourceGroup}, ${resourceType}`, err);
+        //   this.registerWatcher(resourceGroup, resourceType, callback, queryString);
+        //   //throw err;
+        // });
         const jsonStream = new JSONStream();
         stream.pipe(jsonStream);
         jsonStream.on('data', callback);


### PR DESCRIPTION
Workaround for #414 
As we are already refreshing watch after some time again and again, we don't really need `stream.on(error)`.
But if some fine day we are able to avoid refreshing watch or decide to increase refresh logic.
`error` event on stream will have to be handled intelligently.