### PR TITLE
Added code for bosh resilience in create, update and delete flow.

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -385,5 +385,6 @@ module.exports = Object.freeze({
   },
   DOCKER_HOST_CONFIG: {
     PIDS_LIMIT: 150
-  }
+  },
+  SYSTEM_ERRORS: ['ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'ESOCKETTIMEDOUT']
 });

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -306,7 +306,8 @@ class BoshDirectorClient extends HttpClient {
     return Promise
       .map(this.primaryConfigs,
         (directorConfig) => this.getDeploymentsByConfig(directorConfig))
-      .reduce((all_deployments, deployments) => all_deployments.concat(deployments), []);
+      .reduce((all_deployments, deployments) => all_deployments.concat(deployments), [])
+      .catch(err => this.convertHttpErrorAndThrow(err));
   }
 
   getDeploymentNameForInstanceId(guid) {
@@ -354,8 +355,7 @@ class BoshDirectorClient extends HttpClient {
         .compact()
         .uniq()
         .value()
-      )
-      .catch(err => this.convertHttperrorAndThrow(err));
+      );
   }
 
   getDeployment(deploymentName) {
@@ -500,7 +500,7 @@ class BoshDirectorClient extends HttpClient {
           })
           .then(res => this.prefixTaskId(deploymentName, res));
       })
-      .catch(err => this.convertHttperrorAndThrow(err));
+      .catch(err => this.convertHttpErrorAndThrow(err));
   }
 
   deleteDeployment(deploymentName) {
@@ -511,7 +511,7 @@ class BoshDirectorClient extends HttpClient {
         url: `/deployments/${deploymentName}`
       }, 302, deploymentName)
       .then(res => this.prefixTaskId(deploymentName, res))
-      .catch(err => this.convertHttperrorAndThrow(err));
+      .catch(err => this.convertHttpErrorAndThrow(err));
   }
 
   /* VirtualMachines operations */
@@ -530,7 +530,8 @@ class BoshDirectorClient extends HttpClient {
         method: 'GET',
         url: `/deployments/${deploymentName}/instances`
       }, 200, deploymentName)
-      .then(res => JSON.parse(res.body));
+      .then(res => JSON.parse(res.body))
+      .catch(err => this.convertHttpErrorAndThrow(err));
   }
 
   /* Property operations */
@@ -617,8 +618,7 @@ class BoshDirectorClient extends HttpClient {
       .tap(response => {
         logger.info(`Cached Ips for deployment - ${deploymentName} - `, response);
         this.deploymentIpsCache[deploymentName] = response;
-      })
-      .catch(err => this.convertHttperrorAndThrow(err));
+      });
   }
 
   getAgentPropertiesFromManifest(deploymentName) {
@@ -822,7 +822,8 @@ class BoshDirectorClient extends HttpClient {
             return task;
           });
       })
