### PR TITLE
Remove assignManager

### DIFF
--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -154,21 +154,6 @@ class FabrikBaseController extends BaseController {
       });
   }
 
-  ensurePlatformContext(req, res) {
-    /* jshint unused:false */
-    return Promise.try(() => {
-        const context = _.get(req, 'body.context');
-        if (context === undefined && req.body.space_guid && req.body.organization_guid) {
-          _.set(req.body, 'context', {
-            platform: CONST.PLATFORM.CF,
-            organization_guid: req.body.organization_guid,
-            space_guid: req.body.space_guid
-          });
-        }
-      })
-      .throw(new ContinueWithNext());
-  }
-
   getInstanceId(deploymentName) {
     return _.nth(this.fabrik.DirectorManager.parseDeploymentName(deploymentName), 2);
   }

--- a/api-controllers/routes/api/v1.js
+++ b/api-controllers/routes/api/v1.js
@@ -36,7 +36,6 @@ operationRouter.route('/')
 
 /* Service Instance Router */
 instanceRouter.use(controller.handler('verifyTenantPermission'));
-instanceRouter.use(controller.handler('assignManager'));
 instanceRouter.route('/')
   .get(controller.handler('getServiceInstanceState'))
   .all(commonMiddleware.methodNotAllowed(['GET']));

--- a/broker/lib/fabrik/BaseManager.js
+++ b/broker/lib/fabrik/BaseManager.js
@@ -3,6 +3,7 @@
 const formatUrl = require('url').format;
 const _ = require('lodash');
 const config = require('../../../common/config');
+const utils = require('../../../common/utils');
 const errors = require('../../../common/errors');
 const NotImplementedBySubclass = errors.NotImplementedBySubclass;
 const CONST = require('../../../common/constants');
@@ -37,18 +38,13 @@ class BaseManager {
     return this.settings.restore_predecessors || this.updatePredecessors;
   }
 
