### PR TITLE
Fix: Upgrade workflow is running with READ Lock type

### DIFF
--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -88,7 +88,7 @@ class FabrikBaseController extends BaseController {
           resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW,
           resourceType: CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW,
           resourceId: serviceFlowId,
-          operation: `${operationType}_workflow`
+          operation: `${operationType}_${CONST.OPERATION_TYPE.SERVICE_FLOW}`
         };
       }
       return {

--- a/api-controllers/FabrikBaseController.js
+++ b/api-controllers/FabrikBaseController.js
@@ -88,7 +88,7 @@ class FabrikBaseController extends BaseController {
           resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW,
           resourceType: CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW,
           resourceId: serviceFlowId,
-          operation: operationType
+          operation: `${operationType}_workflow`
         };
       }
       return {

--- a/common/constants.js
+++ b/common/constants.js
@@ -73,7 +73,8 @@ module.exports = Object.freeze({
     UPDATE: 'update',
     BIND: 'bind',
     UNBIND: 'unbind',
-    DELETE: 'delete'
+    DELETE: 'delete',
+    SERVICE_FLOW: 'serviceflow'
   },
   URL: {
     backup: '/api/v1/service_instances/:instance_id/backup',
@@ -322,7 +323,7 @@ module.exports = Object.freeze({
       OPTIONS: 'options',
       LASTOPERATION: 'lastoperation'
     },
-    WRITE_OPERATIONS: ['create', 'update', 'delete', 'restore', 'update_workflow'],
+    WRITE_OPERATIONS: ['create', 'update', 'delete', 'restore', 'update_serviceflow'],
     READ_OPERATIONS: ['backup'],
   },
   SERVICE_KEYS: {

--- a/common/constants.js
+++ b/common/constants.js
@@ -322,7 +322,7 @@ module.exports = Object.freeze({
       OPTIONS: 'options',
       LASTOPERATION: 'lastoperation'
     },
-    WRITE_OPERATIONS: ['create', 'update', 'delete', 'restore'],
+    WRITE_OPERATIONS: ['create', 'update', 'delete', 'restore', 'update_workflow'],
     READ_OPERATIONS: ['backup'],
   },
   SERVICE_KEYS: {

--- a/operators/BaseOperator.js
+++ b/operators/BaseOperator.js
@@ -128,7 +128,7 @@ class BaseOperator {
       } else {
         processingLockStatus.conflict = true;
         logger.debug(`Resource ${objectBody.metadata.name}  ${resourceGroup}, ${resourceType}, ${queryString} -` +
-          ` is picked by process with ip ${lockedByManager} at ${processingStartedAt} will be held for another ${elapsedTimeInMs}(ms)`);
+          ` is picked by process with ip ${lockedByManager} at ${processingStartedAt} will be held for another ${elapsedTimeInMs - CONST.PROCESSING_REQUEST_BY_MANAGER_TIMEOUT}(ms)`);
       }
     });
   }

--- a/operators/BaseOperator.js
+++ b/operators/BaseOperator.js
@@ -101,17 +101,17 @@ class BaseOperator {
       const processingStartedAt = _.get(objectBody, 'metadata.annotations.processingStartedAt');
       // To handle already existing resources
       // For already existing resources lockedByManager value is either '' or '<ip>' or undefined
-      const currentTime = new Date();
+      const elapsedTimeInMs = new Date() - new Date(processingStartedAt);
       if (
         lockedByManager &&
         (lockedByManager !== '') &&
         processingStartedAt &&
         (processingStartedAt !== '') &&
-        (currentTime - new Date(processingStartedAt) < CONST.PROCESSING_REQUEST_BY_MANAGER_TIMEOUT)
+        (elapsedTimeInMs < CONST.PROCESSING_REQUEST_BY_MANAGER_TIMEOUT)
       ) {
         processingConflict = true;
       }
-      if ((currentTime - new Date(processingStartedAt) >= CONST.PROCESSING_REQUEST_BY_MANAGER_TIMEOUT)) {
+      if (elapsedTimeInMs >= CONST.PROCESSING_REQUEST_BY_MANAGER_TIMEOUT) {
         logger.info(`Lock is expired on ${objectBody.metadata.name} - acquiring the lock.`);
       }
       if (!processingConflict) {
@@ -127,7 +127,8 @@ class BaseOperator {
           });
       } else {
         processingLockStatus.conflict = true;
-        logger.debug(`Resource ${objectBody.metadata.name}  ${resourceGroup}, ${resourceType}, ${queryString} - is picked by process with ip ${lockedByManager} at ${processingStartedAt}`);
+        logger.debug(`Resource ${objectBody.metadata.name}  ${resourceGroup}, ${resourceType}, ${queryString} -` +
+          ` is picked by process with ip ${lockedByManager} at ${processingStartedAt} will be held for another ${elapsedTimeInMs}(ms)`);
       }
     });
   }

--- a/test/test_broker/operators.serviceflow.SerialServiceFlow.spec.js
+++ b/test/test_broker/operators.serviceflow.SerialServiceFlow.spec.js
@@ -297,7 +297,7 @@ describe('operators', function () {
             });
           });
       });
