### PR TITLE
[rel-10b]Keep creating binding property for sf-mongodb bind (#459)

### DIFF
--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -13,6 +13,7 @@ const NotFound = errors.NotFound;
 const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const ScheduleManager = require('../../jobs');
 const CONST = require('../../common/constants');
+const ServiceBindingAlreadyExists = errors.ServiceBindingAlreadyExists;
 const bosh = require('../../data-access-layer/bosh');
 const eventmesh = require('../../data-access-layer/eventmesh');
 const Agent = require('../../data-access-layer/service-agent');
@@ -686,6 +687,12 @@ class DirectorService extends BaseDirectorService {
         utils.maskSensitiveInfo(bindCreds);
         logger.info(`+-> Created binding:${JSON.stringify(bindCreds)}`);
       })
+      .tap(() => {
+        //TODO: Temporary fix. Binding info should always be fetched from etcd.
+        if (deploymentName === config.mongodb.deployment_name) {
+          return this.createBindingProperty(deploymentName, binding.id, binding);
+        }
+      })
       .catch(err => {
         logger.error(`+-> Failed to create binding for deployment ${deploymentName} with id ${binding.id}`);
         logger.error(err);
@@ -725,6 +732,12 @@ class DirectorService extends BaseDirectorService {
         })
       )
       .tap(() => logger.info('+-> Deleted service credentials'))
+      .tap(() => {
+        //TODO: Temporary fix. Binding info should always be fetched from etcd.
+        if (deploymentName === config.mongodb.deployment_name) {
+          return this.deleteBindingProperty(deploymentName, id);
+        }
+      })
       .catch(err => {
         logger.error(`+-> Failed to delete binding for deployment ${deploymentName} with id ${id}`);
         logger.error(err);
@@ -761,6 +774,17 @@ class DirectorService extends BaseDirectorService {
         logger.error(`[getCredentials] error while fetching resource for binding ${id} - `, err);
         return;
       });
+  }
+
+  createBindingProperty(deploymentName, id, value) {
+    return this.director
+      .createDeploymentProperty(deploymentName, `binding-${id}`, JSON.stringify(value))
+      .catchThrow(BadRequest, new ServiceBindingAlreadyExists(id));
+  }
+
+  deleteBindingProperty(deploymentName, id) {
+    return this.director
+      .deleteDeploymentProperty(deploymentName, `binding-${id}`);
   }
 
   getBindingProperty(deploymentName, id) {

--- a/test/test_broker/mocks/director.js
+++ b/test/test_broker/mocks/director.js
@@ -362,9 +362,10 @@ function updateBindingProperty(binding_id, parameters, binding_credentials) {
     .reply(204);
 }
 
-function deleteBindingProperty(binding_id) {
+function deleteBindingProperty(binding_id, deployment) {
+  const deploymentName = deployment || deploymentNameByIndex(networkSegmentIndex);
   return nock(directorUrl)
-    .delete(`/deployments/${deploymentNameByIndex(networkSegmentIndex)}/properties/binding-${binding_id}`)
+    .delete(`/deployments/${deploymentName}/properties/binding-${binding_id}`)
     .reply(204);
 }
 

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -1086,6 +1086,37 @@ describe('#DirectorService', function () {
               }, WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION);
             });
         });
+
+        it('creates bind property for sfmongodb bind', function (done) {
+          config.mongodb.provision.plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
+          const expectedRequestBody = _.cloneDeep(deploymentHookRequestBody);
+          expectedRequestBody.context = _.chain(expectedRequestBody.context)
+            .set('id', CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID)
+            .set('parameters', {})
+            .omit('params')
+            .omit('sf_operations_args')
+            .value();
+          expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_BIND;
+          expectedRequestBody.context.deployment_name = config.mongodb.deployment_name;
+          _.unset(expectedRequestBody, 'context.instance_guid');
+          mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.director.getDeploymentInstances(config.mongodb.deployment_name);
+          mocks.agent.getInfo();
+          mocks.agent.createCredentials();
+          mocks.director.createBindingProperty(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, {}, config.mongodb.deployment_name);
+          const mongo_plan = catalog.getPlan(config.mongodb.provision.plan_id);
+          return Promise.try(() => new DirectorService(mongo_plan))
+            .then(service => service.createBinding(config.mongodb.deployment_name, {
+              id: CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID,
+              parameters: {}
+            }))
+            .then(res => {
+              delete config.mongodb.provision.plan_id;
+              expect(res).to.eql(mocks.agent.credentials);
+              mocks.verify();
+              done();
+            });
+        });
       });
 
       describe('#unbind', function () {
@@ -1249,6 +1280,34 @@ describe('#DirectorService', function () {
             .then(service => service.unbind(options))
             .then(() => {
               mocks.verify();
+            });
+        });
+
+        it('deleteBinding for sfmongodb deletes property on bosh', function (done) {
+          const expectedRequestBody = _.cloneDeep(deploymentHookRequestBody);
+          expectedRequestBody.context = _.chain(expectedRequestBody.context)
+            .set('id', CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID)
+            .omit('params')
+            .omit('sf_operations_args')
+            .value();
+          expectedRequestBody.context.deployment_name = config.mongodb.deployment_name;
+          _.unset(expectedRequestBody, 'context.instance_guid');
+          expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
+          mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.director.getDeploymentInstances(config.mongodb.deployment_name);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BIND, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND, CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, {}, 1, 404);
+          mocks.director.getBindingProperty(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, {}, config.mongodb.deployment_name);
+          mocks.agent.getInfo();
+          mocks.agent.deleteCredentials();
+          mocks.director.deleteBindingProperty(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, config.mongodb.deployment_name);
+          config.mongodb.provision.plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
+          const mongo_plan = catalog.getPlan(config.mongodb.provision.plan_id);
+          return Promise.try(() => new DirectorService(mongo_plan))
+            .then(service => service.deleteBinding(config.mongodb.deployment_name, CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID))
+            .then(() => {
+              delete config.mongodb.provision.plan_id;
+              mocks.verify();
+              done();
             });
         });
       });


### PR DESCRIPTION
* In previous PR #437, code for creating bind properties on Bosh was removed.
* However, DbManager still fetches bind property of service-fabrik-mongodb from Bosh, which will create problem while recreating landscape. Hence as a temporary fix, allowing creation of bind property for service-fabrik-mongodb.