### PR TITLE
Modifying DbManager init flow to store/fetch credentials on ApiServer

### DIFF
--- a/broker/lib/fabrik/DBManager.js
+++ b/broker/lib/fabrik/DBManager.js
@@ -109,6 +109,7 @@ class DBManager {
         })
         .then(resource => utils.decodeBase64(_.get(resource, 'status.response')))
         .catch(NotFound, () => {
+          //TODO: This can be removed from T2018.13B onwards as bind property would have been moved to ApiServer by then.
           return utils
             .retry(() => this
               .directorService

--- a/broker/lib/fabrik/DBManager.js
+++ b/broker/lib/fabrik/DBManager.js
@@ -116,6 +116,14 @@ class DBManager {
               maxAttempts: 5,
               minDelay: 5000,
               predicate: (err) => !(err instanceof ServiceBindingNotFound)
+            })
+            .then(bindInfo => {
+              return this.storeBindPropertyOnApiServer({
+                id: _.toLower(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID),
+                parameters: bindInfo.parameters,
+                credentials: bindInfo.credentials
+              })
+              .then(() => bindInfo);
             });
         });
     });

--- a/broker/lib/fabrik/DBManager.js
+++ b/broker/lib/fabrik/DBManager.js
@@ -103,27 +103,27 @@ class DBManager {
         return this.bindInfo;
       }
       return eventmesh.apiServerClient.getResource({
-        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BIND,
-        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND,
-        resourceId: _.toLower(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID)
-      })
-      .then(resource => _.get(resource, 'status.response'))
-      .catch(NotFound, () => {
-        return utils
-          .retry(() => this
-            .directorService
-            .getBindingProperty(config.mongodb.deployment_name, CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID), {
-              maxAttempts: 5,
-              minDelay: 5000,
-              predicate: (err) => !(err instanceof ServiceBindingNotFound)
-            })
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BIND,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND,
+          resourceId: _.toLower(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID)
+        })
+        .then(resource => _.get(resource, 'status.response'))
+        .catch(NotFound, () => {
+          return utils
+            .retry(() => this
+              .directorService
+              .getBindingProperty(config.mongodb.deployment_name, CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID), {
+                maxAttempts: 5,
+                minDelay: 5000,
+                predicate: (err) => !(err instanceof ServiceBindingNotFound)
+              })
             .then(bindInfo => {
               return this.storeBindPropertyOnApiServer({
-                id: _.toLower(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID),
-                parameters: bindInfo.parameters,
-                credentials: bindInfo.credentials
-              })
-              .then(() => bindInfo);
+                  id: _.toLower(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID),
+                  parameters: bindInfo.parameters,
+                  credentials: bindInfo.credentials
+                })
+                .then(() => bindInfo);
             });
         });
     });
@@ -233,18 +233,18 @@ class DBManager {
             .pollTaskStatusTillComplete(taskId)
             .then(response => {
               return Promise.try(() => {
-                if(createIfNotPresent) {
-                  //This is precaution to ensure that no previous bind resource exists in the event that
-                  //service-fabrik-mongodb is recreated but ApiServer is not.
-                  return eventmesh.apiServerClient.deleteResource({
-                    resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BIND,
-                    resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND,
-                    resourceId: _.toLower(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID)
-                  });
-                }
-              })
-              .then(() => this.dbCreateUpdateSucceeded(response, createIfNotPresent))
-              .catch(NotFound, () => this.dbCreateUpdateSucceeded(response, createIfNotPresent))
+                  if (createIfNotPresent) {
+                    //This is precaution to ensure that no previous bind resource exists in the event that
+                    //service-fabrik-mongodb is recreated but ApiServer is not.
+                    return eventmesh.apiServerClient.deleteResource({
+                      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BIND,
+                      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND,
+                      resourceId: _.toLower(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID)
+                    });
+                  }
+                })
+                .then(() => this.dbCreateUpdateSucceeded(response, createIfNotPresent))
+                .catch(NotFound, () => this.dbCreateUpdateSucceeded(response, createIfNotPresent));
             })
             .catch(err => this.dbCreateUpdateFailed(err, operation));
         })
@@ -275,7 +275,7 @@ class DBManager {
               id: _.toLower(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID),
               parameters: config.mongodb.provision.bind_params || {},
               credentials: credentials
-            })
+            });
           })
           .then(() => this.initialize());
       })

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -733,12 +733,6 @@ class DirectorService extends BaseDirectorService {
         utils.maskSensitiveInfo(bindCreds);
         logger.info(`+-> Created binding:${JSON.stringify(bindCreds)}`);
       })
-      .tap(() => {
-        //TODO: Temporary fix. Binding info should always be fetched from etcd.
-        if (deploymentName === config.mongodb.deployment_name) {
-          return this.createBindingProperty(deploymentName, binding.id, binding);
-        }
-      })
       .catch(err => {
         logger.error(`+-> Failed to create binding for deployment ${deploymentName} with id ${binding.id}`);
         logger.error(err);
@@ -778,12 +772,6 @@ class DirectorService extends BaseDirectorService {
         })
       )
       .tap(() => logger.info('+-> Deleted service credentials'))
