### PR TITLE
Supporting service manager with CF platform

### DIFF
--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -166,10 +166,12 @@ class FabrikBaseController extends BaseController {
             space_guid: req.body.space_guid
           });
         }
-        _.extend(req.body.context, {
-          platform: CONST.PLATFORM.SM,
-          origin: context.platform
-        });
+        if (context) {
+          _.extend(req.body.context, {
+            platform: CONST.PLATFORM.SM,
+            origin: context.platform
+          });
+        }
       })
       .throw(new ContinueWithNext());
   }

--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -155,27 +155,6 @@ class FabrikBaseController extends BaseController {
       });
   }
 
-  enrichContext(req, res) {
-    /* jshint unused:false */
-    return Promise.try(() => {
-        const context = _.get(req, 'body.context');
-        if (context === undefined && req.body.space_guid && req.body.organization_guid) {
-          _.set(req.body, 'context', {
-            platform: CONST.PLATFORM.CF,
-            organization_guid: req.body.organization_guid,
-            space_guid: req.body.space_guid
-          });
-        }
-        if (context) {
-          _.extend(req.body.context, {
-            platform: CONST.PLATFORM.SM,
-            origin: context.platform
-          });
-        }
-      })
-      .throw(new ContinueWithNext());
-  }
-
   assignManager(req, res) {
     /* jshint unused:false */
     return Promise

--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -176,21 +176,6 @@ class FabrikBaseController extends BaseController {
       .throw(new ContinueWithNext());
   }
 
-  ensurePlatformContext(req, res) {
-    /* jshint unused:false */
-    return Promise.try(() => {
-        const context = _.get(req, 'body.context');
-        if (context === undefined && req.body.space_guid && req.body.organization_guid) {
-          _.set(req.body, 'context', {
-            platform: CONST.PLATFORM.CF,
-            organization_guid: req.body.organization_guid,
-            space_guid: req.body.space_guid
-          });
-        }
-      })
-      .throw(new ContinueWithNext());
-  }
-
   assignManager(req, res) {
     /* jshint unused:false */
     return Promise

--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -155,6 +155,25 @@ class FabrikBaseController extends BaseController {
       });
   }
 
