### PR TITLE
Add the login_hint parameter for password grant flow of accessing oauth token from cf uaa

### DIFF
--- a/data-access-layer/cf/UaaClient.js
+++ b/data-access-layer/cf/UaaClient.js
@@ -117,7 +117,8 @@ class UaaClient extends HttpClient {
         grant_type: 'password',
         client_id: this.clientId,
         username: username,
-        password: password
+        password: password,
+        login_hint: '{"origin":"uaa"}'
       }
     }, 200).then((res) => {
       return JSON.parse(res.body);


### PR DESCRIPTION
With this change we always force the identity provider to be UAA which will ensure that even if some other default identity providers are set oauth would be generated against UAA.