### PR TITLE
Event logging for sf internal update operations

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -80,7 +80,8 @@ module.exports = Object.freeze({
   URL: {
     backup: '/api/v1/service_instances/:instance_id/backup',
     restore: '/api/v1/service_instances/:instance_id/restore',
-    backup_by_guid: '/api/v1/backups/:backup_guid'
+    backup_by_guid: '/api/v1/backups/:backup_guid',
+    instance: '/:platform(cf|k8s)/v2/service_instances/:instance_id'
   },
   INSTANCE_TYPE: {
     DIRECTOR: 'director',

--- a/common/utils/ServiceBrokerClient.js
+++ b/common/utils/ServiceBrokerClient.js
@@ -98,30 +98,6 @@ class ServiceBrokerClient extends HttpClient {
       }, 202)
       .then(res => res.body);
   }
-
-  getLastOperationOfServiceInstance(options) {
-    logger.info(`-> Updating instance -  name: ${options.instance_id}`);
-    return this
-      .request({
-        method: 'GET',
-        url: `/cf/v2/service_instances/${options.instance_id}/last_operation`,
-        auth: {
-          user: config.username,
-          pass: config.password
-        },
-        headers: {
-          Accept: 'application/json',
-          'X-Broker-API-Version': CONST.SF_BROKER_API_VERSION_MIN
-        },
-        qs: {
-          service_id: options.service_id,
-          plan_id: options.plan_id,
-          operation: options.operation
-        },
-        json: true
-      }, 200)
-      .then(res => res.body);
-  }
 }
 
 module.exports = new ServiceBrokerClient();

--- a/common/utils/ServiceBrokerClient.js
+++ b/common/utils/ServiceBrokerClient.js
@@ -98,6 +98,30 @@ class ServiceBrokerClient extends HttpClient {
       }, 202)
       .then(res => res.body);
   }
+
+  getLastOperationOfServiceInstance(options) {
+    logger.info(`-> Updating instance -  name: ${options.instance_id}`);
+    return this
+      .request({
+        method: 'GET',
+        url: `/cf/v2/service_instances/${options.instance_id}/last_operation`,
+        auth: {
+          user: config.username,
+          pass: config.password
+        },
+        headers: {
+          Accept: 'application/json',
+          'X-Broker-API-Version': CONST.SF_BROKER_API_VERSION_MIN
+        },
+        qs: {
+          service_id: options.service_id,
+          plan_id: options.plan_id,
+          operation: options.operation
+        },
+        json: true
+      }, 200)
+      .then(res => res.body);
+  }
 }
 
 module.exports = new ServiceBrokerClient();

--- a/managers/bosh-manager/BoshManager.js
+++ b/managers/bosh-manager/BoshManager.js
@@ -10,8 +10,12 @@ const DirectorService = require('./DirectorService');
 const errors = require('../../common/errors');
 const utils = require('../../common/utils');
 const config = require('../../common/config');
+const DBManager = require('../../broker/lib/fabrik/DBManager');
 const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const assert = require('assert');
