### PR TITLE
fixing the invocation of makeRequest by passing deploymentName

### DIFF
--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -664,8 +664,8 @@ class BoshDirectorClient extends HttpClient {
           qs: {
             format: 'full'
           }
-        }, 302)
-        .then(res => this.prefixTaskId(deploymentName, res));
+        }, 302, deploymentName)
+        .then(res => self.prefixTaskId(deploymentName, res));
     }
 
 


### PR DESCRIPTION
When boshdirector client was enhanced to work with multiple boshes, this method was not fixed correctly which was supposed to pass deployment name to `makeRequest` method.