### PR TITLE
Enable schemas in the service plan

### DIFF
--- a/common/models/Plan.js
+++ b/common/models/Plan.js
@@ -63,6 +63,7 @@ class Plan {
       'name',
       'description',
       'metadata',
+      'schemas',
       'free'
     ];
   }


### PR DESCRIPTION
Enable the definition of schemas in the service plan, such that they can  be a part of the service broker catalog, which is provided to the cloud controller. The schemas should be validated by the cloud controller, when the service fabrik broker is registered.

Schemas have been added in the openbroker api version [v2.13](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md#schema-object)
