### PR TITLE
Add a new admin endpoint to return all instances with updates scheduled.

### DIFF
--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -766,10 +766,41 @@ class ServiceFabrikAdminController extends FabrikBaseController {
   //Method for getting  instance ids with updates scheduled
   getScheduledUpdateInstances(req, res) {
     logger.info('Getting scheduled update instance list...');
-    return getInstancesWithUpdateScheduled()
+    return ServiceFabrikAdminController.getInstancesWithUpdateScheduled()
       .then(body => res
         .status(200)
         .send(body));
+  }
+
+  static getInstancesWithUpdateScheduled() {
+    function getInstancesWithUpdateScheduled(instanceList, offset, modelName, searchCriteria, paginateOpts) {
+      if (offset < 0) {
+        return Promise.resolve();
+      }
+      _.chain(paginateOpts)
+        .set('offset', offset)
+        .value();
+      return Repository.search(modelName, searchCriteria, paginateOpts)
+        .then((result) => {
+          instanceList.push.apply(instanceList, _.map(result.list, 'data'));
+          return getInstancesWithUpdateScheduled(instanceList, result.nextOffset, modelName, searchCriteria, paginateOpts);
+        });
+    }
+    const criteria = {
+      searchBy: {
+        type: CONST.JOB.SERVICE_INSTANCE_UPDATE
+      },
+      projection: {
+        'data.instance_id': 1
+      }
+    };
+    const paginateOpts = {
+      records: config.mongodb.record_max_fetch_count,
+      offset: 0
+    };
+    const result = [];
+    return getInstancesWithUpdateScheduled(result, 0, CONST.DB_MODEL.JOB, criteria, paginateOpts)
+      .then(() => result);
   }
 }
 
@@ -813,35 +844,4 @@ function registerOperationCompletionStatusPoller(deploymentName, operationName,
         name: config.cf.username
       }
     );
-}
-
-function getInstancesWithUpdateScheduled() {
-  function getInstancesWithUpdateScheduled(instanceList, offset, modelName, searchCriteria, paginateOpts) {
-    if (offset < 0) {
-      return Promise.resolve();
-    }
-    _.chain(paginateOpts)
-      .set('offset', offset)
-      .value();
-    return Repository.search(modelName, searchCriteria, paginateOpts)
-      .then((result) => {
-        instanceList.push.apply(instanceList, _.map(result.list, 'data'));
-        return getInstancesWithUpdateScheduled(instanceList, result.nextOffset, modelName, searchCriteria, paginateOpts);
-      });
-  }
-  const criteria = {
-    searchBy: {
-      type: CONST.JOB.SERVICE_INSTANCE_UPDATE
-    },
-    projection: {
-      'data.instance_id': 1,
-    }
-  };
-  const paginateOpts = {
-    records: config.mongodb.record_max_fetch_count,
-    offset: 0
-  };
-  const result = [];
-  return getInstancesWithUpdateScheduled(result, 0, CONST.DB_MODEL.JOB, criteria, paginateOpts)
-    .then(() => result);
 }

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -763,7 +763,7 @@ class ServiceFabrikAdminController extends FabrikBaseController {
         .send(body));
   }
 
