### PR TITLE
Try to get platform context from etcd in DirectorService before getting it from bosh 

### DIFF
--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -43,13 +43,10 @@ class DirectorInstance extends BaseInstance {
 
   getContextFromResource() {
     logger.debug(`Fetching context from etcd for ${this.guid}`);
-    return eventmesh.apiServerClient.getResource({
+    return eventmesh.apiServerClient.getPlatformContext({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
         resourceId: this.guid
-      })
-      .then(resource => {
-        return _.get(resource, 'spec.options.context', undefined);
       })
       .catch(err => {
         logger.error(`Error occured while getting context from resource for instance ${this.guid} `, err);

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -24,23 +24,23 @@ class DirectorInstance extends BaseInstance {
           return context;
         }
         return Promise.try(() => this.networkSegmentIndex ? this.deploymentName : this.manager.director.getDeploymentNameForInstanceId(this.guid))
-        .then(deploymentName => this.manager.director.getDeploymentProperty(deploymentName, CONST.PLATFORM_CONTEXT_KEY))
-        .then(context => JSON.parse(context))
-        .catch(NotFound, () => {
-          /* Following is to handle existing deployments. 
-             For them platform-context is not saved in deployment property. Defaults to CF.
-          */
-          logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
+          .then(deploymentName => this.manager.director.getDeploymentProperty(deploymentName, CONST.PLATFORM_CONTEXT_KEY))
+          .then(context => JSON.parse(context))
+          .catch(NotFound, () => {
+            /* Following is to handle existing deployments. 
+               For them platform-context is not saved in deployment property. Defaults to CF.
+            */
+            logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
           Setting default platform as '${CONST.PLATFORM.CF}'`);
 
-          const context = {
-            platform: CONST.PLATFORM.CF
-          };
-          return context;
-        });
+            const context = {
+              platform: CONST.PLATFORM.CF
+            };
+            return context;
+          });
       });
   }
-  
+
   getContextFromResource() {
     logger.debug(`Fetching context from etcd for ${this.guid}`);
     return eventmesh.apiServerClient.getResource({

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -68,7 +68,7 @@ class DirectorService extends BaseDirectorService {
                 For them platform-context is not saved in deployment property. Defaults to CF.
             */
             /*TODO: Remove the code for querying bosh for property.
-            */
+             */
             logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
           Setting default platform as '${CONST.PLATFORM.CF}'`);
 

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -94,13 +94,10 @@ class DirectorService extends BaseDirectorService {
 
   getContextFromResource() {
     logger.debug(`Fetching context from etcd for ${this.guid}`);
-    return eventmesh.apiServerClient.getResource({
+    return eventmesh.apiServerClient.getPlatformContext({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
         resourceId: this.guid
-      })
-      .then(resource => {
-        return _.get(resource, 'spec.options.context', undefined);
       })
       .catch(err => {
         logger.error(`Error occured while getting context from resource for instance ${this.guid} `, err);

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -59,7 +59,7 @@ class DirectorService extends BaseDirectorService {
         if (context) {
           return context;
         }
-        logger.info(`Fetching context from etcd failed for ${this.guid}. Trying to fetch from Bosh...`);
+        logger.debug(`Fetching context from etcd failed for ${this.guid}. Trying to fetch from Bosh...`);
         return Promise.try(() => this.networkSegmentIndex ? this.deploymentName : this.director.getDeploymentNameForInstanceId(this.guid))
           .then(deploymentName => this.director.getDeploymentProperty(deploymentName, CONST.PLATFORM_CONTEXT_KEY))
           .then(context => JSON.parse(context))
@@ -91,7 +91,7 @@ class DirectorService extends BaseDirectorService {
   }
 
   getContextFromResource() {
-    logger.info(`Fetching context from etcd for ${this.guid}`);
+    logger.debug(`Fetching context from etcd for ${this.guid}`);
     return eventmesh.apiServerClient.getResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -13,7 +13,6 @@ const NotFound = errors.NotFound;
 const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const ScheduleManager = require('../../jobs');
 const CONST = require('../../common/constants');
-const ordinals = ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth'];
 const bosh = require('../../data-access-layer/bosh');
 const eventmesh = require('../../data-access-layer/eventmesh');
 const Agent = require('../../data-access-layer/service-agent');
@@ -56,27 +55,27 @@ class DirectorService extends BaseDirectorService {
 
   get platformContext() {
     return this.getContextFromResource()
-    .then(context => {
-      if(context) {
-        return context;
-      }
-      logger.info(`Fetching context from etcd failed for ${this.guid}. Trying to fetch from Bosh...`);
-      return Promise.try(() => this.networkSegmentIndex ? this.deploymentName : this.director.getDeploymentNameForInstanceId(this.guid))
-        .then(deploymentName => this.director.getDeploymentProperty(deploymentName, CONST.PLATFORM_CONTEXT_KEY))
-        .then(context => JSON.parse(context))
-        .catch(NotFound, () => {
-          /* Following is to handle existing deployments. 
-              For them platform-context is not saved in deployment property. Defaults to CF.
-          */
-          logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
+      .then(context => {
+        if (context) {
+          return context;
+        }
+        logger.info(`Fetching context from etcd failed for ${this.guid}. Trying to fetch from Bosh...`);
+        return Promise.try(() => this.networkSegmentIndex ? this.deploymentName : this.director.getDeploymentNameForInstanceId(this.guid))
+          .then(deploymentName => this.director.getDeploymentProperty(deploymentName, CONST.PLATFORM_CONTEXT_KEY))
+          .then(context => JSON.parse(context))
+          .catch(NotFound, () => {
+            /* Following is to handle existing deployments. 
+                For them platform-context is not saved in deployment property. Defaults to CF.
+            */
+            logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
           Setting default platform as '${CONST.PLATFORM.CF}'`);
 
-          const context = {
-            platform: CONST.PLATFORM.CF
-          };
-          return context;
-        });    
-    });
+            const context = {
+              platform: CONST.PLATFORM.CF
+            };
+            return context;
+          });
+      });
   }
 
   static get prefix() {
@@ -94,17 +93,17 @@ class DirectorService extends BaseDirectorService {
   getContextFromResource() {
     logger.info(`Fetching context from etcd for ${this.guid}`);
     return eventmesh.apiServerClient.getResource({
-      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-      resourceId: this.guid
-    })
-    .then(resource => {
-      return _.get(resource, 'spec.options.context', undefined);
-    })
-    .catch(err => {
-      logger.error(`Error occured while getting context from resource for instance ${this.guid} `, err);
-      return;
-    });
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+        resourceId: this.guid
+      })
+      .then(resource => {
+        return _.get(resource, 'spec.options.context', undefined);
+      })
+      .catch(err => {
+        logger.error(`Error occured while getting context from resource for instance ${this.guid} `, err);
+        return;
+      });
   }
 
   getNetworkSegmentIndex(deploymentName) {

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -67,6 +67,8 @@ class DirectorService extends BaseDirectorService {
             /* Following is to handle existing deployments. 
                 For them platform-context is not saved in deployment property. Defaults to CF.
             */
+            /*TODO: Remove the code for querying bosh for property.
+            */
             logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
           Setting default platform as '${CONST.PLATFORM.CF}'`);
 

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -55,21 +55,28 @@ class DirectorService extends BaseDirectorService {
   }
 
   get platformContext() {
-    return Promise.try(() => this.networkSegmentIndex ? this.deploymentName : this.director.getDeploymentNameForInstanceId(this.guid))
-      .then(deploymentName => this.director.getDeploymentProperty(deploymentName, CONST.PLATFORM_CONTEXT_KEY))
-      .then(context => JSON.parse(context))
-      .catch(NotFound, () => {
-        /* Following is to handle existing deployments. 
-           For them platform-context is not saved in deployment property. Defaults to CF.
-         */
-        logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
-        Setting default platform as '${CONST.PLATFORM.CF}'`);
-
-        const context = {
-          platform: CONST.PLATFORM.CF
-        };
+    return this.getContextFromResource()
+    .then(context => {
+      if(context) {
         return context;
-      });
+      }
+      logger.info(`Fetching context from etcd failed for ${this.guid}. Trying to fetch from Bosh...`);
+      return Promise.try(() => this.networkSegmentIndex ? this.deploymentName : this.director.getDeploymentNameForInstanceId(this.guid))
+        .then(deploymentName => this.director.getDeploymentProperty(deploymentName, CONST.PLATFORM_CONTEXT_KEY))
+        .then(context => JSON.parse(context))
+        .catch(NotFound, () => {
+          /* Following is to handle existing deployments. 
+              For them platform-context is not saved in deployment property. Defaults to CF.
+          */
+          logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
+          Setting default platform as '${CONST.PLATFORM.CF}'`);
+
+          const context = {
+            platform: CONST.PLATFORM.CF
+          };
+          return context;
+        });    
+    });
   }
 
   static get prefix() {
@@ -82,6 +89,23 @@ class DirectorService extends BaseDirectorService {
   get deploymentName() {
     let subnet = this.subnet ? `_${this.subnet}` : '';
     return `${this.prefix}${subnet}-${NetworkSegmentIndex.adjust(this.networkSegmentIndex)}-${this.guid}`;
+  }
+
+  getContextFromResource() {
+    logger.info(`Fetching context from etcd fot ${this.guid}`);
+    return eventmesh.apiServerClient.getResource({
+      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+      resourceId: this.guid
+    })
+    .then(resource => {
+      logger.debug(`Fetched context is: `, _.get(resource, 'spec.options.context', undefined));
+      return _.get(resource, 'spec.options.context', undefined);
+    })
+    .catch(err => {
+      logger.error(`Error occured while getting context from resource for instance ${this.guid} `, err);
+      return;
+    });
   }
 
   getNetworkSegmentIndex(deploymentName) {
@@ -179,20 +203,7 @@ class DirectorService extends BaseDirectorService {
       .try(() => {
         switch (operation.type) {
         case 'create':
-          return utils
-            .retry(tries => {
-              logger.info(`+-> ${ordinals[tries]} attempt to create property '${CONST.PLATFORM_CONTEXT_KEY}' for deployment '${this.deploymentName}'...`);
-              return this.director
-                .createDeploymentProperty(this.deploymentName, CONST.PLATFORM_CONTEXT_KEY, JSON.stringify(operation.context))
-                .catch(err => {
-                  logger.error(`Error occured while trying to create deployment property for deployment ${this.deploymentName}`, err);
-                  throw err;
-                });
-            }, {
-              maxAttempts: 3,
-              minDelay: 1000
-            })
-            .then(() => this.platformManager.postInstanceProvisionOperations({
+          return Promise.try(() => this.platformManager.postInstanceProvisionOperations({
               ipRuleOptions: this.buildIpRules(),
               guid: this.guid,
               context: operation.context

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -92,14 +92,13 @@ class DirectorService extends BaseDirectorService {
   }
 
   getContextFromResource() {
-    logger.info(`Fetching context from etcd fot ${this.guid}`);
+    logger.info(`Fetching context from etcd for ${this.guid}`);
     return eventmesh.apiServerClient.getResource({
       resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
       resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
       resourceId: this.guid
     })
     .then(resource => {
-      logger.debug(`Fetched context is: `, _.get(resource, 'spec.options.context', undefined));
       return _.get(resource, 'spec.options.context', undefined);
     })
     .catch(err => {

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -692,7 +692,6 @@ describe('#DirectorService', function () {
             space_guid: space_guid
           };
           mocks.director.getDeploymentTask(task_id, 'done');
-          mocks.director.createDeploymentProperty('platform-context', context);
           mocks.cloudController.createSecurityGroup(instance_id);
           const payload = {
             repeatInterval: CONST.SCHEDULE.RANDOM,
@@ -775,7 +774,6 @@ describe('#DirectorService', function () {
             repeatInterval: CONST.SCHEDULE.RANDOM,
             timeZone: 'Asia/Kolkata'
           };
-          mocks.director.createDeploymentProperty('platform-context', context);
           mocks.serviceFabrikClient.scheduleUpdate(instance_id, payload);
           config.scheduler.jobs.service_instance_update.run_every_xdays = 15;
           config.mongodb.provision.plan_id = 'TEST';

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -11,6 +11,7 @@ const iaas = require('../../data-access-layer/iaas');
 const backupStore = iaas.backupStore;
 const DirectorService = require('../../operators/bosh-operator/DirectorService');
 const utils = require('../../common/utils');
+const cfPlatformManager = require('../../broker/lib/fabrik/CfPlatformManager');
 
 describe('#DirectorService', function () {
   describe('instances', function () {
@@ -78,11 +79,27 @@ describe('#DirectorService', function () {
       const deferred = Promise.defer();
       Promise.onPossiblyUnhandledRejection(() => {});
       let getScheduleStub;
-      const dummyDeploymentResource = {
+      const dummyDeplResourceWithContext = {
         metadata: {
-          annotations: {
-            labels: 'dummy'
-          }
+          name: instance_id
+        },
+        spec: {
+          options: `{"service_id":"${service_id}","plan_id":"${plan_id}","organization_guid":"${organization_guid}","space_guid":"${space_guid}",
+          "context":{"platform":"cloudfoundry","organization_guid":"${organization_guid}","space_guid":"${space_guid}"}}`
+        },
+        status: {
+          state: 'succeeded'
+        }
+      };
+      const dummyDeplResourceWithoutContext = {
+        metadata: {
+          name: instance_id
+        },
+        spec: {
+          options: `{"service_id":"${service_id}","plan_id":"${plan_id}","organization_guid":"${organization_guid}","space_guid":"${space_guid}"}`
+        },
+        status: {
+          state: 'succeeded'
         }
       };
       before(function () {
@@ -149,9 +166,7 @@ describe('#DirectorService', function () {
           });
           mocks.director.createOrUpdateDeployment(task_id);
           mocks.deploymentHookClient.executeDeploymentActions(200, deploymentHookRequestBodyNoContext);
-          mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
-            platform: 'cloudfoundry'
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           const options = {
             service_id: service_id,
             plan_id: plan_id,
@@ -292,12 +307,9 @@ describe('#DirectorService', function () {
             .value();
           expectedRequestBody.context.params.previous_manifest = mocks.director.manifest;
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UPDATE;
-          mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
-            platform: 'cloudfoundry'
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext, 2);
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           mocks.agent.getInfo();
@@ -346,7 +358,7 @@ describe('#DirectorService', function () {
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           mocks.agent.getInfo();
@@ -395,7 +407,7 @@ describe('#DirectorService', function () {
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           //mocks.agent.preUpdate();
@@ -440,12 +452,9 @@ describe('#DirectorService', function () {
           expectedRequestBody.context.params.previous_manifest = mocks.director.manifest;
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UPDATE;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
-          mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
-            platform: 'cloudfoundry'
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext, 2);
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           mocks.agent.getInfo();
@@ -473,9 +482,7 @@ describe('#DirectorService', function () {
         });
         it('returns 202 when preupdate feature is not implemented by agent', function () {
           let deploymentName = 'service-fabrik-0021-b4719e7c-e8d3-4f7f-c515-769ad1c3ebfa';
-          mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
-            platform: 'cloudfoundry'
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext, 2);
           const expectedRequestBody = _.cloneDeep(deploymentHookRequestBody);
           _.set(expectedRequestBody.context.params, 'plan_id', plan_id_update);
           _.set(expectedRequestBody.context.params, 'previous_values', {
@@ -492,7 +499,6 @@ describe('#DirectorService', function () {
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeployment(deploymentName, true, undefined);
           mocks.director.createOrUpdateDeployment(task_id);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deploymentName);
           mocks.agent.getInfo(1, 'preupdate');
@@ -532,12 +538,12 @@ describe('#DirectorService', function () {
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           const restoreFilename = `${space_guid}/restore/${service_id}.${instance_id}.json`;
           const restorePathname = `/${container}/${restoreFilename}`;
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext, 3);
           mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
             platform: 'cloudfoundry',
             organization_guid: organization_guid,
             space_guid: space_guid
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
@@ -582,7 +588,7 @@ describe('#DirectorService', function () {
             organization_guid: organization_guid,
             space_guid: space_guid
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext, 3);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
@@ -624,7 +630,7 @@ describe('#DirectorService', function () {
             platform: 'kubernetes',
             namespace: 'default'
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext, 3);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.director.deleteDeployment(task_id);
@@ -884,6 +890,7 @@ describe('#DirectorService', function () {
             task_id: `${deployment_name}_${task_id}`,
             type: 'delete'
           };
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext);
           return DirectorService.createInstance(instance_id, options)
             .then(service => service.lastOperation(response))
             .then(res => {
@@ -914,6 +921,7 @@ describe('#DirectorService', function () {
             task_id: `${deployment_name}_${task_id}`,
             type: 'delete'
           };
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext);
           return DirectorService.createInstance(instance_id, options)
             .then(service => service.lastOperation(response))
             .then(res => {
@@ -937,13 +945,10 @@ describe('#DirectorService', function () {
             .value();
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_BIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
-          mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
-            platform: 'cloudfoundry'
-          });
           config.mongodb.provision.plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
           deferred.reject(new errors.NotFound('Schedule not found'));
           const WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION = 0;
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext, 2);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
@@ -996,7 +1001,7 @@ describe('#DirectorService', function () {
             .value();
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_BIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
@@ -1110,7 +1115,7 @@ describe('#DirectorService', function () {
           };
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeploymentInstances(deployment_name);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BIND, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND, binding_id, dummyBindResource, 1, 200);
           mocks.agent.getInfo();
@@ -1152,7 +1157,7 @@ describe('#DirectorService', function () {
           };
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BIND, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND, binding_id, dummyBindResource, 1, 200);
@@ -1191,7 +1196,7 @@ describe('#DirectorService', function () {
 
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BIND, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND, binding_id, {}, 1, 404);
@@ -1230,7 +1235,7 @@ describe('#DirectorService', function () {
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
           mocks.director.getDeploymentProperty(deployment_name, false, 'platform-context', undefined);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext, 2);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BIND, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND, binding_id, dummyBindResource, 1, 200);
           mocks.director.getDeploymentInstances(deployment_name);
@@ -1250,6 +1255,69 @@ describe('#DirectorService', function () {
             .then(() => {
               mocks.verify();
             });
+        });
+      });
+
+      describe('#platformContext - context not present in options ', function() {
+        it('context found in resource', function(done) {
+          const options = {
+            service_id: service_id,
+            plan_id: plan_id,
+            organization_guid: organization_guid,
+            space_guid: space_guid,
+            parameters: parameters
+          };
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
+          return DirectorService.createInstance(instance_id, options)
+          .then(service => {
+            expect(service.platformManager).to.be.an.instanceOf(cfPlatformManager);
+            expect(service.guid).to.equal(instance_id);
+            expect(service.plan).to.deep.equal(catalog.getPlan(plan_id));
+            mocks.verify();
+            done();
+          });
+        });
+
+        it('context not found in resource, but present in bosh property', function(done) {
+          const options = {
+            service_id: service_id,
+            plan_id: plan_id,
+            organization_guid: organization_guid,
+            space_guid: space_guid,
+            parameters: parameters
+          };
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext);
+          mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
+            platform: 'cloudfoundry'
+          });
+          return DirectorService.createInstance(instance_id, options)
+          .then(service => {
+            expect(service.platformManager).to.be.an.instanceOf(cfPlatformManager);
+            expect(service.guid).to.equal(instance_id);
+            expect(service.plan).to.deep.equal(catalog.getPlan(plan_id));
+            mocks.verify();
+            done();
+          });
+        });
+
+        it('context neither found in resource nor in bosh property', function(done) {
+          const options = {
+            service_id: service_id,
+            plan_id: plan_id,
+            organization_guid: organization_guid,
+            space_guid: space_guid,
+            parameters: parameters
+          };
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext);
+          mocks.director.getDeploymentProperty(deployment_name, false, 'platform-context');
+          return DirectorService.createInstance(instance_id, options)
+          .then(service => {
+            expect(service.platformManager).to.be.an.instanceOf(cfPlatformManager);
+            expect(service.guid).to.equal(instance_id);
+            expect(service.plan).to.deep.equal(catalog.getPlan(plan_id));
+            mocks.verify();
+            done();
+          });
         });
       });
     });

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -11,7 +11,7 @@ const iaas = require('../../data-access-layer/iaas');
 const backupStore = iaas.backupStore;
 const DirectorService = require('../../operators/bosh-operator/DirectorService');
 const utils = require('../../common/utils');
-const cfPlatformManager = require('../../broker/lib/fabrik/CfPlatformManager');
+const cfPlatformManager = require('../../platform-managers/CfPlatformManager');
 
 describe('#DirectorService', function () {
   describe('instances', function () {

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -692,11 +692,6 @@ describe('#DirectorService', function () {
         });
 
         it('create: returns 200 OK (state = succeeded)', function () {
-          const context = {
-            platform: 'cloudfoundry',
-            organization_guid: organization_guid,
-            space_guid: space_guid
-          };
           mocks.director.getDeploymentTask(task_id, 'done');
           mocks.cloudController.createSecurityGroup(instance_id);
           const payload = {
@@ -1258,8 +1253,8 @@ describe('#DirectorService', function () {
         });
       });
 
-      describe('#platformContext - context not present in options ', function() {
-        it('context found in resource', function(done) {
+      describe('#platformContext - context not present in options ', function () {
+        it('context found in resource', function (done) {
           const options = {
             service_id: service_id,
             plan_id: plan_id,
@@ -1269,16 +1264,16 @@ describe('#DirectorService', function () {
           };
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           return DirectorService.createInstance(instance_id, options)
-          .then(service => {
-            expect(service.platformManager).to.be.an.instanceOf(cfPlatformManager);
-            expect(service.guid).to.equal(instance_id);
-            expect(service.plan).to.deep.equal(catalog.getPlan(plan_id));
-            mocks.verify();
-            done();
-          });
+            .then(service => {
+              expect(service.platformManager).to.be.an.instanceOf(cfPlatformManager);
+              expect(service.guid).to.equal(instance_id);
+              expect(service.plan).to.deep.equal(catalog.getPlan(plan_id));
+              mocks.verify();
+              done();
+            });
         });
 
-        it('context not found in resource, but present in bosh property', function(done) {
+        it('context not found in resource, but present in bosh property', function (done) {
           const options = {
             service_id: service_id,
             plan_id: plan_id,
@@ -1291,16 +1286,16 @@ describe('#DirectorService', function () {
             platform: 'cloudfoundry'
           });
           return DirectorService.createInstance(instance_id, options)
-          .then(service => {
-            expect(service.platformManager).to.be.an.instanceOf(cfPlatformManager);
-            expect(service.guid).to.equal(instance_id);
-            expect(service.plan).to.deep.equal(catalog.getPlan(plan_id));
-            mocks.verify();
-            done();
-          });
+            .then(service => {
+              expect(service.platformManager).to.be.an.instanceOf(cfPlatformManager);
+              expect(service.guid).to.equal(instance_id);
+              expect(service.plan).to.deep.equal(catalog.getPlan(plan_id));
+              mocks.verify();
+              done();
+            });
         });
 
-        it('context neither found in resource nor in bosh property', function(done) {
+        it('context neither found in resource nor in bosh property', function (done) {
           const options = {
             service_id: service_id,
             plan_id: plan_id,
@@ -1311,13 +1306,13 @@ describe('#DirectorService', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext);
           mocks.director.getDeploymentProperty(deployment_name, false, 'platform-context');
           return DirectorService.createInstance(instance_id, options)
-          .then(service => {
-            expect(service.platformManager).to.be.an.instanceOf(cfPlatformManager);
-            expect(service.guid).to.equal(instance_id);
-            expect(service.plan).to.deep.equal(catalog.getPlan(plan_id));
-            mocks.verify();
-            done();
-          });
+            .then(service => {
+              expect(service.platformManager).to.be.an.instanceOf(cfPlatformManager);
+              expect(service.guid).to.equal(instance_id);
+              expect(service.plan).to.deep.equal(catalog.getPlan(plan_id));
+              mocks.verify();
+              done();
+            });
         });
       });
     });


### PR DESCRIPTION
* Earlier if context was not present in the options provided to DirectorService.createInstance, context used to be fetched from Bosh property of that deployment.
* However context is also present in etcd resource, hence to remove one more dependency on Bosh, flow is modified to first check in the etcd if context is present in resource.
* Along with that, code for creation of platform-context property while creating new instances is also removed. (**Discussion/feedback needed here because now the assumption is that the context will always be present in etcd resource**)