-      .reduce((all_tasks, tasks) => all_tasks.concat(tasks), []);
+      .reduce((all_tasks, tasks) => all_tasks.concat(tasks), [])
+      .catch(err => this.convertHttpErrorAndThrow(err));
   }
 
   getTask(taskId) {
@@ -974,7 +975,7 @@ class BoshDirectorClient extends HttpClient {
     return _.last(parseUrl(url).path.split('/'));
   }
 
-  convertHttperrorAndThrow(err) {
+  convertHttpErrorAndThrow(err) {
     if ((err instanceof InternalServerError) || _.includes(CONST.SYSTEM_ERRORS, err.code)) {
       throw new ServiceUnavailable(err.message);
     } else {

--- a/operators/bosh-operator/BoshOperator.js
+++ b/operators/bosh-operator/BoshOperator.js
@@ -109,7 +109,7 @@ class BoshOperator extends BaseOperator {
         resourceId: _.get(changeObjectBody, 'metadata.name'),
         status: {
           response: response,
-          state: CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS
+          state: _.get(response, 'task_id') ? CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS : CONST.APISERVER.RESOURCE_STATE.WAITING
         }
       }))
       .catch(ServiceInstanceNotFound, () => eventmesh.apiServerClient.deleteResource({

--- a/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
+++ b/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
@@ -24,18 +24,16 @@ class BoshStaggeredDeploymentPoller extends BaseStatusPoller {
     const instanceId = resourceBody.metadata.name;
     const resourceOptions = _.get(resourceBody, 'spec.options');
     const deploymentName = _.get(resourceBody, 'status.response.deployment_name');
+    const operationType = _.get(resourceBody, 'status.response.type');
     return DirectorService
       .createInstance(instanceId, resourceOptions)
       .then(directorService => {
-        if (deploymentName) {
-          return directorService.createOrUpdateDeployment(deploymentName, resourceOptions);
-        } else {
-          const type = _.get(resourceBody, 'status.response.type');
-          if (type === CONST.OPERATION_TYPE.CREATE) {
-            return directorService.create(resourceOptions);
-          } else if (type === CONST.OPERATION_TYPE.UPDATE) {
-            return directorService.update(resourceOptions);
-          }
+        if (operationType === CONST.OPERATION_TYPE.CREATE) {
+          return directorService.create(resourceOptions, deploymentName);
+        } else if (operationType === CONST.OPERATION_TYPE.UPDATE) {
+          return directorService.update(resourceOptions, deploymentName);
+        } else if (operationType === CONST.OPERATION_TYPE.DELETE) {
+          return directorService.delete(resourceOptions, deploymentName);
         }
       })
       .then(directorResponse => {

--- a/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
+++ b/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
@@ -26,7 +26,18 @@ class BoshStaggeredDeploymentPoller extends BaseStatusPoller {
     const deploymentName = _.get(resourceBody, 'status.response.deployment_name');
     return DirectorService
       .createInstance(instanceId, resourceOptions)
-      .then(directorService => directorService.createOrUpdateDeployment(deploymentName, resourceOptions))
+      .then(directorService => {
+        if (deploymentName) {
+          return directorService.createOrUpdateDeployment(deploymentName, resourceOptions);
+        } else {
+          const type = _.get(resourceBody, 'status.response.type');
+          if (type === CONST.OPERATION_TYPE.CREATE) {
+            return directorService.create(resourceOptions);
+          } else if (type === CONST.OPERATION_TYPE.UPDATE) {
+            return directorService.update(resourceOptions);
+          }
+        }
+      })
       .then(directorResponse => {
         if (_.get(directorResponse, 'task_id')) {
           return Promise.all([eventmesh.apiServerClient.updateResource({

--- a/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
+++ b/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
@@ -28,11 +28,12 @@ class BoshStaggeredDeploymentPoller extends BaseStatusPoller {
     return DirectorService
       .createInstance(instanceId, resourceOptions)
       .then(directorService => {
-        if (operationType === CONST.OPERATION_TYPE.CREATE) {
+        switch (operationType) {
+        case CONST.OPERATION_TYPE.CREATE:
           return directorService.create(resourceOptions, deploymentName);
-        } else if (operationType === CONST.OPERATION_TYPE.UPDATE) {
+        case CONST.OPERATION_TYPE.UPDATE:
           return directorService.update(resourceOptions, deploymentName);
-        } else if (operationType === CONST.OPERATION_TYPE.DELETE) {
+        case CONST.OPERATION_TYPE.DELETE:
           return directorService.delete(resourceOptions, deploymentName);
         }
       })

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -247,8 +247,13 @@ class DirectorService extends BaseDirectorService {
     };
     return this
       .initialize(operation)
-      .catch(err => logger.error(`Error occurred while finding network index for update
-        and instance guid :${this.guid}`, err))
+      .catch(err => {
+        logger.error(`Error occurred while finding network index for update
+        and instance guid :${this.guid}`, err);
+        if (err instanceof errors.ServiceInstanceNotFound) {
+          throw err;
+        }
+      })
       .then(() => {
         logger.info('Parameters for update operation:', _.get(params, 'parameters'));
         this.operation = this.operation || 'update';

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -9,6 +9,8 @@ const config = require('../../common/config');
 const logger = require('../../common/logger');
 const NotFound = errors.NotFound;
 const BadRequest = errors.BadRequest;
+const InternalServerError = errors.InternalServerError;
+const ServiceUnavailable = errors.ServiceUnavailable;
 const BoshDirectorClient = require('../../data-access-layer/bosh/BoshDirectorClient');
 const utils = require('../../common/utils');
 const HttpClient = utils.HttpClient;
@@ -42,42 +44,69 @@ class MockBoshDirectorClient extends BoshDirectorClient {
   }
 
   makeRequest(options, expectedStatusCode) {
-    switch (this.res.statusCode) {
-    case 400:
-      this.res.statusCode = 204;
-      return Promise.reject(new BadRequest(''));
-    case 404:
-      this.res.statusCode = 204;
-      return Promise.reject(new NotFound(''));
-    default:
-      expect(expectedStatusCode).to.equal(this.res.statusCode);
-      expect(_.omit(options, 'body')).to.eql(_.omit(this.req, 'body'));
+    if (this.res.statusCode && !this.res.code) {
+      switch (this.res.statusCode) {
+      case 400:
+        this.res.statusCode = 204;
+        return Promise.reject(new BadRequest(''));
+      case 404:
+        this.res.statusCode = 204;
+        return Promise.reject(new NotFound(''));
+      case 502:
+      case 503:
+      case 500:
+        this.res.statusCode = 500;
+        return Promise.reject(new InternalServerError(''));
+      default:
+        expect(expectedStatusCode).to.equal(this.res.statusCode);
+        expect(_.omit(options, 'body')).to.eql(_.omit(this.req, 'body'));
 
-      return Promise.resolve({
-        body: this.res.body,
-        statusCode: this.res.statusCode,
-        headers: this.res.headers
-      });
+        return Promise.resolve({
+          body: this.res.body,
+          statusCode: this.res.statusCode,
+          headers: this.res.headers
+        });
+      }
+    }
+    switch (this.res.code) {
+    case 'ECONNREFUSED':
+      let e = new Error('ECONNREFUSED');
+      e.code = 'ECONNREFUSED';
+      throw e;
     }
   }
 
   makeRequestWithConfig(options, expectedStatusCode) {
-    switch (this.res.statusCode) {
-    case 400:
-      this.res.statusCode = 204;
-      return Promise.reject(new BadRequest(''));
-    case 404:
-      this.res.statusCode = 204;
-      return Promise.reject(new NotFound(''));
-    default:
-      expect(expectedStatusCode).to.equal(this.res.statusCode);
-      expect(_.omit(options, 'body')).to.eql(_.omit(this.req, 'body'));
+    if (this.res.statusCode && !this.res.code) {
+      switch (this.res.statusCode) {
+      case 400:
+        this.res.statusCode = 204;
+        return Promise.reject(new BadRequest(''));
+      case 404:
+        this.res.statusCode = 204;
+        return Promise.reject(new NotFound(''));
+      case 502:
+      case 503:
+      case 500:
+        this.res.statusCode = 500;
+        return Promise.reject(new InternalServerError(''));
+      default:
+        expect(expectedStatusCode).to.equal(this.res.statusCode);
+        expect(_.omit(options, 'body')).to.eql(_.omit(this.req, 'body'));
 
-      return Promise.resolve({
-        body: this.res.body,
-        statusCode: this.res.statusCode,
-        headers: this.res.headers
-      });
+        return Promise.resolve({
+          body: this.res.body,
+          statusCode: this.res.statusCode,
+          headers: this.res.headers
+        });
+      }
+    }
+
+    switch (this.res.code) {
+    case 'ECONNREFUSED':
+      let e = new Error('ECONNREFUSED');
+      e.code = 'ECONNREFUSED';
+      throw e;
     }
   }
 
@@ -313,6 +342,21 @@ describe('bosh', () => {
         clock.tick(500);
         return deployments;
       });
+
+      it('returns ServiceUnavailable error: 503', (done) => {
+        let request = {
+          method: 'GET',
+          url: '/deployments'
+        };
+        let response = {
+          statusCode: 503
+        };
+        new MockBoshDirectorClient(request, response).getDeployments()
+          .catch((res) => {
+            expect(res instanceof ServiceUnavailable).to.eql(true);
+            done();
+          }).catch(done);
+      });
     });
 
     describe('#getDeployment', () => {
@@ -443,6 +487,7 @@ describe('bosh', () => {
           })
           .catch(done);
       });
+
       it('returns an integer (task-id): user-triggered update', (done) => {
         let taskId = Math.floor(Math.random() * 123456789);
         let request = {
@@ -472,6 +517,53 @@ describe('bosh', () => {
           })
           .catch(done);
       });
+
+      it('returns service unavailable exception: ECONNREFUSED : user-triggered update', (done) => {
+        let request = {
+          method: 'POST',
+          url: '/deployments',
+          headers: {
+            'Content-Type': 'text/yaml',
+            'X-Bosh-Context-Id': 'Fabrik::Operation::update'
+          },
+          qs: undefined,
+          body: manifest
+        };
+        let response = {
+          code: 'ECONNREFUSED'
+        };
+        new MockBoshDirectorClient(request, response)
+          .createOrUpdateDeployment(CONST.OPERATION_TYPE.UPDATE, manifest)
+          .catch((res) => {
+            expect(res instanceof ServiceUnavailable).to.eql(true);
+            done();
+          })
+          .catch(done);
+      });
+
+      it('returns service unavailable exception: 502 : user-triggered update', (done) => {
+        let request = {
+          method: 'POST',
+          url: '/deployments',
+          headers: {
+            'Content-Type': 'text/yaml',
+            'X-Bosh-Context-Id': 'Fabrik::Operation::update'
+          },
+          qs: undefined,
+          body: manifest
+        };
+        let response = {
+          statusCode: 502
+        };
+        new MockBoshDirectorClient(request, response)
+          .createOrUpdateDeployment(CONST.OPERATION_TYPE.UPDATE, manifest)
+          .catch((res) => {
+            expect(res instanceof ServiceUnavailable).to.eql(true);
+            done();
+          })
+          .catch(done);
+      });
+
     });
 
     describe('#deleteDeployment', () => {
@@ -496,6 +588,23 @@ describe('bosh', () => {
           done();
         }).catch(done);
       });
+
+      it('returns ServiceUnavailable: 502', (done) => {
+        let request = {
+          method: 'DELETE',
+          url: `/deployments/${deployment_name}`
+        };
+        let response = {
+          statusCode: 502
+        };
+
+        new MockBoshDirectorClient(request, response).deleteDeployment(id)
+          .catch((res) => {
+            expect(res instanceof ServiceUnavailable).to.eql(true);
+            done();
+          }).catch(done);
+      });
+
     });
 
     describe('#getDeploymentVms', () => {
@@ -538,6 +647,34 @@ describe('bosh', () => {
         return new MockBoshDirectorClient(request, response)
           .getDeploymentInstances(id)
           .then(body => expect(body).to.eql(vms));
+      });
+
+      it('returns Service Unavailable Error: 503', () => {
+        let request = {
+          method: 'GET',
+          url: `/deployments/${id}/instances`
+        };
+        let response = {
+          statusCode: 503
+        };
+
+        return new MockBoshDirectorClient(request, response)
+          .getDeploymentInstances(id)
+          .catch(res => expect(res instanceof ServiceUnavailable).to.eql(true));
+      });
+
+      it('returns Service Unavailable Error: 500', () => {
+        let request = {
+          method: 'GET',
+          url: `/deployments/${id}/instances`
+        };
+        let response = {
+          statusCode: 500
+        };
+
+        return new MockBoshDirectorClient(request, response)
+          .getDeploymentInstances(id)
+          .catch(res => expect(res instanceof ServiceUnavailable).to.eql(true));
       });
     });
 
@@ -803,6 +940,27 @@ describe('bosh', () => {
           let body = JSON.parse(response.body)[0];
           body.id = `${deployment_name}_${body.id}`;
           expect(content).to.eql([body]);
+          done();
+        }).catch(done);
+      });
+
+      it('returns Service Unavailable Error : 500', (done) => {
+        let request = {
+          method: 'GET',
+          url: '/tasks',
+          qs: {
+            deployment: deployment_name,
+            limit: 1000
+          }
+        };
+        let response = {
+          statusCode: 500
+        };
+
+        new MockBoshDirectorClient(request, response).getTasks({
+          deployment: deployment_name
+        }).catch((res) => {
+          expect(res instanceof ServiceUnavailable).to.eql(true);
           done();
         }).catch(done);
       });

--- a/test/test_broker/operators.DirectorService.ratelimits.spec.js
+++ b/test/test_broker/operators.DirectorService.ratelimits.spec.js
@@ -303,6 +303,16 @@ describe('service', () => {
         });
     });
 
+    it('should not update without rate limits - fails due to exception', () => {
+      initializeSpy.returns(Promise.reject(new errors.ServiceInstanceNotFound()));
+      directorService.networkSegmentIndex = undefined;
+      return directorService.update(params)
+        .catch(err => {
+          expect(err instanceof errors.ServiceInstanceNotFound).to.eql(true);
+          expect(codSpy.callCount).to.eql(0);
+        });
+    });
+
     it('should update without rate limits - internal operation', () => {
       return directorService.update(internal_params).then(out => {
         let expectedParams = _.cloneDeep(params);


### PR DESCRIPTION
This is to address bosh resilience. In create and update flow if bosh is not reachable during acquire or find network segment index respectively, the deployments should be staggered.  The staggered deployments would tried out later in BoshStaggeredDeploymentPoller. The same thing is done for delete deployment as well.