### PR TITLE
Modifying BoshTaskStatusPoller to update deployment IPs in deployment resources

### DIFF
--- a/managers/bosh-manager/BoshTaskStatusPoller.js
+++ b/managers/bosh-manager/BoshTaskStatusPoller.js
@@ -34,33 +34,77 @@ class BoshTaskStatusPoller extends BaseStatusPoller {
     const instanceId = resourceBody.metadata.name;
     const options = _.get(resourceBody, 'spec.options');
     return DirectorService.createInstance(instanceId, options)
-      .then(directorService => directorService.lastOperation(_.get(resourceBody, 'status.response')))
-      .tap(lastOperationValue => logger.debug('last operation value is ', lastOperationValue))
-      .tap(lastOperationValue => lastOperationOfInstance = lastOperationValue)
-      .then(lastOperationValue => Promise.all([eventmesh.apiServerClient.updateResource({
-        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-        resourceId: instanceId,
-        status: {
-          lastOperation: lastOperationValue,
-          state: lastOperationValue.resourceState
-        }
-      }), Promise.try(() => {
-        if (_.includes([CONST.APISERVER.RESOURCE_STATE.SUCCEEDED, CONST.APISERVER.RESOURCE_STATE.FAILED], lastOperationValue.resourceState)) {
-          // cancel the poller and clear the array
+      .then(directorService => directorService.lastOperation(_.get(resourceBody, 'status.response'))
+        .tap(lastOperationValue => logger.debug('last operation value is ', lastOperationValue))
+        .tap(lastOperationValue => lastOperationOfInstance = lastOperationValue)
+        .then(lastOperationValue => Promise.all([
+          Promise.try(() => {
+            if (lastOperationValue.resourceState === CONST.APISERVER.RESOURCE_STATE.SUCCEEDED &&
+              (lastOperationValue.type === 'create' || lastOperationValue.type === 'update')) {
+              return directorService.director.getDeploymentNameForInstanceId(directorService.guid)
+                .then(deploymentName => directorService.director.getDeploymentIpsFromDirector(deploymentName))
+                .then(ips => eventmesh.apiServerClient.updateResource({
+                  resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+                  resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+                  resourceId: instanceId,
+                  status: {
+                    lastOperation: lastOperationValue,
+                    state: lastOperationValue.resourceState
+                  },
+                  metadata: {
+                    annotations: {
+                      deploymentIps: JSON.stringify(ips)
+                    }
+                  }
+                }));
+            } else {
+              return eventmesh.apiServerClient.updateResource({
+                resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+                resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+                resourceId: instanceId,
+                status: {
+                  lastOperation: lastOperationValue,
+                  state: lastOperationValue.resourceState
+                }
+              });
+            }
+          }),
+          Promise.try(() => {
+            if (_.includes([CONST.APISERVER.RESOURCE_STATE.SUCCEEDED, CONST.APISERVER.RESOURCE_STATE.FAILED], lastOperationValue.resourceState)) {
+              // cancel the poller and clear the array
+              this.clearPoller(instanceId, intervalId);
+            }
+          })
+        ]))
+        .catch(ServiceInstanceNotFound, err => {
+          logger.error(`Error occured while getting last operation`, err);
           this.clearPoller(instanceId, intervalId);
-        }
-      })]))
-      .catch(ServiceInstanceNotFound, err => {
-        logger.error(`Error occured while getting last operation`, err);
-        this.clearPoller(instanceId, intervalId);
-        if (resourceBody.status.response.type === 'delete') {
-          return eventmesh.apiServerClient.deleteResource({
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            resourceId: instanceId
-          });
-        } else {
+          if (resourceBody.status.response.type === 'delete') {
+            return eventmesh.apiServerClient.deleteResource({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+              resourceId: instanceId
+            });
+          } else {
+            lastOperationOfInstance = {
+              state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+              description: CONST.SERVICE_BROKER_ERR_MSG
+            };
+            return eventmesh.apiServerClient.updateResource({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+              resourceId: instanceId,
+              status: {
+                lastOperation: lastOperationOfInstance,
+                state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+                error: utils.buildErrorJson(err)
+              }
+            });
+          }
+        })
+        .catch(AssertionError, err => {
+          logger.error(`Error occured while getting last operation for instance ${instanceId}`, err);
+          this.clearPoller(instanceId, intervalId);
           lastOperationOfInstance = {
             state: CONST.APISERVER.RESOURCE_STATE.FAILED,
             description: CONST.SERVICE_BROKER_ERR_MSG
@@ -75,26 +119,8 @@ class BoshTaskStatusPoller extends BaseStatusPoller {
               error: utils.buildErrorJson(err)
             }
           });
-        }
-      })
-      .catch(AssertionError, err => {
-        logger.error(`Error occured while getting last operation for instance ${instanceId}`, err);
-        this.clearPoller(instanceId, intervalId);
-        lastOperationOfInstance = {
-          state: CONST.APISERVER.RESOURCE_STATE.FAILED,
-          description: CONST.SERVICE_BROKER_ERR_MSG
-        };
-        return eventmesh.apiServerClient.updateResource({
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          resourceId: instanceId,
-          status: {
-            lastOperation: lastOperationOfInstance,
-            state: CONST.APISERVER.RESOURCE_STATE.FAILED,
-            error: utils.buildErrorJson(err)
-          }
-        });
-      })
+        })
+      )
       .finally(() => {
         if (_.get(resourceBody.status.response, 'type') === CONST.OPERATION_TYPE.UPDATE &&
           _.get(resourceBody.status.response, 'parameters.service-fabrik-operation') === true &&


### PR DESCRIPTION
* To introduce bind unbind resiliency towards bosh outages, corresponding flows have been altered to fetch deployment IPs from etcd first. ( See this PR https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/428)
* In this PR we modify BoshTaskStatusPoller to update deployment IPs information on the deployment resource at the time of deployment creation and update to ensure consistency.