### PR TITLE
Modifying flow of getDeploymentIps to fetch IPs from ApiServer

### DIFF
--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -34,7 +34,7 @@ class ServiceFabrikAdminController extends FabrikBaseController {
     const allowForbiddenManifestChanges = (req.body.forbidden_changes === undefined) ? true :
       JSON.parse(req.body.forbidden_changes);
     const deploymentName = req.params.name;
-    const instanceId = this.parseServiceInstanceIdFromDeployment(deploymentName);
+    const instanceId = utils.parseServiceInstanceIdFromDeployment(deploymentName);
     const runImmediately = (req.body.run_immediately === 'true' ? true : false);
     let resourceDetails;
     let plan;
@@ -138,14 +138,6 @@ class ServiceFabrikAdminController extends FabrikBaseController {
         .status(202)
         .send(body)
       );
-  }
-
-  parseServiceInstanceIdFromDeployment(deploymentName) {
-    const deploymentNameArray = utils.deploymentNameRegExp().exec(deploymentName);
-    if (deploymentNameArray !== undefined && deploymentNameArray.length === 4) {
-      return deploymentNameArray[3];
-    }
-    return deploymentName;
   }
 
   getOutdatedDiff(instanceDetails, tenantInfo, plan) {

--- a/common/utils/index.js
+++ b/common/utils/index.js
@@ -53,6 +53,7 @@ exports.initializeEventListener = initializeEventListener;
 exports.buildErrorJson = buildErrorJson;
 exports.deploymentLocked = deploymentLocked;
 exports.deploymentStaggered = deploymentStaggered;
+exports.parseServiceInstanceIdFromDeployment = parseServiceInstanceIdFromDeployment;
 
 function streamToPromise(stream, options) {
   const encoding = _.get(options, 'encoding', 'utf8');
@@ -320,6 +321,14 @@ function deploymentNameRegExp(service_subnet) {
 
 function taskIdRegExp() {
   return new RegExp(`^([0-9a-z-]+)_([0-9]+)$`);
+}
+
+function parseServiceInstanceIdFromDeployment(deploymentName) {
+  const deploymentNameArray = deploymentNameRegExp().exec(deploymentName);
+  if (Array.isArray(deploymentNameArray) && deploymentNameArray.length === 4) {
+    return deploymentNameArray[3];
+  }
+  return deploymentName;
 }
 
 function getRandomInt(min, max) {

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -567,7 +567,7 @@ class BoshDirectorClient extends HttpClient {
     logger.info(`[getDeploymentIps] making request to ApiServer for deployment - ${deploymentName}`);
     let resourceId = utils.parseServiceInstanceIdFromDeployment(deploymentName);
     if (deploymentName === resourceId) {
-      //don't contact to ApiServer if not a service-fabrik deployment
+      //don't contact to ApiServer if it is out-of-band deployment
       return Promise.resolve();
     }
     return eventmesh.apiServerClient.getResource({
@@ -585,7 +585,7 @@ class BoshDirectorClient extends HttpClient {
   putDeploymentIpsInResource(deploymentName, ips) {
     let resourceId = utils.parseServiceInstanceIdFromDeployment(deploymentName);
     if (deploymentName === resourceId) {
-      //don't contact to ApiServer if not a service-fabrik deployment
+      //don't contact to ApiServer if it is out-of-band deployment
       return Promise.resolve();
     }
     return eventmesh.apiServerClient.updateResource({

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -563,20 +563,12 @@ class BoshDirectorClient extends HttpClient {
     });
   }
 
-  parseServiceInstanceIdFromDeployment(deploymentName) {
-    const deploymentNameArray = utils.deploymentNameRegExp().exec(deploymentName);
-    if (Array.isArray(deploymentNameArray) && deploymentNameArray.length === 4) {
-      return deploymentNameArray[3];
-    }
-    return deploymentName;
-  }
-
   getDeploymentIpsFromResource(deploymentName) {
     logger.info(`[getDeploymentIps] making request to ApiServer for deployment - ${deploymentName}`);
-    let resourceId = this.parseServiceInstanceIdFromDeployment(deploymentName);
+    let resourceId = utils.parseServiceInstanceIdFromDeployment(deploymentName);
     if (deploymentName === resourceId) {
       //don't contact to ApiServer if not a service-fabrik deployment
-      return Promise.try(() => {});
+      return Promise.resolve();
     }
     return eventmesh.apiServerClient.getResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
@@ -586,15 +578,15 @@ class BoshDirectorClient extends HttpClient {
       .then(resource => JSON.parse(_.get(resource, 'metadata.annotations.deploymentIps', '{}')))
       .catch(err => {
         logger.error(`[getDeploymentIps] Error occurred while getting deployment Ips for ${deploymentName} from ApiServer`, err);
-        return {};
+        return;
       });
   }
 
   putDeploymentIpsInResource(deploymentName, ips) {
-    let resourceId = this.parseServiceInstanceIdFromDeployment(deploymentName);
+    let resourceId = utils.parseServiceInstanceIdFromDeployment(deploymentName);
     if (deploymentName === resourceId) {
       //don't contact to ApiServer if not a service-fabrik deployment
-      return Promise.try(() => {});
+      return Promise.resolve();
     }
     return eventmesh.apiServerClient.updateResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
@@ -608,7 +600,7 @@ class BoshDirectorClient extends HttpClient {
       })
       .catch(err => {
         logger.error(`[getDeploymentIps] Error occured while updating resource for ${deploymentName} on ApiServer`, err);
-        return {};
+        return;
       });
   }
 

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -17,6 +17,7 @@ const BadRequest = errors.BadRequest;
 const UaaClient = require('../cf/UaaClient');
 const TokenIssuer = require('../cf/TokenIssuer');
 const HttpServer = require('../../common/HttpServer');
+const eventmesh = require('../eventmesh');
 
 class BoshDirectorClient extends HttpClient {
   constructor() {
@@ -536,7 +537,7 @@ class BoshDirectorClient extends HttpClient {
       }, 200, deploymentName)
       .then(res => JSON.parse(res.body));
   }
-
+  /*
   getDeploymentIps(deploymentName) {
     return Promise.try(() => {
       if (this.deploymentIpsCache[deploymentName] !== undefined) {
@@ -552,6 +553,91 @@ class BoshDirectorClient extends HttpClient {
       }
     });
 
+  }
+  */
+  getDeploymentIps(deploymentName) {
+    return Promise.try(() => {
+      if (this.deploymentIpsCache[deploymentName] !== undefined) {
+        return this.deploymentIpsCache[deploymentName];
+      } else {
+        return this.getDeploymentIpsFromResource(deploymentName)
+        .then(ips => {
+          if(!_.isEmpty(ips)) {
+            logger.info(`[getDeploymentIps] Cached Ips for deployment - ${deploymentName} - `, ips);
+            this.deploymentIpsCache[deploymentName] = ips;
+            return ips; 
+          } else {
+            return this.getDeploymentIpsFromDirector(deploymentName)
+            .then(ips => {
+              logger.info(`[getDeploymentIps] Caching IPs on ApiServer and locally`);
+              this.deploymentIpsCache[deploymentName] = ips
+              return this.putDeploymentIpsInResource(deploymentName, ips)
+              .then(() => ips);
+            });
+          }
+        });
+      }
+    });
+  }
+  
+  parseServiceInstanceIdFromDeployment(deploymentName) {
+    const deploymentNameArray = utils.deploymentNameRegExp().exec(deploymentName);
+    if (Array.isArray(deploymentNameArray) && deploymentNameArray.length === 4) {
+      return deploymentNameArray[3];
+    }
+    return deploymentName;
+  }
+
+  getDeploymentIpsFromResource(deploymentName){
+    logger.info(`[getDeploymentIps] making request to ApiServer for deployment - ${deploymentName}`);
+    let resourceId = this.parseServiceInstanceIdFromDeployment(deploymentName);
+    if(deploymentName === resourceId) {
+      //don't contact to ApiServer if not a service-fabrik deployment
+      return Promise.try(() => {});
+    }
+    return eventmesh.apiServerClient.getResource({
+      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+      resourceId: resourceId
+    })
+    .then(resource => JSON.parse(_.get(resource, 'metadata.annotations.deploymentIps', '{}')))
+    .catch(err => {
+      logger.error(`[getDeploymentIps] Error occurred while getting deployment Ips for ${deploymentName} from ApiServer`, err);
+      return {};
+    });
+  }
+
+  putDeploymentIpsInResource(deploymentName, ips) {
+    let resourceId = this.parseServiceInstanceIdFromDeployment(deploymentName);
+    if(deploymentName === resourceId){
+      //don't contact to ApiServer if not a service-fabrik deployment
+      return Promise.try(() => {});
+    }    
+    return eventmesh.apiServerClient.updateResource({
+      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+      resourceId: resourceId,
+      metadata: {
+        annotations:{
+          deploymentIps:JSON.stringify(ips)
+        }
+      }
+    })
+    .catch(err => {
+      logger.error(`[getDeploymentIps] Error occured while updating resource for ${deploymentName} on ApiServer`, err);
+      return {};
+    });
+  }
+
+  getDeploymentIpsFromDirector(deploymentName) {
+    logger.info(`[getDeploymentIps] making request to director for deployment - ${deploymentName}`);
+    return this
+      .getDeploymentInstances(deploymentName)
+      .reduce((ipList, instance) => ipList.concat(instance.ips), [])
+      .tap(response => {
+        logger.info(`Cached Ips for deployment - ${deploymentName} - `, response);
+        this.deploymentIpsCache[deploymentName] = response;
+      });
   }
 
   getAgentPropertiesFromManifest(deploymentName) {

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -537,49 +537,32 @@ class BoshDirectorClient extends HttpClient {
       }, 200, deploymentName)
       .then(res => JSON.parse(res.body));
   }
-  /*
-  getDeploymentIps(deploymentName) {
-    return Promise.try(() => {
-      if (this.deploymentIpsCache[deploymentName] !== undefined) {
-        return this.deploymentIpsCache[deploymentName];
-      } else {
-        return this
-          .getDeploymentInstances(deploymentName)
-          .reduce((ipList, instance) => ipList.concat(instance.ips), [])
-          .tap(response => {
-            logger.info(`Cached Ips for deployment - ${deploymentName} - `, response);
-            this.deploymentIpsCache[deploymentName] = response;
-          });
-      }
-    });
 
-  }
-  */
   getDeploymentIps(deploymentName) {
     return Promise.try(() => {
       if (this.deploymentIpsCache[deploymentName] !== undefined) {
         return this.deploymentIpsCache[deploymentName];
       } else {
         return this.getDeploymentIpsFromResource(deploymentName)
-        .then(ips => {
-          if(!_.isEmpty(ips)) {
-            logger.info(`[getDeploymentIps] Cached Ips for deployment - ${deploymentName} - `, ips);
-            this.deploymentIpsCache[deploymentName] = ips;
-            return ips; 
-          } else {
-            return this.getDeploymentIpsFromDirector(deploymentName)
-            .then(ips => {
-              logger.info(`[getDeploymentIps] Caching IPs on ApiServer and locally`);
-              this.deploymentIpsCache[deploymentName] = ips
-              return this.putDeploymentIpsInResource(deploymentName, ips)
-              .then(() => ips);
-            });
-          }
-        });
+          .then(ips => {
+            if (!_.isEmpty(ips)) {
+              logger.info(`[getDeploymentIps] Cached Ips for deployment - ${deploymentName} - `, ips);
+              this.deploymentIpsCache[deploymentName] = ips;
+              return ips;
+            } else {
+              return this.getDeploymentIpsFromDirector(deploymentName)
+                .then(ips => {
+                  logger.info(`[getDeploymentIps] Caching IPs on ApiServer and locally`);
+                  this.deploymentIpsCache[deploymentName] = ips;
+                  return this.putDeploymentIpsInResource(deploymentName, ips)
+                    .then(() => ips);
+                });
+            }
+          });
       }
     });
   }
-  
+
   parseServiceInstanceIdFromDeployment(deploymentName) {
     const deploymentNameArray = utils.deploymentNameRegExp().exec(deploymentName);
     if (Array.isArray(deploymentNameArray) && deploymentNameArray.length === 4) {
@@ -588,45 +571,45 @@ class BoshDirectorClient extends HttpClient {
     return deploymentName;
   }
 
-  getDeploymentIpsFromResource(deploymentName){
+  getDeploymentIpsFromResource(deploymentName) {
     logger.info(`[getDeploymentIps] making request to ApiServer for deployment - ${deploymentName}`);
     let resourceId = this.parseServiceInstanceIdFromDeployment(deploymentName);
-    if(deploymentName === resourceId) {
+    if (deploymentName === resourceId) {
       //don't contact to ApiServer if not a service-fabrik deployment
       return Promise.try(() => {});
     }
     return eventmesh.apiServerClient.getResource({
-      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-      resourceId: resourceId
-    })
-    .then(resource => JSON.parse(_.get(resource, 'metadata.annotations.deploymentIps', '{}')))
-    .catch(err => {
-      logger.error(`[getDeploymentIps] Error occurred while getting deployment Ips for ${deploymentName} from ApiServer`, err);
-      return {};
-    });
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+        resourceId: resourceId
+      })
+      .then(resource => JSON.parse(_.get(resource, 'metadata.annotations.deploymentIps', '{}')))
+      .catch(err => {
+        logger.error(`[getDeploymentIps] Error occurred while getting deployment Ips for ${deploymentName} from ApiServer`, err);
+        return {};
+      });
   }
 
   putDeploymentIpsInResource(deploymentName, ips) {
     let resourceId = this.parseServiceInstanceIdFromDeployment(deploymentName);
-    if(deploymentName === resourceId){
+    if (deploymentName === resourceId) {
       //don't contact to ApiServer if not a service-fabrik deployment
       return Promise.try(() => {});
-    }    
+    }
     return eventmesh.apiServerClient.updateResource({
-      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-      resourceId: resourceId,
-      metadata: {
-        annotations:{
-          deploymentIps:JSON.stringify(ips)
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+        resourceId: resourceId,
+        metadata: {
+          annotations: {
+            deploymentIps: JSON.stringify(ips)
+          }
         }
-      }
-    })
-    .catch(err => {
-      logger.error(`[getDeploymentIps] Error occured while updating resource for ${deploymentName} on ApiServer`, err);
-      return {};
-    });
+      })
+      .catch(err => {
+        logger.error(`[getDeploymentIps] Error occured while updating resource for ${deploymentName} on ApiServer`, err);
+        return {};
+      });
   }
 
   getDeploymentIpsFromDirector(deploymentName) {

--- a/managers/bosh-manager/BoshTaskPoller.js
+++ b/managers/bosh-manager/BoshTaskPoller.js
@@ -57,73 +57,32 @@ class BoshTaskPoller {
                     BoshTaskPoller.clearPoller(metadata.name, intervalId);
                   } else {
                     return DirectorService.createInstance(metadata.name, options)
-                      .then(directorService => directorService.lastOperation(_.get(resourceBody, 'status.response'))
-                        .tap(lastOperationValue => logger.debug('last operation value is ', lastOperationValue))
-                        .then(lastOperationValue => Promise.all([
-                          Promise.try(() => {
-                            if(lastOperationValue.resourceState === CONST.APISERVER.RESOURCE_STATE.SUCCEEDED && (lastOperationValue.type === 'create' || lastOperationValue.type === 'update')) {
-                              return directorService.director.getDeploymentNameForInstanceId(directorService.guid)
-                              .then(deploymentName => directorService.getDeploymentIps(deploymentName))
-                              .then(ips => eventmesh.apiServerClient.updateResource({
-                                resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-                                resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-                                resourceId: metadata.name,
-                                status: {
-                                  lastOperation: lastOperationValue,
-                                  state: lastOperationValue.resourceState
-                                },
-                                metadata: {
-                                  annotations:{
-                                    deploymentIps:JSON.stringify(ips)
-                                  }
-                                }
-                              })
-                            );
-                            } else {
-                              return eventmesh.apiServerClient.updateResource({
-                              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-                              resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-                              resourceId: metadata.name,
-                              status: {
-                                lastOperation: lastOperationValue,
-                                state: lastOperationValue.resourceState
-                              }});
-                            }
-                          }),
-                          Promise.try(() => {
-                          if (_.includes([CONST.APISERVER.RESOURCE_STATE.SUCCEEDED, CONST.APISERVER.RESOURCE_STATE.FAILED], lastOperationValue.resourceState)) {
-                            // cancel the poller and clear the array
-                            BoshTaskPoller.clearPoller(metadata.name, intervalId);
-                          }
-                        })]))
-                        .catch(ServiceInstanceNotFound, err => {
-                          logger.error(`Error occured while getting last operation`, err);
+                      .then(directorService => directorService.lastOperation(_.get(resourceBody, 'status.response')))
+                      .tap(lastOperationValue => logger.debug('last operation value is ', lastOperationValue))
+                      .then(lastOperationValue => Promise.all([eventmesh.apiServerClient.updateResource({
+                        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+                        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+                        resourceId: metadata.name,
+                        status: {
+                          lastOperation: lastOperationValue,
+                          state: lastOperationValue.resourceState
+                        }
+                      }), Promise.try(() => {
+                        if (_.includes([CONST.APISERVER.RESOURCE_STATE.SUCCEEDED, CONST.APISERVER.RESOURCE_STATE.FAILED], lastOperationValue.resourceState)) {
+                          // cancel the poller and clear the array
                           BoshTaskPoller.clearPoller(metadata.name, intervalId);
-                          if (resourceBody.status.response.type === 'delete') {
-                            return eventmesh.apiServerClient.deleteResource({
-                              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-                              resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-                              resourceId: metadata.name
-                            });
-                          } else {
-                            return eventmesh.apiServerClient.updateResource({
-                              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-                              resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-                              resourceId: metadata.name,
-                              status: {
-                                lastOperation: {
-                                  state: CONST.APISERVER.RESOURCE_STATE.FAILED,
-                                  description: CONST.SERVICE_BROKER_ERR_MSG
-                                },
-                                state: CONST.APISERVER.RESOURCE_STATE.FAILED,
-                                error: utils.buildErrorJson(err)
-                              }
-                            });
-                          }
-                        })
-                        .catch(AssertionError, err => {
-                          logger.error(`Error occured while getting last operation for instance ${object.metadata.name}`, err);
-                          BoshTaskPoller.clearPoller(metadata.name, intervalId);
+                        }
+                      })]))
+                      .catch(ServiceInstanceNotFound, err => {
+                        logger.error(`Error occured while getting last operation`, err);
+                        BoshTaskPoller.clearPoller(metadata.name, intervalId);
+                        if (resourceBody.status.response.type === 'delete') {
+                          return eventmesh.apiServerClient.deleteResource({
+                            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+                            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+                            resourceId: metadata.name
+                          });
+                        } else {
                           return eventmesh.apiServerClient.updateResource({
                             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
                             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
@@ -135,10 +94,27 @@ class BoshTaskPoller {
                               },
                               state: CONST.APISERVER.RESOURCE_STATE.FAILED,
                               error: utils.buildErrorJson(err)
-                           }
+                            }
                           });
-                        })
-                      );
+                        }
+                      })
+                      .catch(AssertionError, err => {
+                        logger.error(`Error occured while getting last operation for instance ${object.metadata.name}`, err);
+                        BoshTaskPoller.clearPoller(metadata.name, intervalId);
+                        return eventmesh.apiServerClient.updateResource({
+                          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+                          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+                          resourceId: metadata.name,
+                          status: {
+                            lastOperation: {
+                              state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+                              description: CONST.SERVICE_BROKER_ERR_MSG
+                            },
+                            state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+                            error: utils.buildErrorJson(err)
+                          }
+                        });
+                      });
                   }
                 })
                 .catch(Conflict, () => {

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -49,13 +49,13 @@ describe('service-fabrik-api-sf2.0', function () {
       const repeatInterval = '*/1 * * * *';
       const repeatTimezone = 'America/New_York';
       const dummyDeploymentResource = {
-        metadata:{
+        metadata: {
           annotations: {
             labels: 'dummy'
           }
         }
       };
-  
+
       const getJob = (name, type) => {
         return Promise.resolve({
           name: `${instance_id}_${type === undefined ? CONST.JOB.SCHEDULED_BACKUP : type}`,
@@ -128,7 +128,7 @@ describe('service-fabrik-api-sf2.0', function () {
           mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
-          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.getState(operational, details);

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -48,7 +48,14 @@ describe('service-fabrik-api-sf2.0', function () {
       const container = backupStore.containerName;
       const repeatInterval = '*/1 * * * *';
       const repeatTimezone = 'America/New_York';
-
+      const dummyDeploymentResource = {
+        metadata:{
+          annotations: {
+            labels: 'dummy'
+          }
+        }
+      };
+  
       const getJob = (name, type) => {
         return Promise.resolve({
           name: `${instance_id}_${type === undefined ? CONST.JOB.SCHEDULED_BACKUP : type}`,
@@ -120,6 +127,8 @@ describe('service-fabrik-api-sf2.0', function () {
           });
           mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.getState(operational, details);

--- a/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
@@ -42,7 +42,7 @@ describe('service-fabrik-api', function () {
       const repeatInterval = '*/1 * * * *';
       const repeatTimezone = 'America/New_York';
       const dummyDeploymentResource = {
-        metadata:{
+        metadata: {
           annotations: {
             labels: 'dummy'
           }

--- a/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
@@ -41,7 +41,13 @@ describe('service-fabrik-api', function () {
       const container = backupStore.containerName;
       const repeatInterval = '*/1 * * * *';
       const repeatTimezone = 'America/New_York';
-
+      const dummyDeploymentResource = {
+        metadata:{
+          annotations: {
+            labels: 'dummy'
+          }
+        }
+      };
       const getJob = (name, type) => {
         return Promise.resolve({
           name: `${instance_id}_${type === undefined ? CONST.JOB.SCHEDULED_BACKUP : type}`,
@@ -114,6 +120,8 @@ describe('service-fabrik-api', function () {
           });
           mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.getState(operational, details);

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -1076,11 +1076,12 @@ describe('bosh', () => {
 
     describe('#getDeploymentIpsFromResource', () => {
       it('should return deployment IPs if present in resource', (done) => {
+        /* jshint expr:true */
         let dummyResource = {
           name: '4aa31303-127b-4004-b134-e9ffa4a39703',
           metadata: {
             annotations: {
-              deploymentIps: JSON.stringify(['10.244.10.216','10.244.10.217'])
+              deploymentIps: JSON.stringify(['10.244.10.216', '10.244.10.217'])
             }
           }
         };
@@ -1090,32 +1091,32 @@ describe('bosh', () => {
         let dummyBoshDirectorClient = new MockBoshDirectorClient();
         let deploymentName = 'service-fabrik-0026-4aa31303-127b-4004-b134-e9ffa4a39703';
         dummyBoshDirectorClient.getDeploymentIpsFromResource(deploymentName)
-        .then(ips => {
-          assert.deepEqual(ips, ['10.244.10.216', '10.244.10.217']);
-          expect(getResourceStub).to.be.calledOnce;
-          sandbox.restore();
-          done();
-        })
+          .then(ips => {
+            assert.deepEqual(ips, ['10.244.10.216', '10.244.10.217']);
+            expect(getResourceStub).to.be.calledOnce;
+            sandbox.restore();
+            done();
+          });
       });
     });
-    
+
     describe('#getDeploymentIps', () => {
       it('should return from cache if entry exists', (done) => {
         let dummyBoshDirectorClient = new MockBoshDirectorClient();
         let deploymentName = 'service-fabrik-0026-4aa31303-127b-4004-b134-e9ffa4a39703';
-        dummyBoshDirectorClient.deploymentIpsCache[deploymentName] = ['10.244.10.216','10.244.10.217'];
+        dummyBoshDirectorClient.deploymentIpsCache[deploymentName] = ['10.244.10.216', '10.244.10.217'];
         let sandbox = sinon.sandbox.create();
         let getDeploymentIpsFromResourceStub = sandbox.stub(dummyBoshDirectorClient, 'getDeploymentIpsFromResource');
         let getDeploymentIpsFromDirectorStub = sandbox.stub(dummyBoshDirectorClient, 'getDeploymentIpsFromDirector');
 
         dummyBoshDirectorClient.getDeploymentIps(deploymentName)
-        .then(ips => {
-          assert.deepEqual(ips, ['10.244.10.216', '10.244.10.217']);
-          assert(getDeploymentIpsFromResourceStub.notCalled);
-          assert(getDeploymentIpsFromDirectorStub.notCalled);        
-          sandbox.restore();
-          done();
-        });
+          .then(ips => {
+            assert.deepEqual(ips, ['10.244.10.216', '10.244.10.217']);
+            assert(getDeploymentIpsFromResourceStub.notCalled);
+            assert(getDeploymentIpsFromDirectorStub.notCalled);
+            sandbox.restore();
+            done();
+          });
       });
 
       it('should make call to ApiServer if entry doesn\'t exist in cache', (done) => {
@@ -1127,20 +1128,20 @@ describe('bosh', () => {
           name: '4aa31303-127b-4004-b134-e9ffa4a39703',
           metadata: {
             annotations: {
-              deploymentIps: JSON.stringify(['10.244.10.216','10.244.10.217'])
+              deploymentIps: JSON.stringify(['10.244.10.216', '10.244.10.217'])
             }
           }
         };
         let getResourceStub = sandbox.stub(eventmesh.apiServerClient, 'getResource');
         getResourceStub.returns(Promise.resolve(dummyResource));
         dummyBoshDirectorClient.getDeploymentIps(deploymentName)
-        .then(ips => {
-          assert.deepEqual(ips, ['10.244.10.216', '10.244.10.217']);
-          assert(getDeploymentIpsFromDirectorStub.notCalled);
-          assert.deepEqual(dummyBoshDirectorClient.deploymentIpsCache[deploymentName], ips);
-          sandbox.restore();
-          done();
-        });
+          .then(ips => {
+            assert.deepEqual(ips, ['10.244.10.216', '10.244.10.217']);
+            assert(getDeploymentIpsFromDirectorStub.notCalled);
+            assert.deepEqual(dummyBoshDirectorClient.deploymentIpsCache[deploymentName], ips);
+            sandbox.restore();
+            done();
+          });
       });
 
       it('should make call to director if entry not found in ApiServer', (done) => {
@@ -1150,22 +1151,26 @@ describe('bosh', () => {
         let dummyResource = {
           name: '4aa31303-127b-4004-b134-e9ffa4a39703'
         };
-        let dummyInstance = [{'ips':['10.244.10.216', '10.244.10.217']}];
+        let dummyInstance = [{
+          'ips': ['10.244.10.216', '10.244.10.217']
+        }];
         let getResourceStub = sandbox.stub(eventmesh.apiServerClient, 'getResource');
         getResourceStub.returns(Promise.resolve(dummyResource));
-        let getDeploymentInstancesStub = sandbox.stub(dummyBoshDirectorClient,'getDeploymentInstances');
+        let getDeploymentInstancesStub = sandbox.stub(dummyBoshDirectorClient, 'getDeploymentInstances');
         getDeploymentInstancesStub.returns(Promise.resolve(dummyInstance));
         let putDeploymentIpsInResourceStub = sandbox.stub(dummyBoshDirectorClient, 'putDeploymentIpsInResource');
-        putDeploymentIpsInResourceStub.returns(Promise.resolve({dummy: 'dummy'}));
+        putDeploymentIpsInResourceStub.returns(Promise.resolve({
+          dummy: 'dummy'
+        }));
         dummyBoshDirectorClient.getDeploymentIps(deploymentName)
-        .then(ips => {
-          console.log(ips);
-          assert.deepEqual(ips, ['10.244.10.216', '10.244.10.217']);
-          assert.deepEqual(dummyBoshDirectorClient.deploymentIpsCache[deploymentName], ips);
-          expect(putDeploymentIpsInResourceStub).to.have.been.calledWith(deploymentName, ips);
-          sandbox.restore();
-          done();
-        });
+          .then(ips => {
+            console.log(ips);
+            assert.deepEqual(ips, ['10.244.10.216', '10.244.10.217']);
+            assert.deepEqual(dummyBoshDirectorClient.deploymentIpsCache[deploymentName], ips);
+            expect(putDeploymentIpsInResourceStub).to.have.been.calledWith(deploymentName, ips);
+            sandbox.restore();
+            done();
+          });
       });
     });
   });

--- a/test/test_broker/managers.BackupService.spec.js
+++ b/test/test_broker/managers.BackupService.spec.js
@@ -43,6 +43,14 @@ describe('managers', function () {
       logs: []
     };
     const manager = new BackupService(plan);
+    const dummyDeploymentResource = {
+      metadata:{
+        annotations: {
+          labels: 'dummy'
+        }
+      }
+    };
+
 
     before(function () {
       sandbox = sinon.sandbox.create();
@@ -108,6 +116,8 @@ describe('managers', function () {
           context: context
         };
         mocks.director.getDeploymentVms(deployment_name);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
         mocks.director.getDeploymentInstances(deployment_name);
         mocks.agent.getInfo();
         const putFileStub = sinon.stub(BackupStore.prototype, 'putFile');

--- a/test/test_broker/managers.BackupService.spec.js
+++ b/test/test_broker/managers.BackupService.spec.js
@@ -44,7 +44,7 @@ describe('managers', function () {
     };
     const manager = new BackupService(plan);
     const dummyDeploymentResource = {
-      metadata:{
+      metadata: {
         annotations: {
           labels: 'dummy'
         }

--- a/test/test_broker/managers.DirectorService.spec.js
+++ b/test/test_broker/managers.DirectorService.spec.js
@@ -78,7 +78,13 @@ describe('#DirectorService', function () {
       const deferred = Promise.defer();
       Promise.onPossiblyUnhandledRejection(() => {});
       let getScheduleStub;
-
+      const dummyDeploymentResource = {
+        metadata:{
+          annotations: {
+            labels: 'dummy'
+          }
+        }
+      };
       before(function () {
         backupStore.cloudProvider = new iaas.CloudProviderClient(config.backup.provider);
         mocks.cloudProvider.auth();
@@ -291,6 +297,8 @@ describe('#DirectorService', function () {
           });
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           mocks.agent.getInfo();
           mocks.agent.preUpdate();
@@ -338,6 +346,8 @@ describe('#DirectorService', function () {
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           mocks.agent.getInfo();
           const options = {
@@ -385,6 +395,8 @@ describe('#DirectorService', function () {
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           //mocks.agent.preUpdate();
           mocks.agent.getInfo();
@@ -433,6 +445,8 @@ describe('#DirectorService', function () {
           });
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           mocks.agent.getInfo();
           //mocks.agent.preUpdate();
@@ -478,6 +492,8 @@ describe('#DirectorService', function () {
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           mocks.agent.getInfo(1, 'preupdate');
           const options = {
@@ -521,6 +537,8 @@ describe('#DirectorService', function () {
             organization_guid: organization_guid,
             space_guid: space_guid
           });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.deprovision();
@@ -564,6 +582,8 @@ describe('#DirectorService', function () {
             organization_guid: organization_guid,
             space_guid: space_guid
           });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.deprovision();
@@ -604,6 +624,8 @@ describe('#DirectorService', function () {
             platform: 'kubernetes',
             namespace: 'default'
           });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.director.deleteDeployment(task_id);
           const options = {
@@ -923,6 +945,8 @@ describe('#DirectorService', function () {
           config.mongodb.provision.plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
           deferred.reject(new errors.NotFound('Schedule not found'));
           const WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION = 0;
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.createCredentials();
@@ -975,6 +999,8 @@ describe('#DirectorService', function () {
             .value();
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_BIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.createCredentials();
@@ -1029,6 +1055,8 @@ describe('#DirectorService', function () {
             .value();
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.director.getBindingProperty(binding_id);
           mocks.agent.getInfo();
@@ -1066,6 +1094,8 @@ describe('#DirectorService', function () {
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeploymentProperty(deployment_name, false, 'platform-context', undefined);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.director.getBindingProperty(binding_id);
           mocks.agent.getInfo();

--- a/test/test_broker/managers.DirectorService.spec.js
+++ b/test/test_broker/managers.DirectorService.spec.js
@@ -79,7 +79,7 @@ describe('#DirectorService', function () {
       Promise.onPossiblyUnhandledRejection(() => {});
       let getScheduleStub;
       const dummyDeploymentResource = {
-        metadata:{
+        metadata: {
           annotations: {
             labels: 'dummy'
           }

--- a/test/test_broker/managers.RestoreService.spec.js
+++ b/test/test_broker/managers.RestoreService.spec.js
@@ -80,7 +80,7 @@ describe('managers', function () {
       username: username
     };
     const dummyDeploymentResource = {
-      metadata:{
+      metadata: {
         annotations: {
           labels: 'dummy'
         }

--- a/test/test_broker/managers.RestoreService.spec.js
+++ b/test/test_broker/managers.RestoreService.spec.js
@@ -79,6 +79,13 @@ describe('managers', function () {
       },
       username: username
     };
+    const dummyDeploymentResource = {
+      metadata:{
+        annotations: {
+          labels: 'dummy'
+        }
+      }
+    };
 
     beforeEach(function () {
       plan = catalog.getPlan(plan_id);
@@ -127,6 +134,8 @@ describe('managers', function () {
     describe('#startRestore', function () {
       it('should start restore', function () {
         mocks.director.getDeploymentVms(deployment_name);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
         mocks.director.getDeploymentInstances(deployment_name);
         mocks.director.getDeployments();
         mocks.agent.getInfo();

--- a/test/test_broker/managers.VirtualHostService.spec.js
+++ b/test/test_broker/managers.VirtualHostService.spec.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const config = require('../../common/config');
+const CONST = require('../../common/constants');
 const iaas = require('../../data-access-layer/iaas');
 const virtualHostStore = iaas.virtualHostStore;
 const VirtualHostService = require('../../managers/virtualhost-manager/VirtualHostService');
@@ -38,6 +39,13 @@ describe('#VirtualHostService', function () {
         organization_guid: organization_guid,
         space_guid: space_guid
       };
+      const dummyDeploymentResource = {
+        metadata:{
+          annotations: {
+            labels: 'dummy'
+          }
+        }
+      };  
       Promise.onPossiblyUnhandledRejection(() => {});
 
       before(function () {
@@ -56,6 +64,8 @@ describe('#VirtualHostService', function () {
       describe('#provision', function () {
         it('returns 201 created', function () {
           mocks.director.getDeploymentInstances(deployment_name);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
           mocks.cloudController.getServiceInstancesInSpaceWithName(instance_name, space_guid, true);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.createVirtualHost(instance_id);
@@ -112,6 +122,8 @@ describe('#VirtualHostService', function () {
 
       describe('#update', function () {
         it('returns 200 OK', function () {
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.updateVirtualHost(instance_id);
@@ -135,6 +147,8 @@ describe('#VirtualHostService', function () {
 
       describe('#bind', function () {
         it('returns 201 Created', function () {
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.createCredentials(instance_id);
@@ -160,6 +174,8 @@ describe('#VirtualHostService', function () {
 
       describe('#unbind', function () {
         it('returns 200 OK', function () {
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.deleteCredentials(instance_id);
@@ -184,8 +200,11 @@ describe('#VirtualHostService', function () {
         });
       });
 
+  
       describe('#deprovision', function () {
         it('returns 200 OK', function () {
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.deleteVirtualHost(instance_id);
@@ -202,6 +221,7 @@ describe('#VirtualHostService', function () {
             });
         });
         it('returns 410 Gone when parent service instance is deleted', function () {
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.director.getDeploymentInstances(deployment_name, undefined, undefined, undefined, false);
           mocks.director.getDeployment(deployment_name, false, undefined, 1);
           mocks.cloudProvider.download(pathname, data);

--- a/test/test_broker/managers.VirtualHostService.spec.js
+++ b/test/test_broker/managers.VirtualHostService.spec.js
@@ -40,12 +40,12 @@ describe('#VirtualHostService', function () {
         space_guid: space_guid
       };
       const dummyDeploymentResource = {
-        metadata:{
+        metadata: {
           annotations: {
             labels: 'dummy'
           }
         }
-      };  
+      };
       Promise.onPossiblyUnhandledRejection(() => {});
 
       before(function () {
@@ -65,7 +65,7 @@ describe('#VirtualHostService', function () {
         it('returns 201 created', function () {
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
-          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.cloudController.getServiceInstancesInSpaceWithName(instance_name, space_guid, true);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.createVirtualHost(instance_id);
@@ -123,7 +123,7 @@ describe('#VirtualHostService', function () {
       describe('#update', function () {
         it('returns 200 OK', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
-          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.updateVirtualHost(instance_id);
@@ -148,7 +148,7 @@ describe('#VirtualHostService', function () {
       describe('#bind', function () {
         it('returns 201 Created', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
-          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.createCredentials(instance_id);
@@ -175,7 +175,7 @@ describe('#VirtualHostService', function () {
       describe('#unbind', function () {
         it('returns 200 OK', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
-          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.deleteCredentials(instance_id);
@@ -200,11 +200,11 @@ describe('#VirtualHostService', function () {
         });
       });
 
-  
+
       describe('#deprovision', function () {
         it('returns 200 OK', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
-          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);  
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.virtualHostAgent.deleteVirtualHost(instance_id);


### PR DESCRIPTION
* To introduce resiliency in bind/unbind during bosh outage, we store deployment IPs (which are needed during bind/unbind) in etcd. (Separate PR for this coming once https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/426 merges).

* This PR adds modifications in getDeploymentIps flow to utilize entries in etcd. Now the flow in getDeploymentIps will be local_cache --> etcd --> bosh.

* Failures while getting/updating resource from/to etcd can be ignored to not alter the flow of parent operation as IPs could still be obtained from bosh.