### PR TITLE
New admin API to get Instances with updates scheduled

### DIFF
--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -763,7 +763,7 @@ class ServiceFabrikAdminController extends FabrikBaseController {
         .send(body));
   }
 
-  //Method for getting backup instance ids
+  //Method for getting  instance ids with updates scheduled
   getScheduledUpdateInstances(req, res) {
     logger.info('Getting scheduled update instance list...');
     return getInstancesWithUpdateScheduled()

--- a/api-controllers/routes/admin.js
+++ b/api-controllers/routes/admin.js
@@ -71,6 +71,9 @@ router.route('/service-fabrik/maintenance')
   .put(controller.handler('updateMaintenance'))
   .get(controller.handler('getMaintenance'))
   .all(commonMiddleware.methodNotAllowed(['GET', 'POST', 'PUT']));
+router.route('/update/schedules')
+  .get(controller.handler('getScheduledUpdateInstances'))
+  .all(commonMiddleware.methodNotAllowed(['GET']));
 
 
 router.use(commonMiddleware.notFound());

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -691,8 +691,7 @@ describe('eventmesh', () => {
 
       it('Gets resource list by state', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 200);
+          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 200);
         return apiserver.getResourceListByState({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
@@ -706,8 +705,7 @@ describe('eventmesh', () => {
 
       it('Gets resource list by state with empy array', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          [CONST.APISERVER.RESOURCE_STATE.WAITING], [], 1, 200);
+          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [], 1, 200);
         return apiserver.getResourceListByState({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
@@ -721,8 +719,7 @@ describe('eventmesh', () => {
 
       it('Gets resource list by state: error', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 404);
+          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 404);
         return apiserver.getResourceListByState({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,

--- a/test/test_broker/operators.DirectorService.ratelimits.spec.js
+++ b/test/test_broker/operators.DirectorService.ratelimits.spec.js
@@ -414,8 +414,7 @@ describe('manager', () => {
     describe('#acquireNetworkSegmentIndex', () => {
       it('should return network segment index when there are deployment names in cache', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 200);
+          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 200);
         getDirectorDeploymentsSpy.returns([`service-fabrik-90-${used_guid}`]);
         return service.acquireNetworkSegmentIndex('guid')
           .then(index => {


### PR DESCRIPTION
- A new admin API is introduced which queries records from job schema and fetches all backing service instances that have updates already scheduled.