### PR TITLE
Removing createBindingProperty on Bosh from bind flow and deleteBindingProperty from unbind flow

### DIFF
--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -834,8 +834,7 @@ class DirectorService extends BaseDirectorService {
         }
         logger.info(`[getCredentials] Fetching property from bosh for binding ${id}`);
         return this.getBindingProperty(deploymentName, id)
-          .then(binding => binding.credentials)
-          .tap(() => this.deleteBindingProperty(deploymentName, id));
+          .then(binding => binding.credentials);
       });
   }
 
@@ -863,11 +862,6 @@ class DirectorService extends BaseDirectorService {
       .getDeploymentProperty(deploymentName, `binding-${id}`)
       .then(result => JSON.parse(result))
       .catchThrow(NotFound, new ServiceBindingNotFound(id));
-  }
-
-  deleteBindingProperty(deploymentName, id) {
-    return this.director
-      .deleteDeploymentProperty(deploymentName, `binding-${id}`);
   }
 
   diffManifest(deploymentName, opts) {

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -18,7 +18,6 @@ const bosh = require('../../data-access-layer/bosh');
 const eventmesh = require('../../data-access-layer/eventmesh');
 const Agent = require('../../data-access-layer/service-agent');
 const NetworkSegmentIndex = bosh.NetworkSegmentIndex;
-const ServiceBindingAlreadyExists = errors.ServiceBindingAlreadyExists;
 const backupStore = require('../../data-access-layer/iaas').backupStore;
 const boshOperationQueue = bosh.BoshOperationQueue;
 const ServiceInstanceAlreadyExists = errors.ServiceInstanceAlreadyExists;

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -866,12 +866,6 @@ class DirectorService extends BaseDirectorService {
       .catchThrow(NotFound, new ServiceBindingNotFound(id));
   }
 
-  createBindingProperty(deploymentName, id, value) {
-    return this.director
-      .createDeploymentProperty(deploymentName, `binding-${id}`, JSON.stringify(value))
-      .catchThrow(BadRequest, new ServiceBindingAlreadyExists(id));
-  }
-
   deleteBindingProperty(deploymentName, id) {
     return this.director
       .deleteDeploymentProperty(deploymentName, `binding-${id}`);

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -1136,7 +1136,7 @@ describe('#DirectorService', function () {
               response: utils.encodeBase64(mocks.agent.credentials),
               state: 'succeeded'
             }
-          };  
+          };
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeploymentProperty(deployment_name, false, 'platform-context', undefined);

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -1124,7 +1124,7 @@ describe('#DirectorService', function () {
             });
         });
 
-        it.only('returns 200 OK: bind resource not found on ApiServer', function () {
+        it('returns 200 OK: bind resource not found on ApiServer', function () {
           const context = {
             platform: 'cloudfoundry',
             organization_guid: organization_guid,

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -1034,6 +1034,60 @@ describe('#DirectorService', function () {
               }, WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION);
             });
         });
+        it('Errors in getting IPs from ApiServer handled properly', function (done) {
+          config.mongodb.provision.plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
+          deferred.reject(new errors.NotFound('Schedule not found'));
+          const WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION = 0;
+          const context = {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          };
+          const expectedRequestBody = _.cloneDeep(deploymentHookRequestBody);
+          expectedRequestBody.context = _.chain(expectedRequestBody.context)
+            .set('id', binding_id)
+            .set('parameters', {})
+            .omit('params')
+            .omit('sf_operations_args')
+            .value();
+          expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_BIND;
+          mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, 404);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, {}, 404);
+          mocks.director.getDeploymentInstances(deployment_name);
+          mocks.agent.getInfo();
+          mocks.agent.createCredentials();
+          mocks.serviceFabrikClient.scheduleBackup(instance_id, {
+            type: CONST.BACKUP.TYPE.ONLINE,
+            repeatInterval: '8 hours'
+          });
+          const options = {
+            binding_id: binding_id,
+            service_id: service_id,
+            plan_id: plan_id,
+            app_guid: app_guid,
+            context: context,
+            bind_resource: {
+              app_guid: app_guid
+            }
+          };
+          return DirectorService.createInstance(instance_id, options)
+            .then(service => service.bind(options))
+            .then(res => {
+              expect(res).to.eql(mocks.agent.credentials);
+              setTimeout(() => {
+                delete config.mongodb.provision.plan_id;
+                expect(getScheduleStub).to.be.calledOnce;
+                expect(getScheduleStub.firstCall.args[0]).to.eql(instance_id);
+                expect(getScheduleStub.firstCall.args[1]).to.eql(CONST.JOB.SCHEDULED_BACKUP);
+                mocks.verify();
+                done();
+                //Schedule operation is performed in background after response has been returned,
+                //hence added this delay of 500 ms which should work in all cases.
+                //In case asserts are failing, try increasing the timeout first & then debug. :-)
+              }, WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION);
+            });
+        });
       });
 
       describe('#unbind', function () {


### PR DESCRIPTION
* Now that bind credentials are being stored on etcd we don't need to create binding property on bosh, so that operation is removed from bind flow.

* Also, operation deleteBindingProperty in unbind flow is also made conditional based on whether bind resource was found in etcd or not. In other words, we don't need to delete binding properties on bosh for new binds as they won't be created there in the first place.

* Modified UTs to accommodate new bind/unbind flow. 