-      it('relay next task is ignored if the same task was already relayed & update service flow state as in-progress', () => {
+      it('relay next task is ignored if the same task was already relayed', () => {
         const inProgressTask = _.cloneDeep(taskObject);
         const inProgressTaskDetails = _.cloneDeep(taskDetails);
         inProgressTaskDetails.task_order = 0;

--- a/test/test_broker/operators.serviceflow.SerialServiceFlow.spec.js
+++ b/test/test_broker/operators.serviceflow.SerialServiceFlow.spec.js
@@ -13,9 +13,10 @@ describe('operators', function () {
     describe('serialServiceFlow', function () {
       /* jshint expr:true */
       let SerialServiceFlowOperator, registerWatcherStub, registerCRDStub, updateResourceStub, createResourceStub, clock, utilsStub;
+      let throwExceptionOnUpdate = false;
       const instance_id = 'b4719e7c-e8d3-4f7f-c515-769ad1c3ebfa';
       const serviceflow_id = 'b4719e7c-e8d3-4f7f-c515-769ad1c3ebfb';
-      const task_id = 'b4719e7c-e8d3-4f7f-c515-769ad1c3ebfc';
+      const task_id = `${serviceflow_id}.0`;
 
       const taskDetails = {
         operation_params: {
@@ -82,11 +83,18 @@ describe('operators', function () {
         });
         registerCRDStub = sinon.stub(BaseOperator.prototype, 'registerCrds', () => Promise.resolve(true));
         SerialServiceFlowOperator = require('../../operators/serviceflow-operator/SerialServiceFlowOperator');
-        updateResourceStub = sinon.stub(apiServerClient, 'updateResource', () => Promise.resolve({
-          body: {
-            status: 200
-          }
-        }));
+        updateResourceStub = sinon.stub(apiServerClient, 'updateResource', () => {
+          return Promise.try(() => {
+            if (throwExceptionOnUpdate) {
+              throw new errors.Conflict(`Task ${task_id} already exists`);
+            }
+            return Promise.resolve({
+              body: {
+                status: 200
+              }
+            });
+          });
+        });
         createResourceStub = sinon.stub(apiServerClient, 'createResource', () => Promise.resolve(true));
         clock = sinon.useFakeTimers(new Date().getTime());
         utilsStub = sinon.stub(utils, 'uuidV4', () => Promise.resolve(task_id));
@@ -177,9 +185,10 @@ describe('operators', function () {
             expect(createResourceStub.firstCall.args[0]).to.eql({
               resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW,
               resourceType: CONST.APISERVER.RESOURCE_TYPES.TASK,
-              resourceId: task_id,
+              resourceId: `${serviceflow_id}.0`,
               labels: {
-                serviceflow_id: serviceflow_id
+                serviceflow_id: serviceflow_id,
+                task_order: '0'
               },
               options: _.merge(serviceFlowOptions, tasks[0], {
                 task_order: 0,
@@ -257,7 +266,7 @@ describe('operators', function () {
             expect(updateResourceStub.firstCall.args[0]).to.eql({
               resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW,
               resourceType: CONST.APISERVER.RESOURCE_TYPES.TASK,
-              resourceId: task_id,
+              resourceId: `${serviceflow_id}.0`,
               status: {
                 lastOperation: {
                   state: CONST.OPERATION.SUCCEEDED,
@@ -265,7 +274,7 @@ describe('operators', function () {
                     state: CONST.OPERATION.SUCCEEDED,
                     description: ''
                   },
-                  message: `Task complete and next relayed task is ${task_id}`
+                  message: `Task complete and next relayed task is ${serviceflow_id}.1`
                 },
                 response: {
                   state: CONST.OPERATION.SUCCEEDED,
@@ -284,6 +293,40 @@ describe('operators', function () {
                   description: `Void blueprint task is complete. Initiated Void blueprint task2 @ ${new Date()}`
                 },
                 state: CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS
+              }
+            });
+          });
+      });
+      it('relay next task is ignored if the same task was already relayed & update service flow state as in-progress', () => {
+        const inProgressTask = _.cloneDeep(taskObject);
+        const inProgressTaskDetails = _.cloneDeep(taskDetails);
+        inProgressTaskDetails.task_order = 0;
+        inProgressTask.object.spec.options = JSON.stringify(inProgressTaskDetails);
+        const serialServiceFlow = new SerialServiceFlowOperator();
+        throwExceptionOnUpdate = true;
+        return serialServiceFlow.init()
+          .then(() => serialServiceFlow.relayTask(inProgressTask.object))
+          .then(() => {
+            throwExceptionOnUpdate = false;
+            expect(updateResourceStub).to.be.calledOnce;
+            expect(updateResourceStub.firstCall.args[0]).to.eql({
+              resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW,
+              resourceType: CONST.APISERVER.RESOURCE_TYPES.TASK,
+              resourceId: `${serviceflow_id}.0`,
+              status: {
+                lastOperation: {
+                  state: CONST.OPERATION.SUCCEEDED,
+                  response: {
+                    state: CONST.OPERATION.SUCCEEDED,
+                    description: ''
+                  },
+                  message: `Task complete and next relayed task is ${serviceflow_id}.1`
+                },
+                response: {
+                  state: CONST.OPERATION.SUCCEEDED,
+                  description: ''
+                },
+                state: CONST.OPERATION.SUCCEEDED
               }
             });
           });


### PR DESCRIPTION
Fixes - HCPCFS-2122
1. Operation Type for workflow was set as update and this operation is flagged as an asncyh_operation that can run in parallel. So this leads to workflow getting read lock. Added new operation type 'update_workflow' and assocaited it with WRITE_LOCK.
2.  During some race conditions (for ex., StreamRefresh & broker restart) where in state of task could not be updated, there were cases of same task being created again. As part of fixing the dupe task issue, made task id as a function of workflow_id and task_order. So this way even if race condition leads to a creation of dupe task scenario it will lead to an error (name of resource is to be unique in etcd) which will be ignored.