### PR TITLE
Dashboard url would be updated with new plan in patch api response and format changed

### DIFF
--- a/api-controllers/DashboardController.js
+++ b/api-controllers/DashboardController.js
@@ -94,7 +94,7 @@ class DashboardController extends FabrikBaseController {
         req.session.user_id = userInfo.user_name || userInfo.email || userInfo.user_id;
         return saveSession(req.session);
       })
-      .then(() => res.redirect(manageInstancePath(req)));
+      .then(() => res.redirect(manageInstancePath(req.session)));
   }
 
   validateServiceInstanceId(req, res) {
@@ -107,7 +107,7 @@ class DashboardController extends FabrikBaseController {
   validateSession(req, res) {
     /* jshint unused:false */
     logger.info(`Validating session '${req.session.id}'`);
-    if (!req.session.service_id || req.session.service_id === req.params.service_id) {
+    if ((!req.session.service_id || req.session.service_id === req.params.service_id) || (!req.session.instance_type || req.session.instance_type === req.params.instance_type)) {
       throw new ContinueWithNext();
     }
     logger.info('Regenerating session...');
@@ -156,7 +156,7 @@ class DashboardController extends FabrikBaseController {
         req.instance = instance;
         req.manager = instance.manager;
       })
-      .tap(() => saveSession(req.session))
+      .then(() => saveSession(req.session))
       .throw(new ContinueWithNext());
   }
 
@@ -263,8 +263,8 @@ function saveSession(session) {
     .tap(() => session.saveAsync());
 }
 
-function manageInstancePath(req) {
-  return req.session.instance_type ? `/manage/dashboards/${req.session.instance_type}/instances/${req.session.instance_id}` : `/manage/instances/${req.session.service_id}/${req.session.plan_id}/${req.session.instance_id}`;
+function manageInstancePath(session) {
+  return session.instance_type ? `/manage/dashboards/${session.instance_type}/instances/${session.instance_id}` : `/manage/instances/${session.service_id}/${session.plan_id}/${session.instance_id}`;
 }
 
 module.exports = DashboardController;

--- a/api-controllers/DashboardController.js
+++ b/api-controllers/DashboardController.js
@@ -136,6 +136,10 @@ class DashboardController extends FabrikBaseController {
       .throw(new ContinueWithNext());
   }
 
+  validateServiceInstanceAndType(req, res) {
+    /* jshint unused:false */
+  }
+
   requireLogin(req, res) {
     logger.info(`Validating user '${req.session.user_id}' and access token`);
     req.session.service_id = req.params.service_id;

--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -16,7 +16,6 @@ const BadRequest = errors.BadRequest;
 const NotFound = errors.NotFound;
 const CONST = require('../common/constants');
 const lockManager = require('../data-access-layer/eventmesh').lockManager;
-const formatUrl = require('url').format;
 
 class FabrikBaseController extends BaseController {
   constructor() {
@@ -170,16 +169,6 @@ class FabrikBaseController extends BaseController {
 
   getPlan(plan_id) {
     return catalog.getPlan(plan_id);
-  }
-
-  static getDashboardUrl(serviceId, planId, instanceId) {
-    return formatUrl(_
-      .chain(config.external)
-      .pick('protocol', 'host')
-      .set('slashes', true)
-      .set('pathname', `/manage/instances/${serviceId}/${planId}/${instanceId}`)
-      .value()
-    );
   }
 }
 

--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -16,6 +16,7 @@ const BadRequest = errors.BadRequest;
 const NotFound = errors.NotFound;
 const CONST = require('../common/constants');
 const lockManager = require('../data-access-layer/eventmesh').lockManager;
+const formatUrl = require('url').format;
 
 class FabrikBaseController extends BaseController {
   constructor() {
@@ -169,6 +170,16 @@ class FabrikBaseController extends BaseController {
 
   getPlan(plan_id) {
     return catalog.getPlan(plan_id);
+  }
+
+  static getDashboardUrl(serviceId, planId, instanceId) {
+    return formatUrl(_
+      .chain(config.external)
+      .pick('protocol', 'host')
+      .set('slashes', true)
+      .set('pathname', `/manage/instances/${serviceId}/${planId}/${instanceId}`)
+      .value()
+    );
   }
 }
 

--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -53,7 +53,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function done() {
       let statusCode = CONST.HTTP_STATUS_CODE.CREATED;
       const body = {
-        dashboard_url: ServiceBrokerApiController.getDashboardUrl(params.service_id, params.plan_id, req.params.instance_id)
+        dashboard_url: ServiceBrokerApiController.getDashboardUrl(plan, req.params.instance_id)
       };
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
@@ -110,7 +110,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function done() {
       let statusCode = CONST.HTTP_STATUS_CODE.OK;
       let body = {
-        dashboard_url: ServiceBrokerApiController.getDashboardUrl(params.service_id, params.plan_id, req.params.instance_id)
+        dashboard_url: ServiceBrokerApiController.getDashboardUrl(plan, req.params.instance_id)
       };
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
@@ -355,12 +355,12 @@ class ServiceBrokerApiController extends FabrikBaseController {
       .catch(NotFound, gone);
   }
 
-  static getDashboardUrl(serviceId, planId, instanceId) {
+  static getDashboardUrl(plan, instanceId) {
     return formatUrl(_
       .chain(config.external)
       .pick('protocol', 'host')
       .set('slashes', true)
-      .set('pathname', `/manage/instances/${serviceId}/${planId}/${instanceId}`)
+      .set('pathname', `manage/dashboards/${plan.manager.name}/instances/${instanceId}`)
       .value()
     );
   }

--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -5,6 +5,7 @@ const Promise = require('bluebird');
 const errors = require('../common/errors');
 const logger = require('../common/logger');
 const utils = require('../common/utils');
+const config = require('../common/config');
 const catalog = require('../common/models/catalog');
 const FabrikBaseController = require('./FabrikBaseController');
 const BadRequest = errors.BadRequest;
@@ -15,6 +16,7 @@ const ContinueWithNext = errors.ContinueWithNext;
 const Conflict = errors.Conflict;
 const CONST = require('../common/constants');
 const eventmesh = require('../data-access-layer/eventmesh');
+const formatUrl = require('url').format;
 
 class ServiceBrokerApiController extends FabrikBaseController {
   constructor() {
@@ -51,7 +53,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function done() {
       let statusCode = CONST.HTTP_STATUS_CODE.CREATED;
       const body = {
-        dashboard_url: FabrikBaseController.getDashboardUrl(params.service_id, params.plan_id, req.params.instance_id)
+        dashboard_url: ServiceBrokerApiController.getDashboardUrl(params.service_id, params.plan_id, req.params.instance_id)
       };
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
@@ -108,7 +110,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function done() {
       let statusCode = CONST.HTTP_STATUS_CODE.OK;
       let body = {
-        dashboard_url: FabrikBaseController.getDashboardUrl(params.service_id, params.plan_id, req.params.instance_id)
+        dashboard_url: ServiceBrokerApiController.getDashboardUrl(params.service_id, params.plan_id, req.params.instance_id)
       };
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
@@ -351,6 +353,16 @@ class ServiceBrokerApiController extends FabrikBaseController {
       }))
       .then(done)
       .catch(NotFound, gone);
+  }
+
+  static getDashboardUrl(serviceId, planId, instanceId) {
+    return formatUrl(_
+      .chain(config.external)
+      .pick('protocol', 'host')
+      .set('slashes', true)
+      .set('pathname', `/manage/instances/${serviceId}/${planId}/${instanceId}`)
+      .value()
+    );
   }
 
 }

--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -109,7 +109,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
 
     function done() {
       let statusCode = CONST.HTTP_STATUS_CODE.OK;
-      let body = {
+      const body = {
         dashboard_url: ServiceBrokerApiController.getDashboardUrl(plan, req.params.instance_id)
       };
       if (plan.manager.async) {

--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -15,9 +15,6 @@ const ContinueWithNext = errors.ContinueWithNext;
 const Conflict = errors.Conflict;
 const CONST = require('../common/constants');
 const eventmesh = require('../data-access-layer/eventmesh');
-const config = require('../common/config');
-const formatUrl = require('url').format;
-
 
 class ServiceBrokerApiController extends FabrikBaseController {
   constructor() {
@@ -51,20 +48,10 @@ class ServiceBrokerApiController extends FabrikBaseController {
     const planId = params.plan_id;
     const plan = catalog.getPlan(planId);
 
-    function getDashboardUrl(serviceId, planId, instanceId) {
-      return formatUrl(_
-        .chain(config.external)
-        .pick('protocol', 'host')
-        .set('slashes', true)
-        .set('pathname', `/manage/instances/${serviceId}/${planId}/${instanceId}`)
-        .value()
-      );
-    }
-
     function done() {
       let statusCode = CONST.HTTP_STATUS_CODE.CREATED;
       const body = {
-        dashboard_url: getDashboardUrl(params.service_id, params.plan_id, req.params.instance_id)
+        dashboard_url: FabrikBaseController.getDashboardUrl(params.service_id, params.plan_id, req.params.instance_id)
       };
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
@@ -120,7 +107,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
 
     function done() {
       let statusCode = CONST.HTTP_STATUS_CODE.OK;
-      let body = {};
+      let body = {
+        dashboard_url: FabrikBaseController.getDashboardUrl(params.service_id, params.plan_id, req.params.instance_id)
+      };
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
         body.operation = utils.encodeBase64({

--- a/api-controllers/routes/manage.js
+++ b/api-controllers/routes/manage.js
@@ -15,6 +15,9 @@ const router = module.exports = express.Router();
 const instanceRouter = express.Router({
   mergeParams: true
 });
+const dashboardRouter = express.Router({
+  mergeParams: true
+});
 
 /* Service Fabrik Manage Router */
 router.use(expressSession({
@@ -33,6 +36,7 @@ router.use(expressSession({
 router.get('/auth/cf', controller.handler('redirectToAuthorizationServer'));
 router.get('/auth/cf/callback', controller.handler('handleAuthorizationResponse'));
 router.use('/instances/:service_id/:plan_id/:instance_id', instanceRouter);
+router.use('/manage/dashboards/:instance_type/instances/:instance_id', dashboardRouter);
 
 /* Service Fabrik Instance Router */
 instanceRouter.use(commonMiddleware.csp());
@@ -44,5 +48,19 @@ instanceRouter.use(controller.handler('ensureTokenNotExpired'));
 instanceRouter.use(controller.handler('ensureAllNecessaryScopesAreApproved'));
 instanceRouter.use(controller.handler('ensureCanManageInstance'));
 instanceRouter.route('/')
+  .get(controller.handler('show'))
+  .all(commonMiddleware.methodNotAllowed(['GET']));
+
+/* Service Fabrik Dashboard Router
+   This is for new dashboard URL */
+dashboardRouter.use(commonMiddleware.csp());
+dashboardRouter.use(controller.handler('validateServiceInstanceId'));
+dashboardRouter.use(controller.handler('validateSession'));
+dashboardRouter.use(controller.handler('validateServiceInstanceAndType'));
+dashboardRouter.use(controller.handler('requireLogin'));
+dashboardRouter.use(controller.handler('ensureTokenNotExpired'));
+dashboardRouter.use(controller.handler('ensureAllNecessaryScopesAreApproved'));
+dashboardRouter.use(controller.handler('ensureCanManageInstance'));
+dashboardRouter.route('/')
   .get(controller.handler('show'))
   .all(commonMiddleware.methodNotAllowed(['GET']));

--- a/api-controllers/routes/manage.js
+++ b/api-controllers/routes/manage.js
@@ -36,7 +36,7 @@ router.use(expressSession({
 router.get('/auth/cf', controller.handler('redirectToAuthorizationServer'));
 router.get('/auth/cf/callback', controller.handler('handleAuthorizationResponse'));
 router.use('/instances/:service_id/:plan_id/:instance_id', instanceRouter);
-router.use('/manage/dashboards/:instance_type/instances/:instance_id', dashboardRouter);
+router.use('/dashboards/:instance_type/instances/:instance_id', dashboardRouter);
 
 /* Service Fabrik Instance Router */
 instanceRouter.use(commonMiddleware.csp());

--- a/broker/lib/fabrik/BaseManager.js
+++ b/broker/lib/fabrik/BaseManager.js
@@ -56,7 +56,7 @@ class BaseManager {
       .chain(config.external)
       .pick('protocol', 'host')
       .set('slashes', true)
-      .set('pathname', `/manage/instances/${this.service.id}/${this.plan.id}/${guid}`)
+      .set('pathname', `/manage/dashboards/${this.plan.manager.name}/instances/${guid}`)
       .value()
     );
   }

--- a/broker/lib/fabrik/DirectorInstance.js
+++ b/broker/lib/fabrik/DirectorInstance.js
@@ -75,7 +75,11 @@ class DirectorInstance extends BaseInstance {
     };
     return Promise
       .all([
-        this.cloudController.getServiceInstance(this.guid),
+        eventmesh.apiServerClient.getResource({
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          resourceId: this.guid
+        }),
         this.initialize(operation).then(() => this.manager.getDeploymentInfo(this.deploymentName))
       ])
       .spread((instance, deploymentInfo) => {

--- a/broker/lib/fabrik/DockerInstance.js
+++ b/broker/lib/fabrik/DockerInstance.js
@@ -7,6 +7,7 @@ const utils = require('../../../common/utils');
 const docker = require('../../../data-access-layer/docker');
 const BaseInstance = require('./BaseInstance');
 const CONST = require('../../../common/constants');
+const eventmesh = require('../../../data-access-layer/eventmesh');
 
 const DockerError = {
   NotFound: {
@@ -115,7 +116,11 @@ class DockerInstance extends BaseInstance {
   getInfo() {
     return Promise
       .all([
-        this.cloudController.getServiceInstance(this.guid),
+        eventmesh.apiServerClient.getResource({
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DOCKER,
+          resourceId: this.guid
+        }),
         this.inspectContainer()
       ])
       .spread((instance, containerInfo) => {

--- a/common/views/mixins/sections.pug
+++ b/common/views/mixins/sections.pug
@@ -25,8 +25,7 @@ mixin showSectionService(service, plan, instance, customAttrs)
           }, customAttrs.plan))
         .col-lg-6
           +renderPropertyListPanel('Service Instance', _.assign({
-            GUID: instance.metadata.guid,
-            Name: instance.entity.name,
+            GUID: instance.metadata.name,
             Manager: plan.manager.name
           }, customAttrs.service_instance))
 
@@ -72,7 +71,6 @@ mixin showSectionParentService(plan, instance)
           })
         .col-lg-6
           +renderPropertyListPanel('Service Instance', {
-            GUID: instance.metadata.guid,
-            Name: instance.entity.name,
+            GUID: instance.metadata.name,
             Manager: plan.manager.name
           })

--- a/test/test_broker/acceptance/dashboard.director.spec.js
+++ b/test/test_broker/acceptance/dashboard.director.spec.js
@@ -158,5 +158,60 @@ describe('dashboard', function () {
       });
 
     });
+
+    // describe('/manage/dashboards/:instance_type/instances/:instance_id', function () {
+    //   this.slow(1500);
+    //   it.only('should redirect to authorization server', function () {
+    //     const agent = chai.request.agent(app);
+    //     agent.app.listen(0);
+    //     mocks.uaa.getAuthorizationCode(service_id);
+    //     mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
+    //     mocks.uaa.getAccessToken();
+    //     mocks.uaa.getUserInfo();
+    //     mocks.cloudController.getServiceInstancePermissions(instance_id);
+    //     mocks.cloudController.findServicePlanByInstanceId(instance_id, service_plan_guid, plan_id, undefined, 1);
+    //     mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, resource, 3);
+    //     mocks.director.getCurrentTasks(deployment_name, [{
+    //       'id': 324,
+    //       'description': 'create deployment succeeded'
+    //     }]);
+    //     mocks.director.getCurrentTaskEvents(324, {});
+    //     return agent
+    //       .get(`/manage/dashboards/director/instances/${instance_id}`)
+    //       .set('Accept', 'application/json')
+    //       .set('X-Forwarded-Proto', 'https')
+    //       .redirects(2)
+    //       .catch(err => err.response)
+    //       .then(res => {
+    //         expect(res).to.have.status(302);
+    //         const location = parseUrl(res.headers.location);
+    //         expect(location.pathname).to.equal('/manage/auth/cf/callback');
+    //         expect(_
+    //           .chain(res.redirects)
+    //           .map(parseUrl)
+    //           .map(url => url.pathname)
+    //           .value()
+    //         ).to.eql([
+    //           '/manage/auth/cf',
+    //           '/oauth/authorize'
+    //         ]);
+    //         return location;
+    //       })
+    //       .then(location => {
+    //         console.log(location);
+    //         return agent
+    //           .get(location.path)
+    //           .set('Accept', 'application/json')
+    //           .set('X-Forwarded-Proto', 'https');
+    //       })
+    //       .then((res, a2) => {
+    //         expect(res.body.userId).to.equal('me');
+    //         expect(res.body.instance.metadata.name).to.equal(instance_id);
+    //         expect(res.body.instance.task.id).to.eql(`${deployment_name}_324`);
+    //         mocks.verify();
+    //       });
+    //   });
+    // });
+
   });
 });

--- a/test/test_broker/acceptance/dashboard.director.spec.js
+++ b/test/test_broker/acceptance/dashboard.director.spec.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const parseUrl = require('url').parse;
 const lib = require('../../../broker/lib');
+const CONST = require('../../../common/constants');
 const app = require('../support/apps').external;
 const fabrik = lib.fabrik;
 
@@ -15,6 +16,38 @@ describe('dashboard', function () {
     const instance_id = 'b4719e7c-e8d3-4f7f-c51c-769ad1c3ebfa';
     const deployment_name = 'service-fabrik-0028-b4719e7c-e8d3-4f7f-c51c-769ad1c3ebfa';
     const service_plan_guid = '466c5078-df6e-427d-8fb2-c76af50c0f56';
+
+    const resource = {
+      apiVersion: 'deployment.servicefabrik.io/v1alpha1',
+      kind: 'Director',
+      metadata: {
+        name: instance_id,
+        labels: {
+          state: 'succeeded'
+        }
+      },
+      spec: {
+        options: JSON.stringify({
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a',
+            space_guid: 'e7c0a437-7585-4d75-addf-aa4d45b49f3a'
+          },
+          organization_guid: 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a',
+          space_guid: 'e7c0a437-7585-4d75-addf-aa4d45b49f3a',
+          parameters: {
+            foo: 'bar'
+          }
+        })
+      },
+      status: {
+        state: 'succeeded',
+        lastOperation: '{}',
+        response: '{}'
+      }
+    };
 
     before(function () {
       _.unset(fabrik.DirectorManager, plan_id);
@@ -35,19 +68,13 @@ describe('dashboard', function () {
         mocks.uaa.getAccessToken();
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
-        mocks.cloudController.getServiceInstance(instance_id);
         mocks.cloudController.findServicePlanByInstanceId(instance_id, service_plan_guid, plan_id, undefined, 2);
-        mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
-          platform: 'cloudfoundry'
-        });
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, resource, 3);
         mocks.director.getCurrentTasks(deployment_name, [{
           'id': 324,
           'description': 'create deployment succeeded'
         }]);
         mocks.director.getCurrentTaskEvents(324, {});
-        mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
-          platform: 'cloudfoundry'
-        });
         return agent
           .get(`/manage/instances/${service_id}/${plan_id}/${instance_id}`)
           .set('Accept', 'application/json')
@@ -76,7 +103,7 @@ describe('dashboard', function () {
           )
           .then(res => {
             expect(res.body.userId).to.equal('me');
-            expect(res.body.instance.metadata.guid).to.equal(instance_id);
+            expect(res.body.instance.metadata.name).to.equal(instance_id);
             expect(res.body.instance.task.id).to.eql(`${deployment_name}_324`);
             mocks.verify();
           });
@@ -89,17 +116,13 @@ describe('dashboard', function () {
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
-        mocks.cloudController.getServiceInstance(instance_id);
         mocks.cloudController.findServicePlanByInstanceId(instance_id, service_plan_guid, plan_id, undefined, 2);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, resource, 3);
         mocks.director.getCurrentTasks(deployment_name, [{
           'id': 324,
           'description': 'create deployment succeeded'
         }]);
         mocks.director.getCurrentTaskEvents(324, {});
-        mocks.director.getDeploymentProperty(deployment_name, false, 'platform-context', undefined);
-        mocks.director.getDeploymentProperty(deployment_name, true, 'platform-context', {
-          platform: 'cloudfoundry'
-        });
         return agent
           .get(`/manage/instances/${service_id}/${plan_id}/${instance_id}`)
           .set('Accept', 'application/json')
@@ -128,7 +151,7 @@ describe('dashboard', function () {
           )
           .then(res => {
             expect(res.body.userId).to.equal('me');
-            expect(res.body.instance.metadata.guid).to.equal(instance_id);
+            expect(res.body.instance.metadata.name).to.equal(instance_id);
             expect(res.body.instance.task.id).to.eql(`${deployment_name}_324`);
             mocks.verify();
           });

--- a/test/test_broker/acceptance/dashboard.docker.spec.js
+++ b/test/test_broker/acceptance/dashboard.docker.spec.js
@@ -120,7 +120,57 @@ describe('dashboard', function () {
             mocks.verify();
           });
       });
+    });
 
+    describe('/manage/dashboards/docker/instances/:instance_id', function () {
+      this.slow(1500);
+      it('should redirect to authorization server', function () {
+        const agent = chai.request.agent(app);
+        agent.app.listen(0);
+        mocks.uaa.getAuthorizationCode(service_id);
+        mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
+        mocks.uaa.getUserInfo();
+        mocks.cloudController.getServiceInstancePermissions(instance_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, resource, 3);
+        mocks.docker.inspectContainer(instance_id);
+        mocks.docker.listContainerProcesses();
+        mocks.docker.getContainerLogs();
+        return agent
+          .get(`/manage/dashboards/docker/instances/${instance_id}`)
+          .set('Accept', 'application/json')
+          .set('X-Forwarded-Proto', 'https')
+          .redirects(2)
+          .catch(err => err.response)
+          .then(res => {
+            expect(res).to.have.status(302);
+            const location = parseUrl(res.headers.location);
+            expect(location.pathname).to.equal('/manage/auth/cf/callback');
+            expect(_
+              .chain(res.redirects)
+              .map(parseUrl)
+              .map(url => url.pathname)
+              .value()
+            ).to.eql([
+              '/manage/auth/cf',
+              '/oauth/authorize'
+            ]);
+            return location;
+          })
+          .then(location => agent
+            .get(location.path)
+            .set('Accept', 'application/json')
+            .set('X-Forwarded-Proto', 'https')
+          )
+          .then(res => {
+            expect(res.body.userId).to.equal('me');
+            expect(res.body.instance.metadata.name).to.equal(instance_id);
+            expect(res.body.processes).to.eql([
+              ['UID', 'PID'],
+              ['root', '13642']
+            ]);
+            mocks.verify();
+          });
+      });
     });
   });
 });

--- a/test/test_broker/acceptance/dashboard.docker.spec.js
+++ b/test/test_broker/acceptance/dashboard.docker.spec.js
@@ -5,6 +5,7 @@ const parseUrl = require('url').parse;
 const lib = require('../../../broker/lib');
 const app = require('../support/apps').external;
 const catalog = require('../../../common/models').catalog;
+const CONST = require('../../../common/constants');
 const docker = require('../../../data-access-layer/docker');
 const fabrik = lib.fabrik;
 
@@ -16,7 +17,41 @@ describe('dashboard', function () {
     const plan_id = '466c5078-df6e-427d-8fb2-c76af50c0f56';
     const instance_id = 'b3e03cb5-29cc-4fcf-9900-023cf149c554';
     const service_plan_guid = '466c5078-df6e-427d-8fb2-c76af50c0f56';
+    const organization_guid = 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a';
+    const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
     const plan = catalog.getPlan(plan_id);
+
+    const resource = {
+      apiVersion: 'deployment.servicefabrik.io/v1alpha1',
+      kind: 'Docker',
+      metadata: {
+        name: instance_id,
+        labels: {
+          state: 'succeeded'
+        }
+      },
+      spec: {
+        options: JSON.stringify({
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          },
+          organization_guid: organization_guid,
+          space_guid: space_guid,
+          parameters: {
+            foo: 'bar'
+          }
+        })
+      },
+      status: {
+        state: 'succeeded',
+        lastOperation: '{}',
+        response: '{}'
+      }
+    };
 
     before(function () {
       _.unset(fabrik.DockerManager, plan_id);
@@ -42,8 +77,8 @@ describe('dashboard', function () {
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
-        mocks.cloudController.getServiceInstance(instance_id);
         mocks.cloudController.findServicePlanByInstanceId(instance_id, service_plan_guid, plan_id, undefined, 2);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DOCKER, instance_id, resource, 1);
         mocks.docker.inspectContainer(instance_id);
         mocks.docker.inspectContainer(instance_id);
         mocks.docker.inspectContainer();
@@ -77,7 +112,7 @@ describe('dashboard', function () {
           )
           .then(res => {
             expect(res.body.userId).to.equal('me');
-            expect(res.body.instance.metadata.guid).to.equal(instance_id);
+            expect(res.body.instance.metadata.name).to.equal(instance_id);
             expect(res.body.processes).to.eql([
               ['UID', 'PID'],
               ['root', '13642']

--- a/test/test_broker/acceptance/dashboard.virtualHost.spec.js
+++ b/test/test_broker/acceptance/dashboard.virtualHost.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const CONST = require('../../../common/constants');
 const parseUrl = require('url').parse;
 const lib = require('../../../broker/lib');
 const app = require('../support/apps').external;
@@ -17,8 +18,11 @@ describe('dashboard', function () {
     const plan_guid = 'f6280923-b144-4f02-adf7-76a7b5ef3a4a';
     const index = mocks.director.networkSegmentIndex;
     const instance_id = mocks.director.uuidByIndex(index);
+    const organization_guid = 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a';
+    const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
     const parent_instance_id = 'b4719e7c-e8d3-4f7f-c515-769ad1c3ebfa';
     const deployment_name = mocks.director.deploymentNameByIndex(index);
+    const instance_name = 'rmq';
     const filename = `virtual_hosts/${instance_id}/${instance_id}.json`;
     const container = virtualHostStore.containerName;
     const pathname = `/${container}/${filename}`;
@@ -26,6 +30,68 @@ describe('dashboard', function () {
       instance_guid: instance_id,
       deployment_name: deployment_name
     };
+
+    const resource1 = {
+      apiVersion: 'deployment.servicefabrik.io/v1alpha1',
+      kind: 'VirtualHost',
+      metadata: {
+        name: instance_id,
+        labels: {
+          state: 'succeeded'
+        }
+      },
+      spec: {
+        options: JSON.stringify({
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          },
+          organization_guid: organization_guid,
+          space_guid: space_guid,
+          parameters: {
+            dedicated_rabbitmq_instance: `${instance_name}`
+          }
+        })
+      },
+      status: {
+        state: 'succeeded',
+        lastOperation: '{}',
+        response: '{}'
+      }
+    };
+
+    const resource2 = {
+      apiVersion: 'deployment.servicefabrik.io/v1alpha1',
+      kind: 'Director',
+      metadata: {
+        name: parent_instance_id,
+        labels: {
+          state: 'succeeded'
+        }
+      },
+      spec: {
+        options: JSON.stringify({
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          },
+          organization_guid: organization_guid,
+          space_guid: space_guid
+        })
+      },
+      status: {
+        state: 'succeeded',
+        lastOperation: '{}',
+        response: '{}'
+      }
+    };
+
     before(function () {
       _.unset(fabrik.VirtualHostManager, plan_id);
       virtualHostStore.cloudProvider = new iaas.CloudProviderClient(config.virtual_host.provider);
@@ -49,9 +115,9 @@ describe('dashboard', function () {
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
-        mocks.cloudController.getServiceInstance(instance_id);
-        mocks.cloudController.getServiceInstance(parent_instance_id);
-        mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id, undefined, 3);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.VIRTUALHOST, instance_id, resource1, 1);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, parent_instance_id, resource2, 1);
+        mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id, undefined, 2);
         mocks.cloudProvider.download(pathname, data);
         return agent
           .get(`/manage/instances/${service_id}/${plan_id}/${instance_id}`)
@@ -81,8 +147,8 @@ describe('dashboard', function () {
           )
           .then(res => {
             expect(res.body.userId).to.equal('me');
-            expect(res.body.instance.metadata.guid).to.equal(instance_id);
-            expect(res.body.parent_instance.metadata.guid).to.equal(parent_instance_id);
+            expect(res.body.instance.metadata.name).to.equal(instance_id);
+            expect(res.body.parent_instance.metadata.name).to.equal(parent_instance_id);
             mocks.verify();
           });
       });

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -49,7 +49,7 @@ describe('service-broker-api-2.0', function () {
       const accepts_incomplete = true;
       const protocol = config.external.protocol;
       const host = config.external.host;
-      const dashboard_url = `${protocol}://${host}/manage/instances/${service_id}/${plan_id}/${instance_id}`;
+      const dashboard_url = `${protocol}://${host}/manage/dashboards/director/instances/${instance_id}`;
       const container = backupStore.containerName;
       const deferred = Promise.defer();
       Promise.onPossiblyUnhandledRejection(() => {});

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -12,7 +12,7 @@ const fabrik = lib.fabrik;
 const ScheduleManager = require('../../../jobs');
 const CONST = require('../../../common/constants');
 const DirectorManager = lib.fabrik.DirectorManager;
-const cloudController = require('../../../data-access-layer/cf').cloudController;
+const apiServerClient = require('../../../data-access-layer/eventmesh').apiServerClient;
 const iaas = require('../../../data-access-layer/iaas');
 const backupStore = iaas.backupStore;
 
@@ -33,7 +33,6 @@ describe('service-broker-api-2.0', function () {
       const api_version = '2.12';
       const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
       const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
-      const service_plan_guid = '466c5078-df6e-427d-8fb2-c76af50c0f56';
       const plan = catalog.getPlan(plan_id);
       const plan_id_deprecated = 'b91d9512-b5c9-4c4a-922a-fa54ae67d235';
       const plan_id_update = 'd616b00a-5949-4b1c-bc73-0d3c59f3954a';
@@ -1327,46 +1326,57 @@ describe('service-broker-api-2.0', function () {
       });
 
       describe('#getInfo', function () {
-        let sandbox, getDeploymentInfoStub, getServiceInstanceStub, getServicePlanStub;
+        let sandbox, getDeploymentInfoStub, getResourceStub;
+
+        const resource = {
+          apiVersion: 'deployment.servicefabrik.io/v1alpha1',
+          kind: 'Director',
+          metadata: {
+            name: instance_id,
+            labels: {
+              state: 'succeeded'
+            }
+          },
+          spec: {
+            options: {
+              service_id: service_id,
+              plan_id: plan_id,
+              context: {
+                platform: 'cloudfoundry',
+                organization_guid: 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a',
+                space_guid: 'e7c0a437-7585-4d75-addf-aa4d45b49f3a'
+              },
+              organization_guid: 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a',
+              space_guid: 'e7c0a437-7585-4d75-addf-aa4d45b49f3a',
+              parameters: {
+                foo: 'bar'
+              }
+            }
+          },
+          status: {
+            state: 'succeeded',
+            lastOperation: {},
+            response: {}
+          }
+        };
         before(function () {
           sandbox = sinon.sandbox.create();
           getDeploymentInfoStub = sandbox.stub(DirectorManager.prototype, 'getDeploymentInfo');
-          getServiceInstanceStub = sandbox.stub(cloudController, 'getServiceInstance');
-          getServicePlanStub = sandbox.stub(cloudController, 'getServicePlan');
+          getResourceStub = sandbox.stub(apiServerClient, 'getResource');
 
-          let entity = {};
-          getServiceInstanceStub
-            .withArgs(instance_id)
-            .returns(Promise.try(() => {
-              return {
-                metadata: {
-                  guid: instance_id
-                },
-                entity: _.assign({
-                  name: 'blueprint',
-                  service_plan_guid: '466c5078-df6e-427d-8fb2-c76af50c0f56'
-                }, entity)
-              };
-            }));
+          getResourceStub
+            .withArgs({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+              resourceId: instance_id
+            })
+            .returns(Promise.try(() => resource));
 
           getDeploymentInfoStub
             .withArgs(deployment_name)
             .returns(Promise.try(() => {
               return {};
             }));
-
-          entity = {};
-          getServicePlanStub
-            .withArgs(service_plan_guid, {})
-            .returns(Promise.try(() => {
-              return {
-                entity: _.assign({
-                  unique_id: plan_id,
-                  name: 'blueprint'
-                }, entity)
-              };
-            }));
-
         });
 
         after(function () {
@@ -1385,7 +1395,7 @@ describe('service-broker-api-2.0', function () {
               expect(res.title).to.equal('Blueprint Dashboard');
               expect(res.plan.id).to.equal(plan_id);
               expect(res.service.id).to.equal(service_id);
-              expect(res.instance.metadata.guid).to.equal(instance_id);
+              expect(res.instance.metadata.name).to.equal(instance_id);
             });
         });
       });

--- a/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
@@ -10,8 +10,6 @@ const fabrik = lib.fabrik;
 const iaas = require('../../../data-access-layer/iaas');
 const backupStore = iaas.backupStore;
 const ScheduleManager = require('../../../jobs');
-const DirectorManager = lib.fabrik.DirectorManager;
-const cloudController = require('../../../data-access-layer/cf').cloudController;
 
 describe('service-broker-api', function () {
   describe('instances', function () {
@@ -22,12 +20,10 @@ describe('service-broker-api', function () {
       const api_version = '2.12';
       const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
       const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
-      const service_plan_guid = '466c5078-df6e-427d-8fb2-c76af50c0f56';
       const plan = catalog.getPlan(plan_id);
       const organization_guid = 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a';
       const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
       const instance_id = mocks.director.uuidByIndex(index);
-      const deployment_name = mocks.director.deploymentNameByIndex(index);
       const parameters = {
         foo: 'bar'
       };
@@ -214,71 +210,6 @@ describe('service-broker-api', function () {
 
       });
 
-      describe('#getInfo', function () {
-
-        let sandbox, getDeploymentInfoStub, getServiceInstanceStub, getServicePlanStub;
-
-        before(function () {
-          sandbox = sinon.sandbox.create();
-          getDeploymentInfoStub = sandbox.stub(DirectorManager.prototype, 'getDeploymentInfo');
-          getServiceInstanceStub = sandbox.stub(cloudController, 'getServiceInstance');
-          getServicePlanStub = sandbox.stub(cloudController, 'getServicePlan');
-
-          let entity = {};
-          getServiceInstanceStub
-            .withArgs(instance_id)
-            .returns(Promise.try(() => {
-              return {
-                metadata: {
-                  guid: instance_id
-                },
-                entity: _.assign({
-                  name: 'blueprint',
-                  service_plan_guid: '466c5078-df6e-427d-8fb2-c76af50c0f56'
-                }, entity)
-              };
-            }));
-
-          getDeploymentInfoStub
-            .withArgs(deployment_name)
-            .returns(Promise.try(() => {
-              return {};
-            }));
-
-          entity = {};
-          getServicePlanStub
-            .withArgs(service_plan_guid, {})
-            .returns(Promise.try(() => {
-              return {
-                entity: _.assign({
-                  unique_id: plan_id,
-                  name: 'blueprint'
-                }, entity)
-              };
-            }));
-
-        });
-
-        after(function () {
-          sandbox.restore();
-        });
-
-        it('should return object with correct plan and service information', function () {
-          let context = {
-            platform: 'cloudfoundry'
-          };
-          return fabrik
-            .createInstance(instance_id, service_id, plan_id, context)
-            .then(instance => instance.getInfo())
-            .catch(err => err.response)
-            .then(res => {
-              expect(res.title).to.equal('Blueprint Dashboard');
-              expect(res.plan.id).to.equal(plan_id);
-              expect(res.service.id).to.equal(service_id);
-              expect(res.instance.metadata.guid).to.equal(instance_id);
-            });
-        });
-      });
     });
   });
 });

--- a/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
@@ -302,7 +302,9 @@ describe('service-broker-api', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(200);
-              expect(res.body).to.eql({});
+              expect(res.body).to.eql({
+                dashboard_url: `${protocol}://${host}/manage/instances/${service_id}/${plan_id}/${instance_id}`
+              });
               mocks.verify();
             });
         });
@@ -330,7 +332,9 @@ describe('service-broker-api', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(200);
-              expect(res.body).to.eql({});
+              expect(res.body).to.eql({
+                dashboard_url: `${protocol}://${host}/manage/instances/${service_id}/${plan_id}/${instance_id}`
+              });
               mocks.verify();
             });
         });

--- a/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
@@ -213,7 +213,7 @@ describe('service-broker-api', function () {
             .then(res => {
               expect(res).to.have.status(201);
               expect(res.body).to.eql({
-                dashboard_url: `${protocol}://${host}/manage/instances/${service_id}/${plan_id}/${instance_id}`
+                dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
               });
               mocks.verify();
             });
@@ -241,7 +241,7 @@ describe('service-broker-api', function () {
             .then(res => {
               expect(res).to.have.status(201);
               expect(res.body).to.eql({
-                dashboard_url: `${protocol}://${host}/manage/instances/${service_id}/${plan_id}/${instance_id}`
+                dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
               });
               mocks.verify();
             });
@@ -268,7 +268,7 @@ describe('service-broker-api', function () {
             .then(res => {
               expect(res).to.have.status(201);
               expect(res.body).to.eql({
-                dashboard_url: `${protocol}://${host}/manage/instances/${service_id}/${plan_id}/${instance_id}`
+                dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
               });
               mocks.verify();
             });
@@ -303,7 +303,7 @@ describe('service-broker-api', function () {
             .then(res => {
               expect(res).to.have.status(200);
               expect(res.body).to.eql({
-                dashboard_url: `${protocol}://${host}/manage/instances/${service_id}/${plan_id}/${instance_id}`
+                dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
               });
               mocks.verify();
             });
@@ -333,7 +333,7 @@ describe('service-broker-api', function () {
             .then(res => {
               expect(res).to.have.status(200);
               expect(res.body).to.eql({
-                dashboard_url: `${protocol}://${host}/manage/instances/${service_id}/${plan_id}/${instance_id}`
+                dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
               });
               mocks.verify();
             });

--- a/test/test_broker/acceptance/service-broker-api.instances.virtualHost.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.virtualHost.spec.js
@@ -27,7 +27,7 @@ describe('service-broker-api', function () {
       const accepts_incomplete = true;
       const protocol = config.external.protocol;
       const host = config.external.host;
-      const dashboard_url = `${protocol}://${host}/manage/instances/${service_id}/${plan_id}/${instance_id}`;
+      const dashboard_url = `${protocol}://${host}/manage/dashboards/virtual_host/instances/${instance_id}`;
       const context = {
         platform: 'cloudfoundry',
         organization_guid: organization_guid,

--- a/test/test_broker/mocks/uaa.js
+++ b/test/test_broker/mocks/uaa.js
@@ -100,7 +100,7 @@ function tokenKey() {
     });
 }
 
-function getAuthorizationCode(service_id) {
+function getAuthorizationCode(service_id, times) {
   const dashboard_client = catalog.getService(service_id).dashboard_client;
   return nock(authorizationEndpointUrl)
     .get('/oauth/authorize')
@@ -115,6 +115,7 @@ function getAuthorizationCode(service_id) {
       })
       .value()
     )
+    .times(times || 1)
     .reply(302, null, {
       location: req => `${redirect_uri}?code=${authorizationCode}&state=${parseUrl(req.path, true).query.state}`
     });


### PR DESCRIPTION
Dashboard url according to osb api spec is also part of response body in PATCH request. So, when update of service instance is done with new plan or with any parameter, the **dashboard_url** is also updated in response body. which was not happening earlier.
Also format of the dashboard is changed and old dashboard support is sustained in parallel. Idea to make internal methods platform agnostic.