+  enrichContext(req, res) {
+    /* jshint unused:false */
+    return Promise.try(() => {
+        const context = _.get(req, 'body.context');
+        if (context === undefined && req.body.space_guid && req.body.organization_guid) {
+          _.set(req.body, 'context', {
+            platform: CONST.PLATFORM.CF,
+            organization_guid: req.body.organization_guid,
+            space_guid: req.body.space_guid
+          });
+        }
+        _.extend(req.body.context, {
+          platform: CONST.PLATFORM.SM,
+          origin: context.platform
+        });
+      })
+      .throw(new ContinueWithNext());
+  }
+
   ensurePlatformContext(req, res) {
     /* jshint unused:false */
     return Promise.try(() => {

--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -179,6 +179,7 @@ class FabrikBaseController extends BaseController {
     return _.nth(this.fabrik.DirectorManager.parseDeploymentName(deploymentName), 2);
   }
 
+  // TODO: This piece of code should be removed; manager code should be imported from Service (Director/Docker) in broker code
   createManager(plan_id) {
     return this.fabrik.createManager(this.getPlan(plan_id));
   }

--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -83,8 +83,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     return Promise
       .try(() => {
         return eventmesh.apiServerClient.createResource({
-          resourceGroup: plan.manager.resource_mappings.resource_group,
-          resourceType: plan.manager.resource_mappings.resource_type,
+          resourceGroup: plan.resourceGroup,
+          resourceType: plan.resourceType,
           resourceId: req.params.instance_id,
           options: params,
           status: {
@@ -97,8 +97,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
       .then(() => {
         if (!plan.manager.async) {
           return eventmesh.apiServerClient.getResourceOperationStatus({
-            resourceGroup: plan.manager.resource_mappings.resource_group,
-            resourceType: plan.manager.resource_mappings.resource_type,
+            resourceGroup: plan.resourceGroup,
+            resourceType: plan.resourceType,
             resourceId: req.params.instance_id,
             start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
             started_at: new Date()
@@ -142,8 +142,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
       })
       .then(() => {
         return eventmesh.apiServerClient.patchResource({
-          resourceGroup: plan.manager.resource_mappings.resource_group,
-          resourceType: plan.manager.resource_mappings.resource_type,
+          resourceGroup: plan.resourceGroup,
+          resourceType: plan.resourceType,
           resourceId: req.params.instance_id,
           options: params,
           status: {
@@ -154,11 +154,11 @@ class ServiceBrokerApiController extends FabrikBaseController {
         });
       })
       .catch(NotFound, () => {
-        logger.info(`Resource resourceGroup: ${plan.manager.resource_mappings.resource_group},` +
-          `resourceType: ${plan.manager.resource_mappings.resource_type}, resourceId: ${req.params.instance_id} not found, Creating now...`);
+        logger.info(`Resource resourceGroup: ${plan.resourceGroup},` +
+          `resourceType: ${plan.resourceType}, resourceId: ${req.params.instance_id} not found, Creating now...`);
         return eventmesh.apiServerClient.createResource({
-          resourceGroup: plan.manager.resource_mappings.resource_group,
-          resourceType: plan.manager.resource_mappings.resource_type,
+          resourceGroup: plan.resourceGroup,
+          resourceType: plan.resourceType,
           resourceId: req.params.instance_id,
           options: params,
           status: {
@@ -171,8 +171,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
       .then(() => {
         if (!plan.manager.async) {
           return eventmesh.apiServerClient.getResourceOperationStatus({
-            resourceGroup: plan.manager.resource_mappings.resource_group,
-            resourceType: plan.manager.resource_mappings.resource_type,
+            resourceGroup: plan.resourceGroup,
+            resourceType: plan.resourceType,
             resourceId: req.params.instance_id,
             start_state: CONST.APISERVER.RESOURCE_STATE.UPDATE,
             started_at: new Date()
@@ -208,8 +208,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     return Promise
       .try(() => {
         return eventmesh.apiServerClient.patchResource({
-          resourceGroup: plan.manager.resource_mappings.resource_group,
-          resourceType: plan.manager.resource_mappings.resource_type,
+          resourceGroup: plan.resourceGroup,
+          resourceType: plan.resourceType,
           resourceId: req.params.instance_id,
           options: params,
           status: {
@@ -220,11 +220,11 @@ class ServiceBrokerApiController extends FabrikBaseController {
         });
       })
       .catch(NotFound, () => {
-        logger.info(`Resource resourceGroup: ${plan.manager.resource_mappings.resource_group},` +
-          `resourceType: ${plan.manager.resource_mappings.resource_type}, resourceId: ${req.params.instance_id} not found, Creating now...`);
+        logger.info(`Resource resourceGroup: ${plan.resourceGroup},` +
+          `resourceType: ${plan.resourceType}, resourceId: ${req.params.instance_id} not found, Creating now...`);
         return eventmesh.apiServerClient.createResource({
-          resourceGroup: plan.manager.resource_mappings.resource_group,
-          resourceType: plan.manager.resource_mappings.resource_type,
+          resourceGroup: plan.resourceGroup,
+          resourceType: plan.resourceType,
           resourceId: req.params.instance_id,
           options: params,
           status: {
@@ -237,8 +237,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
       .then(() => {
         if (!plan.manager.async) {
           return eventmesh.apiServerClient.getResourceOperationStatus({
-            resourceGroup: plan.manager.resource_mappings.resource_group,
-            resourceType: plan.manager.resource_mappings.resource_type,
+            resourceGroup: plan.resourceGroup,
+            resourceType: plan.resourceType,
             resourceId: req.params.instance_id,
             start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
             started_at: new Date()
@@ -279,8 +279,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     const planId = req.query.plan_id;
     const plan = catalog.getPlan(planId);
     return eventmesh.apiServerClient.getLastOperation({
-        resourceGroup: plan.manager.resource_mappings.resource_group,
-        resourceType: plan.manager.resource_mappings.resource_type,
+        resourceGroup: plan.resourceGroup,
+        resourceType: plan.resourceType,
         resourceId: req.params.instance_id
       })
       .then(done)
@@ -310,8 +310,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     return Promise
       .try(() => {
         return eventmesh.apiServerClient.createResource({
-          resourceGroup: plan.manager.resource_mappings.bind.resource_group,
-          resourceType: plan.manager.resource_mappings.bind.resource_type,
+          resourceGroup: plan.bindResourceGroup,
+          resourceType: plan.bindResourceType,
           resourceId: params.binding_id,
           labels: {
             instance_guid: req.params.instance_id
@@ -323,8 +323,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
         });
       })
       .then(() => eventmesh.apiServerClient.getResourceOperationStatus({
-        resourceGroup: plan.manager.resource_mappings.bind.resource_group,
-        resourceType: plan.manager.resource_mappings.bind.resource_type,
+        resourceGroup: plan.bindResourceGroup,
+        resourceType: plan.bindResourceType,
         resourceId: params.binding_id,
         start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
         started_at: new Date()
@@ -352,8 +352,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     return Promise
       .try(() => {
         return eventmesh.apiServerClient.updateResource({
-            resourceGroup: plan.manager.resource_mappings.bind.resource_group,
-            resourceType: plan.manager.resource_mappings.bind.resource_type,
+            resourceGroup: plan.bindResourceGroup,
+            resourceType: plan.bindResourceType,
             resourceId: params.binding_id,
             options: params,
             status: {
@@ -361,11 +361,11 @@ class ServiceBrokerApiController extends FabrikBaseController {
             }
           })
           .catch((NotFound), () => {
-            logger.info(`Resource resourceGroup: ${plan.manager.resource_mappings.bind.resource_group},` +
-              `resourceType: ${plan.manager.resource_mappings.bind.resource_type}, resourceId: ${params.binding_id} not found, Creating now...`);
+            logger.info(`Resource resourceGroup: ${plan.bindResourceGroup},` +
+              `resourceType: ${plan.bindResourceType}, resourceId: ${params.binding_id} not found, Creating now...`);
             return eventmesh.apiServerClient.createResource({
-              resourceGroup: plan.manager.resource_mappings.bind.resource_group,
-              resourceType: plan.manager.resource_mappings.bind.resource_type,
+              resourceGroup: plan.bindResourceGroup,
+              resourceType: plan.bindResourceType,
               resourceId: params.binding_id,
               labels: {
                 instance_guid: req.params.instance_id
@@ -379,15 +379,15 @@ class ServiceBrokerApiController extends FabrikBaseController {
           });
       })
       .then(() => eventmesh.apiServerClient.getResourceOperationStatus({
-        resourceGroup: plan.manager.resource_mappings.bind.resource_group,
-        resourceType: plan.manager.resource_mappings.bind.resource_type,
+        resourceGroup: plan.bindResourceGroup,
+        resourceType: plan.bindResourceType,
         resourceId: params.binding_id,
         start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
         started_at: new Date()
       }))
       .then(() => eventmesh.apiServerClient.deleteResource({
-        resourceGroup: plan.manager.resource_mappings.bind.resource_group,
-        resourceType: plan.manager.resource_mappings.bind.resource_type,
+        resourceGroup: plan.bindResourceGroup,
+        resourceType: plan.bindResourceType,
         resourceId: params.binding_id
       }))
       .then(done)

--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -41,7 +41,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
 
   getCatalog(req, res) {
     /* jshint unused:false */
-    res.status(CONST.HTTP_STATUS_CODE.OK).json(this.fabrik.getPlatformManager(req.params.platform).getCatalog(catalog));
+    res.status(CONST.HTTP_STATUS_CODE.OK).json(this.fabrik.getPlatformManager({
+      platform: req.params.platform
+    }).getCatalog(catalog));
   }
 
   putInstance(req, res) {
@@ -139,7 +141,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         }
       })
       .then(() => {
-        return eventmesh.apiServerClient.updateResource({
+        return eventmesh.apiServerClient.patchResource({
           resourceGroup: plan.manager.resource_mappings.resource_group,
           resourceType: plan.manager.resource_mappings.resource_type,
           resourceId: req.params.instance_id,
@@ -205,7 +207,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
 
     return Promise
       .try(() => {
-        return eventmesh.apiServerClient.updateResource({
+        return eventmesh.apiServerClient.patchResource({
           resourceGroup: plan.manager.resource_mappings.resource_group,
           resourceType: plan.manager.resource_mappings.resource_type,
           resourceId: req.params.instance_id,

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -243,14 +243,14 @@ class ServiceFabrikAdminController extends FabrikBaseController {
 
   getDeployment(req, res) {
     const deploymentName = req.params.name;
+    const plan = catalog.getPlan(req.query.plan_id);
     this.createManager(req.query.plan_id)
       .then(manager =>
-        eventmesh.apiServerClient.getResource({
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+        eventmesh.apiServerClient.getPlatformContext({
+          resourceGroup: plan.resourceGroup,
+          resourceType: plan.resourceType,
           resourceId: this.getInstanceId(deploymentName)
         })
-        .then(resource => _.get(resource, 'spec.options.context'))
         .then(context => {
           const opts = {};
           opts.context = context;
@@ -366,12 +366,11 @@ class ServiceFabrikAdminController extends FabrikBaseController {
           logger.warn(`Found deployment '${deployment.name}' without service instance`);
           return false;
         }
-        return eventmesh.apiServerClient.getResource({
+        return eventmesh.apiServerClient.getPlatformContext({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
             resourceId: this.getInstanceId(deployment.name)
           })
-          .then(resource => _.get(resource, 'spec.options.context'))
           .then(context => {
             const opts = {};
             opts.context = context;

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -244,6 +244,7 @@ class ServiceFabrikAdminController extends FabrikBaseController {
   getDeployment(req, res) {
     const deploymentName = req.params.name;
     const plan = catalog.getPlan(req.query.plan_id);
+    // TODO: Director Service should be used
     this.createManager(req.query.plan_id)
       .then(manager =>
         eventmesh.apiServerClient.getPlatformContext({

--- a/api-controllers/routes/broker/v2.js
+++ b/api-controllers/routes/broker/v2.js
@@ -30,6 +30,9 @@ router.use(commonMiddleware.error({
 }));
 
 /* Service Instance Router */
+// Enriching context object for temporary purposes
+// This will be done by SM when CIS component in integrated
+instanceRouter.use(controller.handler('enrichContext'));
 instanceRouter.use(controller.handler('ensurePlatformContext'));
 instanceRouter.route('/')
   .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])

--- a/api-controllers/routes/broker/v2.js
+++ b/api-controllers/routes/broker/v2.js
@@ -30,9 +30,6 @@ router.use(commonMiddleware.error({
 }));
 
 /* Service Instance Router */
-// Enriching context object for temporary purposes
-// This will be done by SM when CIS component in integrated
-// instanceRouter.use(controller.handler('enrichContext'));
 instanceRouter.route('/')
   .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
   .patch([middleware.checkQuota(), middleware.validateRequest(), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])

--- a/api-controllers/routes/broker/v2.js
+++ b/api-controllers/routes/broker/v2.js
@@ -32,8 +32,7 @@ router.use(commonMiddleware.error({
 /* Service Instance Router */
 // Enriching context object for temporary purposes
 // This will be done by SM when CIS component in integrated
-instanceRouter.use(controller.handler('enrichContext'));
-instanceRouter.use(controller.handler('ensurePlatformContext'));
+// instanceRouter.use(controller.handler('enrichContext'));
 instanceRouter.route('/')
   .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
   .patch([middleware.checkQuota(), middleware.validateRequest(), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -567,6 +567,7 @@ defaults: &defaults
     supported_platform:
     - k8s
     - cf
+    - sm
     actions: Blueprint
     backup_interval: '8 hours'
     pitr: true
@@ -733,6 +734,7 @@ defaults: &defaults
       supported_platform:
       - k8s
       - cf
+      - sm
     - &blueprint_plan4
       id: 'bc158c9a-7934-401e-94ab-057082a5073e'
       name: 'v1.0-small'
@@ -767,6 +769,7 @@ defaults: &defaults
       supported_platform:
       - k8s
       - cf
+      - sm
     - &blueprint_plan5
       id: 'd616b00a-5949-4b1c-bc73-0d3c59f3954a'
       name: 'v1.0-large'
@@ -802,6 +805,7 @@ defaults: &defaults
       supported_platform:
       - k8s
       - cf
+      - sm
     - &blueprint_plan8
       id: 'gd158c9a-7934-401e-94ab-057082a5073e'
       name: 'v2.0-xsmall'
@@ -836,6 +840,7 @@ defaults: &defaults
       supported_platform:
       - k8s
       - cf
+      - sm
     - &blueprint_plan6
       id: 'b91d9512-b5c9-4c4a-922a-fa54ae67d235'
       name: 'v1.0-dedicated-large-deprecated'

--- a/broker/lib/fabrik/BasePlatformManager.js
+++ b/broker/lib/fabrik/BasePlatformManager.js
@@ -12,9 +12,9 @@ class BasePlatformManager {
     const platform = this.platform;
     _.remove(modifiedCatalog.services, function (service) {
       _.remove(service.plans, function (plan) {
-        return !_.includes(_.get(plan, 'metadata.supportedPlatforms', ['cf']), platform);
+        return !_.includes(_.get(plan, 'supported_platform', ['cf']), platform);
       });
-      return !_.includes(_.get(service, 'metadata.supportedPlatforms', ['cf']), platform);
+      return !_.includes(_.get(service, 'supported_platform', ['cf']), platform);
     });
     return modifiedCatalog;
   }

--- a/broker/lib/fabrik/BasePlatformManager.js
+++ b/broker/lib/fabrik/BasePlatformManager.js
@@ -1,12 +1,22 @@
 'use strict';
 
+const _ = require('lodash');
+
 class BasePlatformManager {
   constructor(platform) {
     this.platform = platform;
   }
 
   getCatalog(catalog) {
-    return catalog;
+    const modifiedCatalog = _.cloneDeep(catalog);
+    const platform = this.platform;
+    _.remove(modifiedCatalog.services, function (service) {
+      _.remove(service.plans, function (plan) {
+        return !_.includes(_.get(plan, 'metadata.supportedPlatforms', ['cf']), platform);
+      });
+      return !_.includes(_.get(service, 'metadata.supportedPlatforms', ['cf']), platform);
+    });
+    return modifiedCatalog;
   }
 
   postInstanceProvisionOperations(options) {

--- a/broker/lib/fabrik/Fabrik.js
+++ b/broker/lib/fabrik/Fabrik.js
@@ -47,12 +47,16 @@ class Fabrik {
         const instance = manager.createInstance(instance_id);
         return Promise
           .try(() => context ? context : instance.platformContext)
-          .then(context => instance.assignPlatformManager(Fabrik.getPlatformManager(context.platform)))
+          .then(context => instance.assignPlatformManager(Fabrik.getPlatformManager(context)))
           .return(instance);
       });
   }
 
-  static getPlatformManager(platform) {
+  static getPlatformManager(context) {
+    let platform = context.platform;
+    if (platform === CONST.PLATFORM.SM) {
+      platform = platform.origin;
+    }
     const PlatformManager = (platform && CONST.PLATFORM_MANAGER[platform]) ? require(`./${CONST.PLATFORM_MANAGER[platform]}`) : ((platform && CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]) ? require(`./${CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]}`) : undefined);
     if (PlatformManager === undefined) {
       return new BasePlatformManager(platform);

--- a/broker/lib/fabrik/Fabrik.js
+++ b/broker/lib/fabrik/Fabrik.js
@@ -55,7 +55,7 @@ class Fabrik {
   static getPlatformManager(context) {
     let platform = context.platform;
     if (platform === CONST.PLATFORM.SM) {
-      platform = platform.origin;
+      platform = context.origin;
     }
     const PlatformManager = (platform && CONST.PLATFORM_MANAGER[platform]) ? require(`./${CONST.PLATFORM_MANAGER[platform]}`) : ((platform && CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]) ? require(`./${CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]}`) : undefined);
     if (PlatformManager === undefined) {

--- a/broker/lib/fabrik/K8sPlatformManager.js
+++ b/broker/lib/fabrik/K8sPlatformManager.js
@@ -9,18 +9,6 @@ class K8sPlatformManager extends BasePlatformManager {
     this.platform = platform;
   }
 
-  // getCatalog(catalog) {
-  //   const modifiedCatalog = _.cloneDeep(catalog);
-  //   const platform = this.platform;
-  //   _.remove(modifiedCatalog.services, function (service) {
-  //     _.remove(service.plans, function (plan) {
-  //       return !_.includes(_.get(plan, 'supported_platform'), platform);
-  //     });
-  //     return !_.includes(_.get(service, 'supported_platform'), platform);
-  //   });
-  //   return modifiedCatalog;
-  // }
-
   postInstanceProvisionOperations(options) {
     /* jshint unused:false */
   }

--- a/broker/lib/fabrik/K8sPlatformManager.js
+++ b/broker/lib/fabrik/K8sPlatformManager.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BasePlatformManager = require('./BasePlatformManager');
-// const _ = require('lodash');
 
 class K8sPlatformManager extends BasePlatformManager {
   constructor(platform) {

--- a/broker/lib/fabrik/K8sPlatformManager.js
+++ b/broker/lib/fabrik/K8sPlatformManager.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const BasePlatformManager = require('./BasePlatformManager');
-const _ = require('lodash');
+// const _ = require('lodash');
 
 class K8sPlatformManager extends BasePlatformManager {
   constructor(platform) {
@@ -9,17 +9,17 @@ class K8sPlatformManager extends BasePlatformManager {
     this.platform = platform;
   }
 
-  getCatalog(catalog) {
-    const modifiedCatalog = _.cloneDeep(catalog);
-    const platform = this.platform;
-    _.remove(modifiedCatalog.services, function (service) {
-      _.remove(service.plans, function (plan) {
-        return !_.includes(_.get(plan, 'supported_platform'), platform);
-      });
-      return !_.includes(_.get(service, 'supported_platform'), platform);
-    });
-    return modifiedCatalog;
-  }
+  // getCatalog(catalog) {
+  //   const modifiedCatalog = _.cloneDeep(catalog);
+  //   const platform = this.platform;
+  //   _.remove(modifiedCatalog.services, function (service) {
+  //     _.remove(service.plans, function (plan) {
+  //       return !_.includes(_.get(plan, 'supported_platform'), platform);
+  //     });
+  //     return !_.includes(_.get(service, 'supported_platform'), platform);
+  //   });
+  //   return modifiedCatalog;
+  // }
 
   postInstanceProvisionOperations(options) {
     /* jshint unused:false */

--- a/broker/lib/middleware.js
+++ b/broker/lib/middleware.js
@@ -103,7 +103,7 @@ exports.checkQuota = function () {
             });
         }
       } else {
-        logger.debug(`[Quota]: Platform/Origin can be either ${CONST.PLATFORM.CF} or ${CONST.PLATFORM.SM}/${CONST.PLATFORM.CF}. Skipping quota check : calling next handler..`);
+        logger.debug(`[Quota]: Platform: ${platform}, Origin: ${origin}. Platform is not ${CONST.PLATFORM.CF} or ${CONST.PLATFORM.SM}/${CONST.PLATFORM.CF}. Skipping quota check : calling next handler..`);
         next();
       }
     }

--- a/broker/lib/middleware.js
+++ b/broker/lib/middleware.js
@@ -69,6 +69,11 @@ exports.checkBlockingOperationInProgress = function () {
 };
 
 exports.checkQuota = function () {
+  function shouldCheckQuotaForPlatform(platform, origin) {
+    return (platform === CONST.PLATFORM.CF ||
+      (platform === CONST.PLATFORM.SM &&
+        origin === CONST.PLATFORM.CF));
+  }
   return function (req, res, next) {
     if (utils.isServiceFabrikOperation(req.body)) {
       logger.debug('[Quota]: Check skipped as it is ServiceFabrikOperation: calling next handler..');
@@ -76,9 +81,7 @@ exports.checkQuota = function () {
     } else {
       const platform = _.get(req, 'body.context.platform');
       const origin = _.get(req, 'body.context.origin');
-      if (platform === CONST.PLATFORM.CF ||
-        (platform === CONST.PLATFORM.SM &&
-          origin === CONST.PLATFORM.CF)) {
+      if (shouldCheckQuotaForPlatform(platform, origin)) {
         const orgId = req.body.organization_guid || req.body.context.organization_guid || _.get(req, 'body.previous_values.organization_id');
         if (orgId === undefined) {
           next(new BadRequest(`organization_id is undefined`));

--- a/broker/lib/middleware.js
+++ b/broker/lib/middleware.js
@@ -75,7 +75,10 @@ exports.checkQuota = function () {
       next();
     } else {
       const platform = _.get(req, 'body.context.platform');
-      if (platform === CONST.PLATFORM.CF) {
+      const origin = _.get(req, 'body.context.origin');
+      if (platform === CONST.PLATFORM.CF ||
+        (platform === CONST.PLATFORM.SM &&
+          origin === CONST.PLATFORM.CF)) {
         const orgId = req.body.organization_guid || req.body.context.organization_guid || _.get(req, 'body.previous_values.organization_id');
         if (orgId === undefined) {
           next(new BadRequest(`organization_id is undefined`));
@@ -100,7 +103,7 @@ exports.checkQuota = function () {
             });
         }
       } else {
-        logger.debug(`[Quota]: Platform: ${platform}. Not ${CONST.PLATFORM.CF}. Skipping quota check : calling next handler..`);
+        logger.debug(`[Quota]: Platform/Origin can be either ${CONST.PLATFORM.CF} or ${CONST.PLATFORM.SM}/${CONST.PLATFORM.CF}. Skipping quota check : calling next handler..`);
         next();
       }
     }

--- a/broker/server.js
+++ b/broker/server.js
@@ -19,7 +19,7 @@ const internal = ExpressApp.create('internal', app => {
   });
   app.use('/admin', routes.admin);
   // cloud foundry service broker api
-  app.use('/:platform(cf|k8s)', routes.broker);
+  app.use('/:platform(cf|k8s|sm)', routes.broker);
 });
 
 // exernal app

--- a/common/config/eventlog-config-internal.yml
+++ b/common/config/eventlog-config-internal.yml
@@ -10,14 +10,14 @@ defaults:
   ignore_service_fabrik_operation: false # flag to indicate if service-fabrik operations are to be excluded. for ex. broker update (HTTP Patch)
                                          #  gets invoked via backup/restore etc, which are to be ignored when coming via HTTP Patch.
   include_response_body: false # wheter HTTP response body is to be logged after sanitization or not
-"/:platform(cf|k8s)/v2/catalog":
+"/:platform(cf|k8s|sm)/v2/catalog":
   GET:
     enabled: true
     event_name: broker_catalog
     description: Get broker service catalog
     tags:
     - catalog
-"/:platform(cf|k8s)/v2/service_instances/:instance_id":
+"/:platform(cf|k8s|sm)/v2/service_instances/:instance_id":
   PUT:
     enabled: true
     event_name: create_instance
@@ -40,7 +40,7 @@ defaults:
     http_success_codes:
     - 200
     - 410
-"/:platform(cf|k8s)/v2/service_instances/:instance_id/service_bindings/:binding_id":
+"/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/service_bindings/:binding_id":
   PUT:
     enabled: true
     event_name: create_binding
@@ -57,7 +57,7 @@ defaults:
     http_success_codes:
     - 200
     - 410
-"/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation":
+"/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation":
   GET:
     enabled: true
     cf_last_operation: true

--- a/common/constants.js
+++ b/common/constants.js
@@ -79,7 +79,7 @@ module.exports = Object.freeze({
     backup: '/api/v1/service_instances/:instance_id/backup',
     restore: '/api/v1/service_instances/:instance_id/restore',
     backup_by_guid: '/api/v1/backups/:backup_guid',
-    instance: '/:platform(cf|k8s)/v2/service_instances/:instance_id'
+    instance: '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id'
   },
   INSTANCE_TYPE: {
     DIRECTOR: 'director',

--- a/common/constants.js
+++ b/common/constants.js
@@ -322,12 +322,14 @@ module.exports = Object.freeze({
   },
   PLATFORM: {
     CF: 'cloudfoundry',
-    K8S: 'kubernetes'
+    K8S: 'kubernetes',
+    SM: 'sapcp'
   },
 
   PLATFORM_ALIAS_MAPPINGS: {
     'cf': 'cloudfoundry',
-    'k8s': 'kubernetes'
+    'k8s': 'kubernetes',
+    'sm': 'sapcp'
   },
 
   PLATFORM_MANAGER: {

--- a/common/models/Plan.js
+++ b/common/models/Plan.js
@@ -46,6 +46,22 @@ class Plan {
     return _.get(this.manager.settings, 'update_predecessors');
   }
 
+  get resourceGroup() {
+    return _.get(this.manager, 'resource_mappings.resource_group');
+  }
+
+  get resourceType() {
+    return _.get(this.manager, 'resource_mappings.resource_type');
+  }
+
+  get bindResourceGroup() {
+    return _.get(this.manager, 'resource_mappings.bind.resource_group');
+  }
+
+  get bindResourceType() {
+    return _.get(this.manager, 'resource_mappings.bind.resource_type');
+  }
+
   toJSON() {
     return _
       .chain(this)

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -572,8 +572,6 @@ class ApiServerClient {
       })
       .then(resource => _.get(resource, 'spec.options.context'));
   }
-
-
 }
 
 module.exports = ApiServerClient;

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -558,6 +558,22 @@ class ApiServerClient {
       .then(resource => _.get(resource, 'status.lastOperation'));
   }
 
+  /**
+   * @description Get platform context
+   * @param {string} opts.resourceGroup - Name of resourceGroup
+   * @param {string} opts.resourceType - Type of resource
+   * @param {string} opts.resourceId - Unique id of resource
+   */
+  getPlatformContext(opts) {
+    return this.getResource({
+        resourceGroup: opts.resourceGroup,
+        resourceType: opts.resourceType,
+        resourceId: opts.resourceId
+      })
+      .then(resource => _.get(resource, 'spec.options.context'));
+  }
+
+
 }
 
 module.exports = ApiServerClient;

--- a/operators/BaseService.js
+++ b/operators/BaseService.js
@@ -21,9 +21,13 @@ class BaseService {
   }
 
   getTenantGuid(context) {
-    if (context.platform === CONST.PLATFORM.CF) {
+    let platform = context.platform;
+    if (platform === CONST.PLATFORM.SM) {
+      platform = context.origin;
+    }
+    if (platform === CONST.PLATFORM.CF) {
       return context.space_guid;
-    } else if (context.platform === CONST.PLATFORM.K8S) {
+    } else if (platform === CONST.PLATFORM.K8S) {
       return context.namespace;
     }
   }

--- a/operators/backup-operator/BackupService.js
+++ b/operators/backup-operator/BackupService.js
@@ -197,16 +197,6 @@ class BackupService extends BaseDirectorService {
       });
   }
 
-  getLastBackup(tenant_id, instance_guid) {
-    return this.backupStore
-      .getBackupFile({
-        tenant_id: tenant_id,
-        service_id: this.plan.service.id,
-        plan_id: this.plan.id,
-        instance_guid: instance_guid
-      });
-  }
-
   getBackupOperationState(opts) {
     logger.debug('Getting Backup operation State for:', opts);
     const agent_ip = opts.agent_ip;

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -921,11 +921,15 @@ class DirectorService extends BaseDirectorService {
     const directorService = new DirectorService(plan, instanceId);
     return Promise
       .try(() => context ? context : directorService.platformContext)
-      .then(context => directorService.assignPlatformManager(DirectorService.getPlatformManager(context.platform)))
+      .then(context => directorService.assignPlatformManager(DirectorService.getPlatformManager(context)))
       .return(directorService);
   }
 
-  static getPlatformManager(platform) {
+  static getPlatformManager(context) {
+    let platform = context.platform;
+    if (platform === CONST.PLATFORM.SM) {
+      platform = platform.origin;
+    }
     const PlatformManager = (platform && CONST.PLATFORM_MANAGER[platform]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[platform]}`) : ((platform && CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]}`) : undefined);
     if (PlatformManager === undefined) {
       return new BasePlatformManager(platform);

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -112,7 +112,7 @@ class DirectorService extends BaseDirectorService {
               this.platformManager.preInstanceDeleteOperations({
                 guid: this.guid
               }),
-              this.deleteRestoreFile()
+              this.deleteRestoreFile() // This should be revisited when broker start supporting K8s through service manager
             ]);
         }
       });

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -876,6 +876,7 @@ class DirectorService extends BaseDirectorService {
                 }
                 logger.info(`Scheduling Backup for instance : ${this.guid} with backup interval of - ${options.repeatInterval}`);
                 //Even if there is an error while fetching backup schedule, trigger backup schedule we would want audit log captured and riemann alert sent
+                // This flow has to be revisited when we start supporting K8s through service manager
                 return this.serviceFabrikClient.scheduleBackup(options);
               });
           } catch (err) {

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -923,17 +923,14 @@ class DirectorService extends BaseDirectorService {
     return Promise
       .try(() => context ? context : directorService.platformContext)
       .then(context => directorService.assignPlatformManager(DirectorService.getPlatformManager(context)))
-      .tap(() => console.log(this.platformManager))
       .return(directorService);
   }
 
   static getPlatformManager(context) {
     let platform = context.platform;
-    console.log(platform);
     if (platform === CONST.PLATFORM.SM) {
       platform = context.origin;
     }
-    console.log(platform);
     const PlatformManager = (platform && CONST.PLATFORM_MANAGER[platform]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[platform]}`) : ((platform && CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]}`) : undefined);
     if (PlatformManager === undefined) {
       return new BasePlatformManager(platform);

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -923,14 +923,17 @@ class DirectorService extends BaseDirectorService {
     return Promise
       .try(() => context ? context : directorService.platformContext)
       .then(context => directorService.assignPlatformManager(DirectorService.getPlatformManager(context)))
+      .tap(() => console.log(this.platformManager))
       .return(directorService);
   }
 
   static getPlatformManager(context) {
     let platform = context.platform;
+    console.log(platform);
     if (platform === CONST.PLATFORM.SM) {
-      platform = platform.origin;
+      platform = context.origin;
     }
+    console.log(platform);
     const PlatformManager = (platform && CONST.PLATFORM_MANAGER[platform]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[platform]}`) : ((platform && CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]}`) : undefined);
     if (PlatformManager === undefined) {
       return new BasePlatformManager(platform);

--- a/operators/docker-operator/DockerService.js
+++ b/operators/docker-operator/DockerService.js
@@ -666,11 +666,15 @@ class DockerService extends BaseService {
         dockerService.imageInfo = manager.imageInfo;
       })
       .then(() => context ? context : dockerService.platformContext)
-      .then(context => dockerService.assignPlatformManager(DockerService.getPlatformManager(context.platform)))
+      .then(context => dockerService.assignPlatformManager(DockerService.getPlatformManager(context)))
       .return(dockerService);
   }
 
-  static getPlatformManager(platform) {
+  static getPlatformManager(context) {
+    let platform = context.platform;
+    if (platform === CONST.PLATFORM.SM) {
+      platform = platform.origin;
+    }
     const PlatformManager = (platform && CONST.PLATFORM_MANAGER[platform]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[platform]}`) : ((platform && CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]}`) : undefined);
     if (PlatformManager === undefined) {
       return new BasePlatformManager(platform);

--- a/operators/docker-operator/DockerService.js
+++ b/operators/docker-operator/DockerService.js
@@ -673,7 +673,7 @@ class DockerService extends BaseService {
   static getPlatformManager(context) {
     let platform = context.platform;
     if (platform === CONST.PLATFORM.SM) {
-      platform = platform.origin;
+      platform = context.origin;
     }
     const PlatformManager = (platform && CONST.PLATFORM_MANAGER[platform]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[platform]}`) : ((platform && CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]) ? require(`../../broker/lib/fabrik/${CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]}`) : undefined);
     if (PlatformManager === undefined) {

--- a/test/test_broker/EventLogInterceptor.spec.js
+++ b/test/test_broker/EventLogInterceptor.spec.js
@@ -74,7 +74,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '5a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/5a6e7c34-d97c-4fc0-95e6-7a3bc8030b14';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('PUT', url, route, {}, pathParams, {}, dockerManager, respBody, 200);
       return Promise
@@ -99,7 +99,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '5a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/5a6e7c34-d97c-4fc0-95e6-7a3bc8030b14';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('DELETE', url, route, {}, pathParams, {}, dockerManager, respBody, 200);
       return Promise
@@ -124,7 +124,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('PUT', url, route, {}, pathParams, {}, directorManager, respBody, 202);
       return Promise
@@ -149,7 +149,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('DELETE', url, route, {}, pathParams, {}, directorManager, respBody, 202);
       return Promise
@@ -176,7 +176,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b14';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('PATCH', url, route, {}, pathParams, {}, directorManager, respBody, 202);
       return Promise
@@ -235,7 +235,7 @@ describe('EventLogInterceptor', function () {
         binding_id: '082da7c8-c557-4b3d-b698-3b0a9a3ca947'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b14/service_bindings/082da7c8-c557-4b3d-b698-3b0a9a3ca947';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/service_bindings/:binding_id';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/service_bindings/:binding_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('PUT', url, route, {}, pathParams, {}, directorManager, respBody, 201);
       return Promise
@@ -262,7 +262,7 @@ describe('EventLogInterceptor', function () {
         binding_id: '082da7c8-c557-4b3d-b698-3b0a9a3ca947'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b14/service_bindings/082da7c8-c557-4b3d-b698-3b0a9a3ca947';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/service_bindings/:binding_id';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/service_bindings/:binding_id';
       const respBody = {};
       const [request, response] = buildExpectedRequestArgs('DELETE', url, route, {}, pathParams, {}, directorManager, respBody, 200);
       return Promise
@@ -605,7 +605,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'succeeded',
@@ -644,7 +644,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'succeeded',
@@ -683,7 +683,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'failed',
@@ -722,7 +722,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'failed',
@@ -761,7 +761,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'succeeded',
@@ -800,7 +800,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {};
       const op = {
@@ -836,7 +836,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const timestamp = new Date();
       const respBody = {
         state: 'failed',
@@ -875,7 +875,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const op = {
         type: 'update',
         subtype: 'backup',
@@ -917,7 +917,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const op = {
         type: 'update',
         subtype: 'backup',
@@ -959,7 +959,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const op = {
         type: 'update',
         subtype: 'restore',
@@ -1001,7 +1001,7 @@ describe('EventLogInterceptor', function () {
         instance_id: '4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15'
       };
       const url = '/cf/v2/service_instances/4a6e7c34-d97c-4fc0-95e6-7a3bc8030b15/last_operation';
-      const route = '/:platform(cf|k8s)/v2/service_instances/:instance_id/last_operation';
+      const route = '/:platform(cf|k8s|sm)/v2/service_instances/:instance_id/last_operation';
       const op = {
         type: 'update',
         subtype: 'restore',

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -454,6 +454,7 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, payload1);
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}?accepts_incomplete=true`)
@@ -499,6 +500,7 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, payload);
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}?accepts_incomplete=true`)
@@ -686,6 +688,7 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)
@@ -756,6 +759,7 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)
@@ -790,6 +794,7 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)

--- a/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
@@ -279,6 +279,7 @@ describe('service-broker-api', function () {
       describe('#update', function () {
         it('returns 200 OK', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payload, 1);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payload2, 1);
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}`)
@@ -307,6 +308,7 @@ describe('service-broker-api', function () {
         });
         it('returns 200 OK : For K8S', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payloadK8s, 1);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payload2K8s, 1);
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}`)
@@ -464,6 +466,7 @@ describe('service-broker-api', function () {
         };
         it('returns 200 OK', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payload, 1);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payload2, 1);
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)
@@ -482,6 +485,7 @@ describe('service-broker-api', function () {
 
         it('returns 410 Gone', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payload, 1);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, {}, 1, 404);
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)
@@ -501,6 +505,7 @@ describe('service-broker-api', function () {
 
         it('returns 200 OK: for existing deployment not having platfrom-context in environment', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payload, 1);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payload2, 1);
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)
@@ -519,6 +524,7 @@ describe('service-broker-api', function () {
 
         it('returns 200 OK: In K8S platform', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payloadK8s, 1);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, payload2K8s, 1);
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)

--- a/test/test_broker/acceptance/service-broker-api.instances.virtualHost.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.virtualHost.spec.js
@@ -439,6 +439,7 @@ describe('service-broker-api', function () {
         };
         it('returns 200 OK', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.VIRTUALHOST, instance_id, payload, 1);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.VIRTUALHOST, instance_id, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.VIRTUALHOST, instance_id, payload2, 1);
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)
@@ -457,6 +458,7 @@ describe('service-broker-api', function () {
         });
         it('returns 410 Gone when parent service instance is deleted', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.VIRTUALHOST, instance_id, payload, 1);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.VIRTUALHOST, instance_id, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.VIRTUALHOST, instance_id, {}, 1, 404);
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)

--- a/test/test_broker/acceptance/service-fabrik-admin.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.instances.director.spec.js
@@ -85,13 +85,17 @@ describe('service-fabrik-admin', function () {
           mocks.cloudController.getServiceInstances(plan_guid, numberOfDeployments);
           mocks.director.getDeploymentManifest(numberOfDeployments);
           mocks.director.diffDeploymentManifest(numberOfDeployments);
-          _.each(_.range(numberOfDeployments), index => mocks.cloudController
-            .getServiceInstance(mocks.director.uuidByIndex(index), {
-              space_guid: space_guid
-            }));
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: org_guid
-          }, numberOfDeployments);
+          _.each(_.range(numberOfDeployments), index => mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, mocks.director.uuidByIndex(index), {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: org_guid
+                }
+              })
+            }
+          }));
           return chai
             .request(apps.internal)
             .get(`${base_url}/deployments/outdated`)
@@ -235,11 +239,16 @@ describe('service-fabrik-admin', function () {
             const token = _.get(body.parameters, 'service-fabrik-operation');
             return support.jwt.verify(token, name, args);
           });
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid
-          });
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: org_guid
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: org_guid
+                }
+              })
+            }
           });
           return chai
             .request(apps.internal)
@@ -270,11 +279,16 @@ describe('service-fabrik-admin', function () {
           mocks.cloudController.getServiceInstances(plan_guid, numberOfDeployments);
           mocks.director.getDeploymentManifest(numberOfDeployments);
           mocks.director.diffDeploymentManifest(numberOfDeployments, diff);
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid
-          });
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: org_guid
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: org_guid
+                }
+              })
+            }
           });
           return chai
             .request(apps.internal)

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -176,13 +176,6 @@ describe('service-fabrik-api-sf2.0', function () {
         it('should initiate a start-backup with SF2.0 not via cloud controller', function (done) {
           mocks.uaa.tokenKey();
           mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid
-          });
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: organization_guid
-          });
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudProvider.list(container, list_prefix, [
@@ -205,6 +198,18 @@ describe('service-fabrik-api-sf2.0', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, {
             metadata: {
               resourceVersion: 10
+            }
+          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                },
+                plan_id: plan_id
+              })
             }
           });
           mocks.apiServerEventMesh.nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, {});
@@ -229,13 +234,6 @@ describe('service-fabrik-api-sf2.0', function () {
         it('should fail start-backup with SF2.0 not via cloud controller with unlocking', function (done) {
           mocks.uaa.tokenKey();
           mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid
-          });
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: organization_guid
-          });
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudProvider.list(container, list_prefix, [
@@ -260,6 +258,18 @@ describe('service-fabrik-api-sf2.0', function () {
               resourceVersion: 10
             }
           }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                },
+                plan_id: plan_id
+              })
+            }
+          });
           mocks.apiServerEventMesh.nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, {}, 1, undefined, 404);
           return chai
             .request(apps.external)
@@ -280,13 +290,6 @@ describe('service-fabrik-api-sf2.0', function () {
         it('should initiate a start-backup operation with optional space_guid', function (done) {
           mocks.uaa.tokenKey();
           mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid
-          });
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: organization_guid
-          });
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudProvider.list(container, list_prefix, [
@@ -308,6 +311,18 @@ describe('service-fabrik-api-sf2.0', function () {
             }
           });
           mocks.apiServerEventMesh.nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, {});
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                },
+                plan_id: plan_id
+              })
+            }
+          });
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           return chai
             .request(apps.external)
@@ -329,13 +344,6 @@ describe('service-fabrik-api-sf2.0', function () {
         it('should initiate a start-backup operation with context', function (done) {
           mocks.uaa.tokenKey();
           mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid
-          });
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: organization_guid
-          });
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudProvider.list(container, list_prefix, [
@@ -357,6 +365,18 @@ describe('service-fabrik-api-sf2.0', function () {
             }
           });
           mocks.apiServerEventMesh.nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, {});
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                },
+                plan_id: plan_id
+              })
+            }
+          });
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           return chai
             .request(apps.external)
@@ -440,13 +460,6 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid
-          });
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: organization_guid
-          });
           mocks.cloudController.findServicePlan(instance_id, plan_id);
           //cloud controller admin check will ensure getSpaceDeveloper isnt called, so no need to set that mock.
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, {
@@ -461,6 +474,18 @@ describe('service-fabrik-api-sf2.0', function () {
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, {
             metadata: {
               resourceVersion: 10
+            }
+          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                },
+                plan_id: plan_id
+              })
             }
           });
           mocks.apiServerEventMesh.nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, {});
@@ -1417,6 +1442,17 @@ describe('service-fabrik-api-sf2.0', function () {
           });
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, lock_body);
           mocks.apiServerEventMesh.nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_RESTORE, backup_create_response);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                }
+              })
+            }
+          });
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           return chai
             .request(apps.external)
@@ -1447,6 +1483,17 @@ describe('service-fabrik-api-sf2.0', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, {
             spec: {
               options: '{}'
+            }
+          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                }
+              })
             }
           });
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, lock_body);
@@ -1482,6 +1529,17 @@ describe('service-fabrik-api-sf2.0', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, {
             spec: {
               options: '{}'
+            }
+          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                }
+              })
             }
           });
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, lock_body);
@@ -1521,6 +1579,17 @@ describe('service-fabrik-api-sf2.0', function () {
               options: '{}'
             }
           });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                }
+              })
+            }
+          });
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, lock_body);
           mocks.apiServerEventMesh.nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_RESTORE, backup_create_response);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
@@ -1558,6 +1627,17 @@ describe('service-fabrik-api-sf2.0', function () {
           });
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, lock_body);
           mocks.apiServerEventMesh.nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_RESTORE, backup_create_response);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                }
+              })
+            }
+          });
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {});
           return chai
             .request(apps.external)
@@ -2246,11 +2326,17 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid
-          });
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: organization_guid
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                },
+                plan_id: plan_id
+              })
+            }
           });
           mocks.director.getDeployments();
           mocks.director.getDeployment(deploymentName, true);

--- a/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
@@ -532,11 +532,17 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid
-          });
-          mocks.cloudController.getSpace(space_guid, {
-            organization_guid: organization_guid
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                context: {
+                  platform: CONST.PLATFORM.CF,
+                  space_guid: space_guid,
+                  organization_guid: organization_guid
+                },
+                plan_id: plan_id
+              })
+            }
           });
           mocks.director.getDeployments();
           mocks.director.getDeployment(deploymentName, true);

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -1164,7 +1164,6 @@ describe('bosh', () => {
         }));
         dummyBoshDirectorClient.getDeploymentIps(deploymentName)
           .then(ips => {
-            console.log(ips);
             assert.deepEqual(ips, ['10.244.10.216', '10.244.10.217']);
             assert.deepEqual(dummyBoshDirectorClient.deploymentIpsCache[deploymentName], ips);
             expect(putDeploymentIpsInResourceStub).to.have.been.calledWith(deploymentName, ips);

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -20,6 +20,9 @@ const expectedGetDeploymentResponse = {
   },
   spec: {
     options: JSON.stringify({
+      context: {
+        platform: 'abc'
+      },
       opt1: 'opt1',
       opt2: 'opt2'
     }),
@@ -45,6 +48,9 @@ const sampleDeploymentResource = {
   },
   spec: {
     options: {
+      context: {
+        'platform': 'abc'
+      },
       opt1: 'opt1',
       opt2: 'opt2'
     },
@@ -790,6 +796,21 @@ describe('eventmesh', () => {
           })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource.status.state);
+            verify();
+          });
+      });
+    });
+
+    describe('getPlatformContext', () => {
+      it('Gets getPlatformContext', () => {
+        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', expectedGetDeploymentResponse);
+        return apiserver.getPlatformContext({
+            resourceId: 'deployment1',
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+          })
+          .then(res => {
+            expect(res).to.eql(sampleDeploymentResource.spec.options.context);
             verify();
           });
       });

--- a/test/test_broker/support/apps.js
+++ b/test/test_broker/support/apps.js
@@ -15,7 +15,7 @@ const internal = ExpressApp.create('internal', app => {
   });
   app.use('/admin', routes.admin);
   // cloud foundry service broker api
-  app.use('/:platform(cf|k8s)', routes.broker);
+  app.use('/:platform(cf|k8s|sm)', routes.broker);
 });
 
 // exernal app


### PR DESCRIPTION
With following changes service-fabrik-broker can support lifecycle and extension operation with service-manager for CF platform.
Changes were done in following apis
- v2 apis
- v1 apis
- admin apis

**Major changes**
Majorly changed were done to replace hardcoded context values with context from apiserver resource.


**`ServiceBrokerApiController.js`:**
- `getCatalog `
- `deleteInstance` and `updateInstance`, made changes for patching `options` field in resource rather than overwriting it hence now apiserver persists context object and other params which come as part of create request

**`ServiceFabrikAdminController.js`:**
`getDeployment`: fetch context object from apiserver resource
`findOutdatedDeployments `:  fetch context object from apiserver resource

**`ServiceFabrikApiController.js`:**
`getBackupOptions `: fetch context object from apiserver resource
`getRestoreOptions`: fetch context object from apiserver resource

**`v2.js`:**
`ensurePlatformContext `: Removed after discussions with @subhankarc @jagadish-kb 

**`BasePlatformManager.js`:**
`getCatalog `: Only gives service/plan details which has given platform in `supported_platforms` list

**`middleware.js`:**
`checkQuota`: support for SM platform

`getPlatformManager` method is enhanced to support SM platform


Note to @amitmalav `enrichContext` middleware should be removed before merging (Currently present in commits for testing purposes)