+
+/* jshint nonew:false */
+new DBManager(); //to log events
 
 class BoshManager extends BaseManager {
   init() {

--- a/managers/bosh-manager/BoshManager.js
+++ b/managers/bosh-manager/BoshManager.js
@@ -9,11 +9,13 @@ const BaseManager = require('../BaseManager');
 const DirectorService = require('./DirectorService');
 const errors = require('../../common/errors');
 const utils = require('../../common/utils');
+const config = require('../../common/config');
 const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const assert = require('assert');
 
 class BoshManager extends BaseManager {
   init() {
+    utils.initializeEventListener(config.internal, 'internal');
     const validStateList = [CONST.APISERVER.RESOURCE_STATE.IN_QUEUE, CONST.APISERVER.RESOURCE_STATE.UPDATE, CONST.APISERVER.RESOURCE_STATE.DELETE];
     return this.registerCrds(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR)
       .then(() => this.registerWatcher(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, validStateList));

--- a/managers/bosh-manager/BoshTaskPoller.js
+++ b/managers/bosh-manager/BoshTaskPoller.js
@@ -132,7 +132,9 @@ class BoshTaskPoller {
                   if (_.get(resourceBody.status.response, 'type') === CONST.OPERATION_TYPE.UPDATE &&
                     _.get(resourceBody.status.response, 'parameters.service-fabrik-operation') === true &&
                     _.includes([CONST.APISERVER.RESOURCE_STATE.FAILED, CONST.APISERVER.RESOURCE_STATE.FAILED], lastOperationOfInstance.state)) {
-                    return _logEvent(options, lastOperationOfInstance, CONST.HTTP_METHOD.PATCH);
+                    return _logEvent(_.assign(options, {
+                      instance_id: metadata.name
+                    }), lastOperationOfInstance, CONST.HTTP_METHOD.PATCH);
                   }
                 });
             }

--- a/managers/bosh-manager/BoshTaskPoller.js
+++ b/managers/bosh-manager/BoshTaskPoller.js
@@ -10,7 +10,7 @@ const logger = require('../../common/logger');
 const config = require('../../common/config');
 const utils = require('../../common/utils');
 const DirectorService = require('./DirectorService');
-const serviceBrokerClient = require('../../common/utils/ServiceBrokerClient');
+const EventLogInterceptor = require('../../common/EventLogInterceptor');
 const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const AssertionError = assert.AssertionError;
 const Conflict = errors.Conflict;
@@ -30,6 +30,10 @@ class BoshTaskPoller {
           const options = _.get(resourceBody, 'spec.options');
           const pollerAnnotation = _.get(resourceBody, 'metadata.annotations.lockedByTaskPoller');
           logger.debug(`pollerAnnotation is ${pollerAnnotation} current time is: ${new Date()}`);
+          let lastOperationOfInstance = {
+            state: 'in progress',
+            description: 'Update deployment is still in progress'
+          };
           return Promise.try(() => {
             // If task is not picked by poller which has the lock on task for CONST.DIRECTOR_RESOURCE_POLLER_INTERVAL + DIRECTOR_RESOURCE_POLLER_RELAXATION_TIME then try to acquire lock
             if (pollerAnnotation && (JSON.parse(pollerAnnotation).ip !== config.broker_ip) && (new Date() - new Date(JSON.parse(pollerAnnotation).lockTime) < (CONST.DIRECTOR_RESOURCE_POLLER_INTERVAL + CONST.DIRECTOR_RESOURCE_POLLER_RELAXATION_TIME))) { // cahnge this to 5000
@@ -60,6 +64,7 @@ class BoshTaskPoller {
                     return DirectorService.createInstance(metadata.name, options)
                       .then(directorService => directorService.lastOperation(_.get(resourceBody, 'status.response')))
                       .tap(lastOperationValue => logger.debug('last operation value is ', lastOperationValue))
+                      .tap(lastOperationValue => lastOperationOfInstance = lastOperationValue)
                       .then(lastOperationValue => Promise.all([eventmesh.apiServerClient.updateResource({
                         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
                         resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
@@ -84,15 +89,16 @@ class BoshTaskPoller {
                             resourceId: metadata.name
                           });
                         } else {
+                          lastOperationOfInstance = {
+                            state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+                            description: CONST.SERVICE_BROKER_ERR_MSG
+                          };
                           return eventmesh.apiServerClient.updateResource({
                             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
                             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
                             resourceId: metadata.name,
                             status: {
-                              lastOperation: {
-                                state: CONST.APISERVER.RESOURCE_STATE.FAILED,
-                                description: CONST.SERVICE_BROKER_ERR_MSG
-                              },
+                              lastOperation: lastOperationOfInstance,
                               state: CONST.APISERVER.RESOURCE_STATE.FAILED,
                               error: utils.buildErrorJson(err)
                             }
@@ -102,15 +108,16 @@ class BoshTaskPoller {
                       .catch(AssertionError, err => {
                         logger.error(`Error occured while getting last operation for instance ${object.metadata.name}`, err);
                         BoshTaskPoller.clearPoller(metadata.name, intervalId);
+                        lastOperationOfInstance = {
+                          state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+                          description: CONST.SERVICE_BROKER_ERR_MSG
+                        };
                         return eventmesh.apiServerClient.updateResource({
                           resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
                           resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
                           resourceId: metadata.name,
                           status: {
-                            lastOperation: {
-                              state: CONST.APISERVER.RESOURCE_STATE.FAILED,
-                              description: CONST.SERVICE_BROKER_ERR_MSG
-                            },
+                            lastOperation: lastOperationOfInstance,
                             state: CONST.APISERVER.RESOURCE_STATE.FAILED,
                             error: utils.buildErrorJson(err)
                           }
@@ -124,15 +131,9 @@ class BoshTaskPoller {
                 .finally(() => {
                   if (_.get(resourceBody.status.response, 'type') === 'update' &&
                     _.get(resourceBody.status.response, 'parameters.service-fabrik-operation') === true &&
-                    _.get(resourceBody.status.response, 'parameters.scheduled') === true) {
-                    return serviceBrokerClient.getLastOperationOfServiceInstance({
-                      instance_id: metadata.name,
-                      service_id: options.service_id,
-                      plan_id: options.plan_id,
-                      operation: utils.encodeBase64({
-                        'type': 'update'
-                      })
-                    });
+                    _.get(resourceBody.status.response, 'parameters.scheduled') === true &&
+                    _.includes([CONST.APISERVER.RESOURCE_STATE.FAILED, CONST.APISERVER.RESOURCE_STATE.FAILED], lastOperationOfInstance.state)) {
+                    return _logEvent(options, lastOperationOfInstance, CONST.HTTP_METHOD.PATCH);
                   }
                 });
             }
@@ -142,6 +143,18 @@ class BoshTaskPoller {
           logger.error(`Error occured while polling for last operation for instance ${object.metadata.name}, clearing bosh task poller interval now`, err);
           BoshTaskPoller.clearPoller(object.metadata.name, intervalId);
         });
+
+      function _logEvent(opts, operationStatusResponse, method) {
+        const eventLogger = EventLogInterceptor.getInstance(config.internal.event_type, 'internal');
+        const check_res_body = true;
+        const resp = {
+          statusCode: 200,
+          body: operationStatusResponse
+        };
+        if (CONST.URL.instance) {
+          return eventLogger.publishAndAuditLogEvent(CONST.URL.instance, method, opts, resp, check_res_body);
+        }
+      }
     }
 
     function startPoller(event) {

--- a/managers/bosh-manager/BoshTaskPoller.js
+++ b/managers/bosh-manager/BoshTaskPoller.js
@@ -129,9 +129,8 @@ class BoshTaskPoller {
                   logger.debug(`Not able to acquire bosh task poller processing lock for instance ${object.metadata.name}, Request is probably picked by other worker`);
                 })
                 .finally(() => {
-                  if (_.get(resourceBody.status.response, 'type') === 'update' &&
+                  if (_.get(resourceBody.status.response, 'type') === CONST.OPERATION_TYPE.UPDATE &&
                     _.get(resourceBody.status.response, 'parameters.service-fabrik-operation') === true &&
-                    _.get(resourceBody.status.response, 'parameters.scheduled') === true &&
                     _.includes([CONST.APISERVER.RESOURCE_STATE.FAILED, CONST.APISERVER.RESOURCE_STATE.FAILED], lastOperationOfInstance.state)) {
                     return _logEvent(options, lastOperationOfInstance, CONST.HTTP_METHOD.PATCH);
                   }

--- a/managers/bosh-manager/BoshTaskPoller.js
+++ b/managers/bosh-manager/BoshTaskPoller.js
@@ -131,7 +131,7 @@ class BoshTaskPoller {
                 .finally(() => {
                   if (_.get(resourceBody.status.response, 'type') === CONST.OPERATION_TYPE.UPDATE &&
                     _.get(resourceBody.status.response, 'parameters.service-fabrik-operation') === true &&
-                    _.includes([CONST.APISERVER.RESOURCE_STATE.FAILED, CONST.APISERVER.RESOURCE_STATE.FAILED], lastOperationOfInstance.state)) {
+                    _.includes([CONST.APISERVER.RESOURCE_STATE.SUCCEEDED, CONST.APISERVER.RESOURCE_STATE.FAILED], lastOperationOfInstance.state)) {
                     return _logEvent(_.assign(options, {
                       instance_id: metadata.name
                     }), lastOperationOfInstance, CONST.HTTP_METHOD.PATCH);


### PR DESCRIPTION
Earlier sf triggered update used to happen via cloud controller. Hence event logging for update used to happen via last operation api. Now broker triggered updates (schedule/admin update) happens via calling broker's api directly. so, there is no one call last operation api. Internally apiserver entity is updated with operation status for that instance e.g. update is in_progress, succeeded etc. So event logging is now done when for update and parameter 'service-fabrik-operation' is present then only log event.