-  //Method for getting backup instance ids
+  //Method for getting  instance ids with updates scheduled
   getScheduledUpdateInstances(req, res) {
     logger.info('Getting scheduled update instance list...');
     return getInstancesWithUpdateScheduled()

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -766,13 +766,13 @@ class ServiceFabrikAdminController extends FabrikBaseController {
   //Method for getting  instance ids with updates scheduled
   getScheduledUpdateInstances(req, res) {
     logger.info('Getting scheduled update instance list...');
-    return ServiceFabrikAdminController.getInstancesWithUpdateScheduled()
+    return this.getInstancesWithUpdateScheduled()
       .then(body => res
         .status(200)
         .send(body));
   }
 
-  static getInstancesWithUpdateScheduled() {
+  getInstancesWithUpdateScheduled() {
     function getInstancesWithUpdateScheduled(instanceList, offset, modelName, searchCriteria, paginateOpts) {
       if (offset < 0) {
         return Promise.resolve();

--- a/api-controllers/routes/admin.js
+++ b/api-controllers/routes/admin.js
@@ -71,6 +71,9 @@ router.route('/service-fabrik/maintenance')
   .put(controller.handler('updateMaintenance'))
   .get(controller.handler('getMaintenance'))
   .all(commonMiddleware.methodNotAllowed(['GET', 'POST', 'PUT']));
+router.route('/update/schedules')
+  .get(controller.handler('getScheduledUpdateInstances'))
+  .all(commonMiddleware.methodNotAllowed(['GET']));
 
 
 router.use(commonMiddleware.notFound());

--- a/api-controllers/routes/admin.js
+++ b/api-controllers/routes/admin.js
@@ -71,7 +71,7 @@ router.route('/service-fabrik/maintenance')
   .put(controller.handler('updateMaintenance'))
   .get(controller.handler('getMaintenance'))
   .all(commonMiddleware.methodNotAllowed(['GET', 'POST', 'PUT']));
-router.route('/update/schedules')
+router.route('/instances/update/schedules')
   .get(controller.handler('getScheduledUpdateInstances'))
   .all(commonMiddleware.methodNotAllowed(['GET']));
 

--- a/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const _ = require('lodash');
+const app = require('../support/apps').internal;
+const config = require('../../../common/config');
+const proxyquire = require('proxyquire');
+const CONST = require('../../../common/constants');
+const ServiceFabrikAdminController = require('../../../api-controllers/ServiceFabrikAdminController');
+const numOfInstances = 2 * config.mongodb.record_max_fetch_count;
+
+const getInstance = (instanceId) => {
+  return Promise.resolve({
+    _id: `${instanceId}-12121`,
+    data: {
+      instance_id: instanceId
+    }
+  });
+};
+const instanceId = '9999-8888-7777-6666';
+const repositoryStub = {
+  search: () => undefined
+};
+const listOfInstances = [];
+
+for (let i = 1; i <= numOfInstances; i++) {
+  let instance = getInstance(`${instanceId}-${i}`).value();
+  listOfInstances.push(instance);
+}
+
+class Repository {
+  static search(model, searchCriteria, paginateOpts) {
+    let returnedList = [];
+    {
+      returnedList = listOfInstances;
+      repositoryStub.search(arguments);
+      return Promise.try(() => {
+        let nextOffset = paginateOpts.offset + paginateOpts.records;
+        nextOffset = nextOffset >= numOfInstances ? -1 : nextOffset;
+        return {
+          list: _.slice(returnedList, paginateOpts.offset, paginateOpts.offset + paginateOpts.records),
+          totalRecordCount: 10,
+          nextOffset: nextOffset
+        };
+      });
+    }
+  }
+}
+
+describe('service-fabrik-admin', function () {
+  const base_url = '/admin';
+
+    describe('#getScheduledUpdateInstances', function () {
+
+      before(function () {
+        sinon.stub(ServiceFabrikAdminController, 'getInstancesWithUpdateScheduled').returns(Promise.resolve([{instance_id : '9999-8888-7777-6666'},{instance_id : '5555-4444-3333-2222'}]));
+      });
+    
+      it.only('should list all instances with updates scheduled', function () {
+        return chai
+          .request(app)
+          .get(`${base_url}/update/schedules`)
+          .set('Accept', 'application/json')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            expect(res.body).to.have.length(2);
+            expect(res).to.have.status(200);
+          });
+      });
+      });
+
+      describe('#getInstancesWithUpdateScheduled', function () {
+        const adminController = proxyquire('../../../api-controllers/ServiceFabrikAdminController', {
+          '../common/db': {
+            Repository: Repository
+          }
+        });
+        let repoSpy = sinon.stub(repositoryStub);
+        let clock;
+      
+        before(function () {
+          clock = sinon.useFakeTimers();
+        });
+      
+        afterEach(function () {
+          repoSpy.search.reset();
+          clock.reset();
+        });
+      
+        after(function () {
+          clock.restore();
+        });
+
+        it('should get all instances with updates scheduled from database', function () {
+      
+          const expectedInstanceList = [];
+          expectedInstanceList.push.apply(expectedInstanceList, _.map(listOfInstances, 'data'));
+          const criteria = {
+            searchBy: {
+              type: CONST.JOB.SERVICE_INSTANCE_UPDATE
+            },
+            projection: {
+              'data.instance_id': 1
+            }
+          };
+          const paginateOpts = {
+            records: config.mongodb.record_max_fetch_count,
+            offset: config.mongodb.record_max_fetch_count
+          };
+
+      return adminController
+        .getInstancesWithUpdateScheduled()
+        .then(instances => {
+          expect(instances).to.eql(expectedInstanceList);
+          expect(repoSpy.search.callCount).to.equal(2);
+          expect(repoSpy.search.firstCall.args[0][0]).to.be.equal(CONST.DB_MODEL.JOB);
+          expect(repoSpy.search.firstCall.args[0][1]).to.deep.equal(criteria);
+          expect(repoSpy.search.firstCall.args[0][2]).to.deep.equal(paginateOpts);
+        });
+        });
+        });
+});

--- a/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
@@ -29,8 +29,7 @@ for (let i = 1; i <= numOfInstances; i++) {
 
 class Repository {
   static search(model, searchCriteria, paginateOpts) {
-    let returnedList = [];
-    {
+    let returnedList = []; {
       returnedList = listOfInstances;
       repositoryStub.search(arguments);
       return Promise.try(() => {
@@ -49,64 +48,68 @@ class Repository {
 describe('service-fabrik-admin', function () {
   const base_url = '/admin';
 
-    describe('#getScheduledUpdateInstances', function () {
+  describe('#getScheduledUpdateInstances', function () {
 
-      before(function () {
-        sinon.stub(ServiceFabrikAdminController, 'getInstancesWithUpdateScheduled').returns(Promise.resolve([{instance_id : '9999-8888-7777-6666'},{instance_id : '5555-4444-3333-2222'}]));
-      });
-    
-      it.only('should list all instances with updates scheduled', function () {
-        return chai
-          .request(app)
-          .get(`${base_url}/update/schedules`)
-          .set('Accept', 'application/json')
-          .auth(config.username, config.password)
-          .catch(err => err.response)
-          .then(res => {
-            expect(res.body).to.have.length(2);
-            expect(res).to.have.status(200);
-          });
-      });
-      });
+    before(function () {
+      sinon.stub(ServiceFabrikAdminController, 'getInstancesWithUpdateScheduled').returns(Promise.resolve([{
+        instance_id: '9999-8888-7777-6666'
+      }, {
+        instance_id: '5555-4444-3333-2222'
+      }]));
+    });
 
-      describe('#getInstancesWithUpdateScheduled', function () {
-        const adminController = proxyquire('../../../api-controllers/ServiceFabrikAdminController', {
-          '../common/db': {
-            Repository: Repository
-          }
+    it.only('should list all instances with updates scheduled', function () {
+      return chai
+        .request(app)
+        .get(`${base_url}/update/schedules`)
+        .set('Accept', 'application/json')
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          expect(res.body).to.have.length(2);
+          expect(res).to.have.status(200);
         });
-        let repoSpy = sinon.stub(repositoryStub);
-        let clock;
-      
-        before(function () {
-          clock = sinon.useFakeTimers();
-        });
-      
-        afterEach(function () {
-          repoSpy.search.reset();
-          clock.reset();
-        });
-      
-        after(function () {
-          clock.restore();
-        });
+    });
+  });
 
-        it('should get all instances with updates scheduled from database', function () {
-      
-          const expectedInstanceList = [];
-          expectedInstanceList.push.apply(expectedInstanceList, _.map(listOfInstances, 'data'));
-          const criteria = {
-            searchBy: {
-              type: CONST.JOB.SERVICE_INSTANCE_UPDATE
-            },
-            projection: {
-              'data.instance_id': 1
-            }
-          };
-          const paginateOpts = {
-            records: config.mongodb.record_max_fetch_count,
-            offset: config.mongodb.record_max_fetch_count
-          };
+  describe('#getInstancesWithUpdateScheduled', function () {
+    const adminController = proxyquire('../../../api-controllers/ServiceFabrikAdminController', {
+      '../common/db': {
+        Repository: Repository
+      }
+    });
+    let repoSpy = sinon.stub(repositoryStub);
+    let clock;
+
+    before(function () {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(function () {
+      repoSpy.search.reset();
+      clock.reset();
+    });
+
+    after(function () {
+      clock.restore();
+    });
+
+    it('should get all instances with updates scheduled from database', function () {
+
+      const expectedInstanceList = [];
+      expectedInstanceList.push.apply(expectedInstanceList, _.map(listOfInstances, 'data'));
+      const criteria = {
+        searchBy: {
+          type: CONST.JOB.SERVICE_INSTANCE_UPDATE
+        },
+        projection: {
+          'data.instance_id': 1
+        }
+      };
+      const paginateOpts = {
+        records: config.mongodb.record_max_fetch_count,
+        offset: config.mongodb.record_max_fetch_count
+      };
 
       return adminController
         .getInstancesWithUpdateScheduled()
@@ -117,6 +120,6 @@ describe('service-fabrik-admin', function () {
           expect(repoSpy.search.firstCall.args[0][1]).to.deep.equal(criteria);
           expect(repoSpy.search.firstCall.args[0][2]).to.deep.equal(paginateOpts);
         });
-        });
-        });
+    });
+  });
 });

--- a/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
@@ -51,7 +51,7 @@ describe('service-fabrik-admin', function () {
   describe('#getScheduledUpdateInstances', function () {
 
     before(function () {
-      sinon.stub(ServiceFabrikAdminController, 'getInstancesWithUpdateScheduled').returns(Promise.resolve([{
+      sinon.stub(ServiceFabrikAdminController.prototype, 'getInstancesWithUpdateScheduled').returns(Promise.resolve([{
         instance_id: '9999-8888-7777-6666'
       }, {
         instance_id: '5555-4444-3333-2222'
@@ -61,7 +61,7 @@ describe('service-fabrik-admin', function () {
     it('should list all instances with updates scheduled', function () {
       return chai
         .request(app)
-        .get(`${base_url}/update/schedules`)
+        .get(`${base_url}/instances/update/schedules`)
         .set('Accept', 'application/json')
         .auth(config.username, config.password)
         .catch(err => err.response)
@@ -111,7 +111,7 @@ describe('service-fabrik-admin', function () {
         offset: config.mongodb.record_max_fetch_count
       };
 
-      return adminController
+      return new adminController()
         .getInstancesWithUpdateScheduled()
         .then(instances => {
           expect(instances).to.eql(expectedInstanceList);

--- a/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
@@ -58,7 +58,7 @@ describe('service-fabrik-admin', function () {
       }]));
     });
 
-    it.only('should list all instances with updates scheduled', function () {
+    it('should list all instances with updates scheduled', function () {
       return chai
         .request(app)
         .get(`${base_url}/update/schedules`)

--- a/test/test_broker/broker.middleware.spec.js
+++ b/test/test_broker/broker.middleware.spec.js
@@ -16,7 +16,7 @@ const utils = require('../../common/utils');
 const errors = require('../../common/errors');
 const BadRequest = errors.BadRequest;
 const Forbidden = errors.Forbidden;
-const PROMISE_WAIT_SIMULATED_DELAY = 2;
+const PROMISE_WAIT_SIMULATED_DELAY = 30;
 
 class Response {
   constructor() {

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -691,8 +691,7 @@ describe('eventmesh', () => {
 
       it('Gets resource list by state', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 200);
+          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 200);
         return apiserver.getResourceListByState({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
@@ -706,8 +705,7 @@ describe('eventmesh', () => {
 
       it('Gets resource list by state with empy array', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          [CONST.APISERVER.RESOURCE_STATE.WAITING], [], 1, 200);
+          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [], 1, 200);
         return apiserver.getResourceListByState({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
@@ -721,8 +719,7 @@ describe('eventmesh', () => {
 
       it('Gets resource list by state: error', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 404);
+          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 404);
         return apiserver.getResourceListByState({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,

--- a/test/test_broker/operators.DirectorService.ratelimits.spec.js
+++ b/test/test_broker/operators.DirectorService.ratelimits.spec.js
@@ -414,8 +414,7 @@ describe('manager', () => {
     describe('#acquireNetworkSegmentIndex', () => {
       it('should return network segment index when there are deployment names in cache', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 200);
+          CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 200);
         getDirectorDeploymentsSpy.returns([`service-fabrik-90-${used_guid}`]);
         return service.acquireNetworkSegmentIndex('guid')
           .then(index => {


### PR DESCRIPTION
A new admin API is introduced which queries records from job schema and fetches all backing service instances that have updates already scheduled.