-      .tap(() => {
-        //TODO: Temporary fix. Binding info should always be fetched from etcd.
-        if (deploymentName === config.mongodb.deployment_name) {
-          return this.deleteBindingProperty(deploymentName, id);
-        }
-      })
       .catch(err => {
         logger.error(`+-> Failed to delete binding for deployment ${deploymentName} with id ${id}`);
         logger.error(err);
@@ -820,17 +808,6 @@ class DirectorService extends BaseDirectorService {
         logger.error(`[getCredentials] error while fetching resource for binding ${id} - `, err);
         return;
       });
-  }
-
-  createBindingProperty(deploymentName, id, value) {
-    return this.director
-      .createDeploymentProperty(deploymentName, `binding-${id}`, JSON.stringify(value))
-      .catchThrow(BadRequest, new ServiceBindingAlreadyExists(id));
-  }
-
-  deleteBindingProperty(deploymentName, id) {
-    return this.director
-      .deleteDeploymentProperty(deploymentName, `binding-${id}`);
   }
 
   getBindingProperty(deploymentName, id) {

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -13,7 +13,6 @@ const NotFound = errors.NotFound;
 const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const ScheduleManager = require('../../jobs');
 const CONST = require('../../common/constants');
-const ServiceBindingAlreadyExists = errors.ServiceBindingAlreadyExists;
 const bosh = require('../../data-access-layer/bosh');
 const eventmesh = require('../../data-access-layer/eventmesh');
 const Agent = require('../../data-access-layer/service-agent');

--- a/test/test_broker/acceptance/service-fabrik-admin.internal-db.lifecycle.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.internal-db.lifecycle.spec.js
@@ -10,6 +10,8 @@ const backupStore = iaas.backupStore;
 const filename = backupStore.filename;
 const CONST = require('../../../common/constants');
 const utils = require('../../../common/utils');
+const eventmesh = require('../../../data-access-layer/eventmesh');
+const errors = require('../../../common/errors');
 
 describe('service-fabrik-admin', function () {
   describe('internal-db-lifecycle', function () {
@@ -21,6 +23,7 @@ describe('service-fabrik-admin', function () {
     const container = backupStore.containerName;
     let deploymentHookRequestBody;
     let timestampStub, uuidv4Stub;
+    let getResourceStub, deleteResourceStub, createResourceStub;
 
     function isoDate(time) {
       return new Date(time).toISOString().replace(/\.\d*/, '').replace(/:/g, '-');
@@ -52,6 +55,19 @@ describe('service-fabrik-admin', function () {
           sf_operations_args: {},
         }
       };
+      getResourceStub = sinon.stub(eventmesh.apiServerClient, 'getResource');
+      createResourceStub = sinon.stub(eventmesh.apiServerClient, 'createResource');
+      deleteResourceStub = sinon.stub(eventmesh.apiServerClient, 'deleteResource');
+
+      getResourceStub.withArgs().returns(Promise.try(() => {
+        throw new errors.NotFound('resource not found on ApiServer');
+      }));
+      deleteResourceStub.withArgs().returns(Promise.try(() => {
+        throw new errors.NotFound('resource not found on ApiServer');
+      }));
+
+      createResourceStub.withArgs().returns(Promise.resolve());
+
       mocks.director.getBindingProperty(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, {}, config.mongodb.deployment_name, 'NOTFOUND');
       fabrik.dbManager = new DBManager();
       //By default config is not configured for DB. So just for the test cases in this suite
@@ -77,6 +93,9 @@ describe('service-fabrik-admin', function () {
     after(function () {
       timestampStub.restore();
       uuidv4Stub.restore();
+      getResourceStub.restore();
+      deleteResourceStub.restore();
+      createResourceStub.restore();
       delete config.mongodb.provision.plan_id;
     });
 

--- a/test/test_broker/fabrik.DBManager.spec.js
+++ b/test/test_broker/fabrik.DBManager.spec.js
@@ -307,6 +307,18 @@ describe('fabrik', function () {
           return validateConnected(dbManager);
         });
       });
+      it('On start if binding property is found in ApiServer then no further calls to director are made', function() {
+        bindPropertyFoundOnApiServer = true;
+        bindPropertyFound = 1; //ensure bindProperty won't be found on Director 
+        const dbManager = new DBManager();
+        return Promise.delay(10).then(() => {
+          expect(dbManager.dbState).to.eql(CONST.DB.STATE.CONNECTING);
+          expect(dbManager.dbInitialized).to.eql(true);
+          bindPropertyFound = 0;
+          bindPropertyFoundOnApiServer = false;
+          return validateConnected(dbManager, 1);
+        });
+      });
       it('On start if mongodb URL is configured, then it must connect to it successfully', function () {
         const dbManager = new DBManagerByUrl();
         return Promise.delay(20).then(() => {

--- a/test/test_broker/fabrik.DBManager.spec.js
+++ b/test/test_broker/fabrik.DBManager.spec.js
@@ -307,7 +307,7 @@ describe('fabrik', function () {
           return validateConnected(dbManager);
         });
       });
-      it('On start if binding property is found in ApiServer then no further calls to director are made', function() {
+      it('On start if binding property is found in ApiServer then no further calls to director are made', function () {
         bindPropertyFoundOnApiServer = true;
         bindPropertyFound = 1; //ensure bindProperty won't be found on Director 
         const dbManager = new DBManager();

--- a/test/test_broker/fabrik.DBManager.spec.js
+++ b/test/test_broker/fabrik.DBManager.spec.js
@@ -58,11 +58,11 @@ let eventMeshStub = {
         if (bindPropertyFoundOnApiServer) {
           return {
             status: {
-              response: {
+              response: utils.encodeBase64({
                 credentials: {
                   uri: mongoDBUrl
                 }
-              }
+              })
             }
           };
         } else {
@@ -74,7 +74,9 @@ let eventMeshStub = {
       if (bindPropertyFoundOnApiServer) {
         return Promise.resolve();
       } else {
-        throw new errors.NotFound('resource not found on ApiServer');
+        return Promise.try(() => {
+          throw new errors.NotFound('resource not found on ApiServer');
+        });
       }
     },
     createResource: () => {

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -1086,37 +1086,6 @@ describe('#DirectorService', function () {
               }, WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION);
             });
         });
-
-        it('creates bind property for sfmongodb bind', function (done) {
-          config.mongodb.provision.plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
-          const expectedRequestBody = _.cloneDeep(deploymentHookRequestBody);
-          expectedRequestBody.context = _.chain(expectedRequestBody.context)
-            .set('id', CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID)
-            .set('parameters', {})
-            .omit('params')
-            .omit('sf_operations_args')
-            .value();
-          expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_BIND;
-          expectedRequestBody.context.deployment_name = config.mongodb.deployment_name;
-          _.unset(expectedRequestBody, 'context.instance_guid');
-          mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
-          mocks.director.getDeploymentInstances(config.mongodb.deployment_name);
-          mocks.agent.getInfo();
-          mocks.agent.createCredentials();
-          mocks.director.createBindingProperty(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, {}, config.mongodb.deployment_name);
-          const mongo_plan = catalog.getPlan(config.mongodb.provision.plan_id);
-          return Promise.try(() => new DirectorService(mongo_plan))
-            .then(service => service.createBinding(config.mongodb.deployment_name, {
-              id: CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID,
-              parameters: {}
-            }))
-            .then(res => {
-              delete config.mongodb.provision.plan_id;
-              expect(res).to.eql(mocks.agent.credentials);
-              mocks.verify();
-              done();
-            });
-        });
       });
 
       describe('#unbind', function () {
@@ -1280,34 +1249,6 @@ describe('#DirectorService', function () {
             .then(service => service.unbind(options))
             .then(() => {
               mocks.verify();
-            });
-        });
-
-        it('deleteBinding for sfmongodb deletes property on bosh', function (done) {
-          const expectedRequestBody = _.cloneDeep(deploymentHookRequestBody);
-          expectedRequestBody.context = _.chain(expectedRequestBody.context)
-            .set('id', CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID)
-            .omit('params')
-            .omit('sf_operations_args')
-            .value();
-          expectedRequestBody.context.deployment_name = config.mongodb.deployment_name;
-          _.unset(expectedRequestBody, 'context.instance_guid');
-          expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
-          mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
-          mocks.director.getDeploymentInstances(config.mongodb.deployment_name);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BIND, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND, CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, {}, 1, 404);
-          mocks.director.getBindingProperty(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, {}, config.mongodb.deployment_name);
-          mocks.agent.getInfo();
-          mocks.agent.deleteCredentials();
-          mocks.director.deleteBindingProperty(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, config.mongodb.deployment_name);
-          config.mongodb.provision.plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
-          const mongo_plan = catalog.getPlan(config.mongodb.provision.plan_id);
-          return Promise.try(() => new DirectorService(mongo_plan))
-            .then(service => service.deleteBinding(config.mongodb.deployment_name, CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID))
-            .then(() => {
-              delete config.mongodb.provision.plan_id;
-              mocks.verify();
-              done();
             });
         });
       });


### PR DESCRIPTION
* In continuation to previous changes towards bosh resiliency, we need to reduce bosh dependency in  case of service-fabrik-mongodb credentials also.
* With this PR, any new attempts to bind to service-fabrik-mongodb (e.g., landscape recreations, fresh setup etc) will result into storing credentials on ApiServer instead of bosh deployment property.
* In case of existing bind credentials, once they are fetched from bosh binding property they will also be populated on ApiServer and thenceforth will be fetched from ApiServer itself.
* (For previous workflow regarding this issue please see:  https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/437, https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/459)