### PR TITLE
Fixing the query criteria for purging jobdetails collection

### DIFF
--- a/jobs/ScheduleManager.js
+++ b/jobs/ScheduleManager.js
@@ -211,7 +211,9 @@ class ScheduleManager {
         runOnlyOnce: true
       });
       criteria.push({
-        type: '/.*_[0-9]+/'
+        type: {
+          $regex: '.*_[0-9]+'
+        }
       });
       return scheduler
         .purgeOldFinishedJobs()


### PR DESCRIPTION
DBCollection Reaper invokes ScheduleManager to reap completed one time jobs. However only agendaJobDetails was getting purged and not jobdetails collection. This was due to the incorrect regex usage in the mongo query. This is being fixed in this PR.