### PR TITLE
Adding support for query parameter specifying login_hint in dashboard URL

### DIFF
--- a/api-controllers/DashboardController.js
+++ b/api-controllers/DashboardController.js
@@ -188,7 +188,7 @@ class DashboardController extends FabrikBaseController {
     req.session.plan_id = req.params.plan_id || req.session.plan_id;
     req.session.instance_id = req.params.instance_id;
     req.session.instance_type = req.params.instance_type;
-    if(req.query.login_hint) {
+    if (req.query.login_hint) {
       req.session.login_hint = req.query.login_hint;
     }
     const oldestAllowableLastSeen = Date.now() - config.external.session_expiry * 1000;

--- a/api-controllers/DashboardController.js
+++ b/api-controllers/DashboardController.js
@@ -67,7 +67,7 @@ class DashboardController extends FabrikBaseController {
         state: req.session.state
       }))
       .tap(query => logger.info('Redirecting to authorization server with query parameters:', query))
-      .then(query => res.redirect(this.uaa.authorizationUrl(query)));
+      .then(query => res.redirect(this.uaa.authorizationUrl(query, req.session.login_hint)));
   }
 
   handleAuthorizationResponse(req, res) {
@@ -188,6 +188,9 @@ class DashboardController extends FabrikBaseController {
     req.session.plan_id = req.params.plan_id || req.session.plan_id;
     req.session.instance_id = req.params.instance_id;
     req.session.instance_type = req.params.instance_type;
+    if(req.query.login_hint) {
+      req.session.login_hint = req.query.login_hint;
+    }
     const oldestAllowableLastSeen = Date.now() - config.external.session_expiry * 1000;
     if (req.session.user_id && req.session.access_token && req.session.last_seen > oldestAllowableLastSeen) {
       req.session.last_seen = Date.now();

--- a/data-access-layer/cf/UaaClient.js
+++ b/data-access-layer/cf/UaaClient.js
@@ -22,12 +22,12 @@ class UaaClient extends HttpClient {
     this.clientId = config.cf.client_id || 'cf';
   }
 
-  authorizationUrl(options, addLoginHint) {
+  authorizationUrl(options, loginHint) {
     options = _.assign({
       response_type: 'code'
     }, options);
-    if (addLoginHint) {
-      options.login_hint = '{"origin":"uaa"}';
+    if (loginHint && loginHint !== '') {
+      options.login_hint = `{"origin":"${loginHint}"}`;
     }
     if (Array.isArray(options.scope)) {
       options.scope = options.scope.join(' ');

--- a/data-access-layer/cf/UaaClient.js
+++ b/data-access-layer/cf/UaaClient.js
@@ -22,11 +22,13 @@ class UaaClient extends HttpClient {
     this.clientId = config.cf.client_id || 'cf';
   }
 
-  authorizationUrl(options) {
+  authorizationUrl(options, addLoginHint) {
     options = _.assign({
       response_type: 'code'
     }, options);
-    options.login_hint = '{"origin":"uaa"}';
+    if (addLoginHint) {
+      options.login_hint = '{"origin":"uaa"}';
+    }
     if (Array.isArray(options.scope)) {
       options.scope = options.scope.join(' ');
     }

--- a/test/test_broker/cf.UaaClient.spec.js
+++ b/test/test_broker/cf.UaaClient.spec.js
@@ -43,6 +43,15 @@ describe('cf', () => {
         done();
       });
 
+      it('returns a string containing the authorization endpoint with login_hint', (done) => {
+        let options = {
+          scope: ['foo', 'bar']
+        };
+
+        expect(new MockUaaClient().authorizationUrl(options, {login_hint: 'uaa'})).to.eql(`${authorizationEndpoint}/oauth/authorize?response_type=code&scope=foo%20bar&login_hint=%7B%22origin%22%3A%22uaa%22%7D`);
+        done();
+      });
+
       it('returns a string containing the authorization endpoint (scope is a string)', (done) => {
         let options = {
           scope: 'foo'

--- a/test/test_broker/cf.UaaClient.spec.js
+++ b/test/test_broker/cf.UaaClient.spec.js
@@ -48,9 +48,7 @@ describe('cf', () => {
           scope: ['foo', 'bar']
         };
 
-        expect(new MockUaaClient().authorizationUrl(options, {
-          login_hint: 'uaa'
-        })).to.eql(`${authorizationEndpoint}/oauth/authorize?response_type=code&scope=foo%20bar&login_hint=%7B%22origin%22%3A%22uaa%22%7D`);
+        expect(new MockUaaClient().authorizationUrl(options, 'uaa')).to.eql(`${authorizationEndpoint}/oauth/authorize?response_type=code&scope=foo%20bar&login_hint=%7B%22origin%22%3A%22uaa%22%7D`);
         done();
       });
 

--- a/test/test_broker/cf.UaaClient.spec.js
+++ b/test/test_broker/cf.UaaClient.spec.js
@@ -39,7 +39,7 @@ describe('cf', () => {
           scope: ['foo', 'bar']
         };
 
-        expect(new MockUaaClient().authorizationUrl(options)).to.eql(`${authorizationEndpoint}/oauth/authorize?response_type=code&scope=foo%20bar&login_hint=%7B%22origin%22%3A%22uaa%22%7D`);
+        expect(new MockUaaClient().authorizationUrl(options)).to.eql(`${authorizationEndpoint}/oauth/authorize?response_type=code&scope=foo%20bar`);
         done();
       });
 
@@ -48,7 +48,7 @@ describe('cf', () => {
           scope: 'foo'
         };
 
-        expect(new MockUaaClient().authorizationUrl(options)).to.eql(`${authorizationEndpoint}/oauth/authorize?response_type=code&scope=foo&login_hint=%7B%22origin%22%3A%22uaa%22%7D`);
+        expect(new MockUaaClient().authorizationUrl(options)).to.eql(`${authorizationEndpoint}/oauth/authorize?response_type=code&scope=foo`);
         done();
       });
     });

--- a/test/test_broker/cf.UaaClient.spec.js
+++ b/test/test_broker/cf.UaaClient.spec.js
@@ -48,7 +48,9 @@ describe('cf', () => {
           scope: ['foo', 'bar']
         };
 
-        expect(new MockUaaClient().authorizationUrl(options, {login_hint: 'uaa'})).to.eql(`${authorizationEndpoint}/oauth/authorize?response_type=code&scope=foo%20bar&login_hint=%7B%22origin%22%3A%22uaa%22%7D`);
+        expect(new MockUaaClient().authorizationUrl(options, {
+          login_hint: 'uaa'
+        })).to.eql(`${authorizationEndpoint}/oauth/authorize?response_type=code&scope=foo%20bar&login_hint=%7B%22origin%22%3A%22uaa%22%7D`);
         done();
       });
 

--- a/test/test_broker/mocks/uaa.js
+++ b/test/test_broker/mocks/uaa.js
@@ -111,8 +111,7 @@ function getAuthorizationCode(service_id, times) {
         response_type: 'code',
         client_id: dashboard_client.id,
         redirect_uri: redirect_uri,
-        scope: 'cloud_controller_service_permissions.read openid',
-        login_hint: '{"origin":"uaa"}'
+        scope: 'cloud_controller_service_permissions.read openid'
       })
       .value()
     )


### PR DESCRIPTION
* With this PR dashboard URL can be optionally appended with a query parameter specifying login_hint.