### PR TITLE
fix: context object sent during schedule update required check 

### DIFF
--- a/api-controllers/ServiceFabrikApiController.js
+++ b/api-controllers/ServiceFabrikApiController.js
@@ -921,9 +921,7 @@ class ServiceFabrikApiController extends FabrikBaseController {
               return directorService
                 .findDeploymentNameByInstanceId(req.params.instance_id)
                 .then(deploymentName => directorService.diffManifest(deploymentName, {
-                  opts: {
-                    context: context
-                  }
+                  context: context
                 }))
                 .then(result => utils.unifyDiffResult(result))
                 .then(result => {

--- a/broker/config/templates/blueprint-manifest.yml.ejs
+++ b/broker/config/templates/blueprint-manifest.yml.ejs
@@ -48,7 +48,6 @@ if(!spec.actions && spec.previous_manifest){
 else{
   properties.blueprint.actionResponse = JSON.stringify(spec.actions);
 }
-properties.blueprint.update_params = JSON.stringify(spec.parameters);
 %>
 - name: blueprint
   migrated_from:
@@ -69,7 +68,6 @@ properties.blueprint.update_params = JSON.stringify(spec.parameters);
       port: 8080
       actionResponse: <%= properties.blueprint.actionResponse %>
       preUpdateAgentResponse: <%= properties.blueprint.preUpdateAgentResponse %>
-      update_params: <%= properties.blueprint.update_params %>
       admin:
         username: <%= properties.blueprint.admin.username %>
         password: <%= properties.blueprint.admin.password %>
@@ -79,4 +77,3 @@ properties.blueprint.update_params = JSON.stringify(spec.parameters);
       username: <%= p('agent.auth.username') %>
       password: <%= p('agent.auth.password') %>
       provider: <%= JSON.stringify(p('agent.provider')) %>
-      update_params: <%= properties.blueprint.update_params %>

--- a/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
+++ b/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
@@ -55,6 +55,7 @@ class BoshStaggeredDeploymentPoller extends BaseStatusPoller {
       })
       .catch(err => {
         logger.error(`Error occured while triggering deployment for instance ${instanceId}`, err);
+        const timestamp = new Date(task.timestamp * 1000).toISOString();
         this.clearPoller(instanceId, intervalId);
         return eventmesh.apiServerClient.updateResource({
           resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
@@ -62,6 +63,10 @@ class BoshStaggeredDeploymentPoller extends BaseStatusPoller {
           resourceId: instanceId,
           status: {
             state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+            lastOperation: {
+              state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+              description: `${operationType} deployment ${deploymentName} failed at ${timestamp} with Error "${err.message}"`
+            },
             error: utils.buildErrorJson(err)
           }
         });

--- a/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
+++ b/operators/bosh-operator/BoshStaggeredDeploymentPoller.js
@@ -55,7 +55,7 @@ class BoshStaggeredDeploymentPoller extends BaseStatusPoller {
       })
       .catch(err => {
         logger.error(`Error occured while triggering deployment for instance ${instanceId}`, err);
-        const timestamp = new Date(task.timestamp * 1000).toISOString();
+        const timestamp = new Date().toISOString();
         this.clearPoller(instanceId, intervalId);
         return eventmesh.apiServerClient.updateResource({
           resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,

--- a/platform-managers/CfPlatformManager.js
+++ b/platform-managers/CfPlatformManager.js
@@ -124,7 +124,6 @@ class CfPlatformManager extends BasePlatformManager {
     const orgId = _.get(options, 'context.organization_guid');
     assert.ok(orgId, 'OrgId must be present when checking for whitelisting of Tenant in CF Context');
     return this.cloudController.getOrganization(orgId)
-      .tap((res) => console.log('Org Response -->', res))
       .then(org => _.includes(config.quota.whitelist, org.entity.name))
       .tap(result => logger.info(`Current org - ${orgId} is whitelisted: ${result}`));
   }


### PR DESCRIPTION
There are 3 issues that is being fixed in this PR:
1. All services throwing error when checking for update status - This is because in `ServiceFabrikApiController.getUpdateSchedule` context object was being sent with additional key 'opts'. Now due to this tags object would result in being empty & accessing `tags.platform` would throw undefined error in manifest ejs template.  -- This is regression from CF dependency removal.
2. blueprint always reporting as outdated -- This is because of service flow params included in manifest, which coincidentally also included `c params' sent on update request. For now removed it. Need a way to address it for service flow later.
3. BoshStaggeredDeploymentPoller - this was not setting `lastOperation` object on failure, so due to this, for instance if Bosh is down & if predeploy hook is also down then the state of resource is updated to 'failed', however since 'lastOperation' remains blank, CF just keeps polling infinitely. -- This is regression from removing etcd direct access.