### PR TITLE
Throw exception when deployment name is not present in task id

### DIFF
--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -829,12 +829,7 @@ class BoshDirectorClient extends HttpClient {
   getTask(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      return this
-        .makeRequestWithConfig({
-          method: 'GET',
-          url: `/tasks/${taskId}`
-        }, 200, this.getConfigByName(CONST.BOSH_DIRECTORS.BOSH))
-        .then(res => JSON.parse(res.body));
+      throw new UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
@@ -849,21 +844,7 @@ class BoshDirectorClient extends HttpClient {
   getTaskResult(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      return this
-        .makeRequestWithConfig({
-          method: 'GET',
-          url: `/tasks/${taskId}/output`,
-          qs: {
-            type: 'result'
-          }
-        }, 200, this.getConfigByName(CONST.BOSH_DIRECTORS.BOSH))
-        .then(res => _
-          .chain(res.body)
-          .split('\n')
-          .compact()
-          .map(JSON.parse)
-          .value()
-        );
+      throw new UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
@@ -918,25 +899,7 @@ class BoshDirectorClient extends HttpClient {
   getTaskEvents(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      return this
-        .makeRequestWithConfig({
-          method: 'GET',
-          url: `/tasks/${taskId}/output`,
-          qs: {
-            type: 'event'
-          }
-        }, 200, this.getConfigByName(CONST.BOSH_DIRECTORS.BOSH))
-        .then(res => {
-          let events = [];
-          _.trim(res.body).split('\n').forEach((event) => {
-            try {
-              events.push(JSON.parse(event));
-            } catch (err) {
-              logger.error(`Error parsing task ${taskId} event ${event}: event response - ${res.body} `, err);
-            }
-          });
-          return events;
-        });
+      throw new UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -829,7 +829,7 @@ class BoshDirectorClient extends HttpClient {
   getTask(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      throw new UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
+      throw new errors.UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
@@ -844,7 +844,7 @@ class BoshDirectorClient extends HttpClient {
   getTaskResult(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      throw new UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
+      throw new errors.UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
@@ -899,7 +899,7 @@ class BoshDirectorClient extends HttpClient {
   getTaskEvents(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      throw new UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
+      throw new errors.UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -829,7 +829,8 @@ class BoshDirectorClient extends HttpClient {
   getTask(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      throw new errors.UnprocessableEntity(`Not able to query correct bosh as taskId is not in required format: ${taskId}`);
+      //Required format is deploymentName_taskId.
+      throw new errors.UnprocessableEntity(`Not able to query correct bosh as taskId is not in required format: ${taskId}.`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
@@ -844,7 +845,8 @@ class BoshDirectorClient extends HttpClient {
   getTaskResult(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      throw new errors.UnprocessableEntity(`Not able to query correct bosh as taskId is not in required format: ${taskId}`);
+      //Required format is deploymentName_taskId.
+      throw new errors.UnprocessableEntity(`Not able to query correct bosh as taskId is not in required format: ${taskId}.`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
@@ -899,7 +901,8 @@ class BoshDirectorClient extends HttpClient {
   getTaskEvents(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      throw new errors.UnprocessableEntity(`Not able to query correct bosh as taskId is not in required format: ${taskId}`);
+      //Required format is deploymentName_taskId.
+      throw new errors.UnprocessableEntity(`Not able to query correct bosh as taskId is not in required format: ${taskId}.`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -829,7 +829,7 @@ class BoshDirectorClient extends HttpClient {
   getTask(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      throw new errors.UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
+      throw new errors.UnprocessableEntity(`Not able to query correct bosh as taskId is not in required format: ${taskId}`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
@@ -844,7 +844,7 @@ class BoshDirectorClient extends HttpClient {
   getTaskResult(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      throw new errors.UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
+      throw new errors.UnprocessableEntity(`Not able to query correct bosh as taskId is not in required format: ${taskId}`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
@@ -899,7 +899,7 @@ class BoshDirectorClient extends HttpClient {
   getTaskEvents(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {
-      throw new errors.UnprocessableEntity(`not able to query correct bosh as taskId is not in required format: ${taskId}`);
+      throw new errors.UnprocessableEntity(`Not able to query correct bosh as taskId is not in required format: ${taskId}`);
     }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -1032,6 +1032,10 @@ describe('bosh', () => {
           done();
         }).catch(done);
       });
+
+      it('throws exception when taskId is in wrong format', () => {
+        expect(() => new MockBoshDirectorClient().getTask(taskId)).to.throw(errors.UnprocessableEntity);
+      });
     });
 
     describe('#getTaskResult', () => {
@@ -1055,6 +1059,10 @@ describe('bosh', () => {
           expect(content).to.eql([body]);
           done();
         });
+      });
+
+      it('throws exception when taskId is in wrong format', () => {
+        expect(() => new MockBoshDirectorClient().getTaskResult(taskId)).to.throw(errors.UnprocessableEntity);
       });
     });
 
@@ -1080,6 +1088,10 @@ describe('bosh', () => {
           expect(content[0].uuid).to.eql(id1);
           expect(content[1].uuid).to.eql(id2);
         });
+      });
+
+      it('throws exception when taskId is in wrong format', () => {
+        expect(() => new MockBoshDirectorClient().getTaskEvents(taskId)).to.throw(errors.UnprocessableEntity);
       });
     });
 


### PR DESCRIPTION
* This PR addresses code in getTask and other methods of BoshDirectorClient, which by default communicate to landscape bosh (not bosh_sf) when taskId passed is not in required format.
* This is not a desired behaviour because:
1. we no longer actively create deployments on landscape bosh
2. taskId should always be in required format (see here: https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/rel-2018.T10b/data-access-layer/bosh/BoshDirectorClient.js#L498 and https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/rel-2018.T10b/data-access-layer/bosh/BoshDirectorClient.js#L509)
* Therefore replacing this behaviour with exception.