-  isAutoUpdatePossible() {
-    throw new NotImplementedBySubclass('isAutoUpdatePossible');
-  }
-
   isUpdatePossible(plan_id) {
     const previousPlan = _.find(this.service.plans, ['id', plan_id]);
     return this.plan === previousPlan || _.includes(this.updatePredecessors, previousPlan.id);
   }
 
   isRestorePossible(plan_id) {
-    const previousPlan = _.find(this.service.plans, ['id', plan_id]);
-    return this.plan === previousPlan || _.includes(this.restorePredecessors, previousPlan.id);
+    return utils.isRestorePossible(plan_id, this.plan);
   }
 
   getSecurityGroupName(guid) {

--- a/broker/lib/fabrik/DirectorManager.js
+++ b/broker/lib/fabrik/DirectorManager.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash');
 const yaml = require('js-yaml');
-const Promise = require('bluebird');
 const config = require('../../../common/config');
 const logger = require('../../../common/logger');
 const errors = require('../../../common/errors');
@@ -12,14 +11,12 @@ const utils = require('../../../common/utils');
 const Agent = require('../../../data-access-layer/service-agent');
 const BaseManager = require('./BaseManager');
 const DirectorInstance = require('./DirectorInstance');
-const CONST = require('../../../common/constants');
 const BoshDirectorClient = bosh.BoshDirectorClient;
 const NetworkSegmentIndex = bosh.NetworkSegmentIndex;
 const EvaluationContext = bosh.EvaluationContext;
 const Networks = bosh.manifest.Networks;
 const Header = bosh.manifest.Header;
 const Addons = bosh.manifest.Addons;
-const catalog = require('../../../common/models/catalog');
 
 class DirectorManager extends BaseManager {
   constructor(plan) {

--- a/broker/lib/fabrik/DockerManager.js
+++ b/broker/lib/fabrik/DockerManager.js
@@ -6,8 +6,6 @@ const config = require('../../../common/config');
 const docker = require('../../../data-access-layer/docker');
 const BaseManager = require('./BaseManager');
 const DockerInstance = require('./DockerInstance');
-const errors = require('../../../common/errors');
-const NotImplemented = errors.NotImplemented;
 const dockerClient = docker.client;
 
 class DockerManager extends BaseManager {
@@ -15,10 +13,6 @@ class DockerManager extends BaseManager {
     super(plan);
     this.credentials = docker.createCredentials(this.plan.credentials);
     this.imageInfo = undefined;
-  }
-
-  isAutoUpdatePossible() {
-    throw new NotImplemented(`Feature 'Update' not supported for selected service`);
   }
 
   get imageName() {

--- a/common/utils/index.js
+++ b/common/utils/index.js
@@ -17,6 +17,7 @@ const EventLogDomainSocketClient = require('./EventLogDomainSocketClient');
 const EventLogDBClient = require('./EventLogDBClient');
 const EventLogInterceptor = require('../EventLogInterceptor');
 const errors = require('../errors');
+const NotImplemented = errors.NotImplemented;
 exports.HttpClient = HttpClient;
 exports.RetryOperation = RetryOperation;
 exports.promiseWhile = promiseWhile;
@@ -55,6 +56,21 @@ exports.buildErrorJson = buildErrorJson;
 exports.deploymentLocked = deploymentLocked;
 exports.deploymentStaggered = deploymentStaggered;
 exports.parseServiceInstanceIdFromDeployment = parseServiceInstanceIdFromDeployment;
+exports.verifyFeatureSupport = verifyFeatureSupport;
+exports.isRestorePossible = isRestorePossible;
+
+function isRestorePossible(plan_id, plan) {
+  const settings = plan.manager.settings;
+  const restorePredecessors = settings.restore_predecessors || settings.update_predecessors || [];
+  const previousPlan = _.find(plan.service.plans, ['id', plan_id]);
+  return plan === previousPlan || _.includes(restorePredecessors, previousPlan.id);
+}
+
+function verifyFeatureSupport(plan, feature) {
+  if (!_.includes(plan.manager.settings.agent.supported_features, feature)) {
+    throw new NotImplemented(`Feature '${feature}' not supported`);
+  }
+}
 
 function streamToPromise(stream, options) {
   const encoding = _.get(options, 'encoding', 'utf8');

--- a/operators/BaseService.js
+++ b/operators/BaseService.js
@@ -1,10 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
 const CONST = require('../common/constants');
 const Agent = require('../data-access-layer/service-agent');
-const errors = require('../common/errors');
-const NotImplemented = errors.NotImplemented;
 
 class BaseService {
   constructor(plan) {
@@ -36,11 +33,6 @@ class BaseService {
     return this.plan.service;
   }
 
-  verifyFeatureSupport(feature) {
-    if (!_.includes(this.agent.features, feature)) {
-      throw new NotImplemented(`Feature '${feature}' not supported`);
-    }
-  }
 }
 
 module.exports = BaseService;

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -72,10 +72,6 @@ class DirectorService extends BaseDirectorService {
       });
   }
 
-  verifyFeatureSupport(feature) {
-    utils.verifyFeatureSupport(this.plan, feature);
-  }
-
   getDeploymentName(guid, networkSegmentIndex) {
     let subnet = this.subnet ? `_${this.subnet}` : '';
     return `${this.prefix}${subnet}-${NetworkSegmentIndex.adjust(networkSegmentIndex)}-${guid}`;
@@ -686,7 +682,7 @@ class DirectorService extends BaseDirectorService {
   }
 
   createBinding(deploymentName, binding) {
-    this.verifyFeatureSupport('credentials');
+    utils.verifyFeatureSupport(this.plan, 'credentials');
     logger.info(`Creating binding '${binding.id}' for deployment '${deploymentName}'...`);
     logger.info('+-> Binding parameters:', binding.parameters);
     let actionContext = {
@@ -726,7 +722,7 @@ class DirectorService extends BaseDirectorService {
   }
 
   deleteBinding(deploymentName, id) {
-    this.verifyFeatureSupport('credentials');
+    utils.verifyFeatureSupport(this.plan, 'credentials');
     logger.info(`Deleting binding '${id}' for deployment '${deploymentName}'...`);
     let actionContext = {
       'deployment_name': deploymentName,
@@ -891,7 +887,7 @@ class DirectorService extends BaseDirectorService {
       .try(() => {
         if (utils.isFeatureEnabled(CONST.FEATURE.SCHEDULED_BACKUP)) {
           try {
-            this.verifyFeatureSupport('backup');
+            utils.verifyFeatureSupport(this.plan, 'backup');
             ScheduleManager
               .getSchedule(this.guid, CONST.JOB.SCHEDULED_BACKUP)
               .then(schedule => {

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -2043,7 +2043,6 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -2089,7 +2088,6 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -2134,7 +2132,6 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -2160,7 +2157,6 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -1964,7 +1964,6 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -1990,7 +1989,6 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -2045,7 +2043,7 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -2091,7 +2089,7 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -2136,7 +2134,7 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -2162,7 +2160,7 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)

--- a/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
@@ -246,7 +246,6 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -272,7 +271,6 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -327,7 +325,6 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -373,7 +370,6 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -418,7 +414,6 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -444,7 +439,6 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)

--- a/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
@@ -246,7 +246,7 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -272,7 +272,7 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -327,7 +327,7 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -373,7 +373,7 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -418,7 +418,7 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -444,7 +444,7 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          // mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)

--- a/test/test_broker/broker.middleware.spec.js
+++ b/test/test_broker/broker.middleware.spec.js
@@ -16,7 +16,7 @@ const utils = require('../../common/utils');
 const errors = require('../../common/errors');
 const BadRequest = errors.BadRequest;
 const Forbidden = errors.Forbidden;
-const PROMISE_WAIT_SIMULATED_DELAY = 2;
+const PROMISE_WAIT_SIMULATED_DELAY = 30;
 
 class Response {
   constructor() {

--- a/test/test_broker/fabrik.DirectorManager.spec.js
+++ b/test/test_broker/fabrik.DirectorManager.spec.js
@@ -5,7 +5,6 @@ const yaml = require('js-yaml');
 const catalog = require('../../common/models').catalog;
 const proxyquire = require('proxyquire');
 const Promise = require('bluebird');
-const CONST = require('../../common/constants');
 
 var used_guid = '4a6e7c34-d97c-4fc0-95e6-7a3bc8030be9';
 var deployment_name = `service-fabrik-0021-${used_guid}`;

--- a/test/test_broker/fabrik.DirectorManager.spec.js
+++ b/test/test_broker/fabrik.DirectorManager.spec.js
@@ -72,52 +72,6 @@ describe('fabrik', function () {
       });
     });
 
-    describe('#executeActions', function () {
-      before(function () {
-        return mocks.setup([]);
-      });
-
-      afterEach(function () {
-        mocks.reset();
-      });
-      const rabbit_plan_id = 'b715f834-2048-11e7-a560-080027afc1e6';
-      const context = {
-        deployment_name: 'my-deployment'
-      };
-      it('should return empty response if no actions are defined', function () {
-        manager = new DirectorManager(catalog.getPlan(rabbit_plan_id));
-        return manager.executeActions(CONST.SERVICE_LIFE_CYCLE.PRE_CREATE, context)
-          .then(actionResponse => {
-            expect(actionResponse).to.eql({});
-          });
-      });
-      it('should return empty response if actions are not provided', function () {
-        manager = new DirectorManager(catalog.getPlan(small_plan_id));
-        let temp_actions = manager.service.actions;
-        manager.service.actions = '';
-        return manager.executeActions(CONST.SERVICE_LIFE_CYCLE.PRE_CREATE, context)
-          .then(actionResponse => {
-            manager.service.actions = temp_actions;
-            expect(actionResponse).to.eql({});
-          });
-      });
-      it('should return correct action response', function () {
-        const expectedRequestBody = {
-          phase: 'PreCreate',
-          actions: ['Blueprint', 'ReserveIps'],
-          context: {
-            deployment_name: 'my-deployment'
-          }
-        };
-        mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
-        manager = new DirectorManager(catalog.getPlan(xsmall_plan_id));
-        return manager.executeActions(CONST.SERVICE_LIFE_CYCLE.PRE_CREATE, context)
-          .then(actionResponse => {
-            expect(actionResponse).to.eql({});
-            mocks.verify();
-          });
-      });
-    });
     describe('#configureAddOns', function () {
       it('should update manifest with addons', function () {
         const plan = _.cloneDeep(catalog.getPlan(plan_id));


### PR DESCRIPTION
Remove `assignManager` call from `api-controllers/routes/api/v1.js`
The functionality is now available in `setPlan` in `api-controllers/ServiceFabrikApiController.js`
Remove `req.manager.isAutoUpdatePossible` 