### PR TITLE
Introducing config for schedule-update

### DIFF
--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -72,10 +72,10 @@ class ServiceFabrikAdminController extends FabrikBaseController {
     return Promise.try(() => {
       logger.info(`Forbidden Manifest flag set to ${allowForbiddenManifestChanges}`);
       return eventmesh.apiServerClient.getResource({
-        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-        resourceId: instanceId
-      })
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          resourceId: instanceId
+        })
         .catch(errors.NotFound, () => undefined)
         .then(resource => _.get(resource, 'spec.options'))
         .then(resource => {
@@ -109,9 +109,9 @@ class ServiceFabrikAdminController extends FabrikBaseController {
     const deploymentName = instanceDetails.deployment_name;
     logger.debug(`Getting outdated diff for  :  ${deploymentName}`);
     return DirectorService.createInstance(instanceDetails.instance_id, {
-      plan_id: plan.id,
-      context: tenantInfo.context
-    })
+        plan_id: plan.id,
+        context: tenantInfo.context
+      })
       .then(directorInstance => directorInstance.diffManifest(deploymentName, tenantInfo))
       .tap(result => logger.debug(`Diff of manifest for ${deploymentName} is ${result.diff}`))
       .then(result => result.diff);
@@ -217,24 +217,24 @@ class ServiceFabrikAdminController extends FabrikBaseController {
           resourceType: plan.resourceType,
           resourceId: this.getInstanceId(deploymentName)
         })
-          .then(context => {
-            const opts = {};
-            opts.context = context;
-            return Promise
-              .all([
-                this.director.getDeploymentVmsVitals(deploymentName),
-                this.director.getTasks({
-                  deployment: deploymentName
-                }),
-                manager.diffManifest(deploymentName, opts).then(utils.unifyDiffResult)
-              ])
-              .spread((vms, tasks, diff) => ({
-                name: deploymentName,
-                diff: diff,
-                tasks: _.filter(tasks, task => !_.startsWith(task.description, 'snapshot')),
-                vms: _.filter(vms, vm => !_.isNil(vm.vitals))
-              }));
-          })
+        .then(context => {
+          const opts = {};
+          opts.context = context;
+          return Promise
+            .all([
+              this.director.getDeploymentVmsVitals(deploymentName),
+              this.director.getTasks({
+                deployment: deploymentName
+              }),
+              manager.diffManifest(deploymentName, opts).then(utils.unifyDiffResult)
+            ])
+            .spread((vms, tasks, diff) => ({
+              name: deploymentName,
+              diff: diff,
+              tasks: _.filter(tasks, task => !_.startsWith(task.description, 'snapshot')),
+              vms: _.filter(vms, vm => !_.isNil(vm.vitals))
+            }));
+        })
       )
       .then(locals => {
         res.format({
@@ -333,10 +333,10 @@ class ServiceFabrikAdminController extends FabrikBaseController {
           return false;
         }
         return eventmesh.apiServerClient.getPlatformContext({
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          resourceId: this.getInstanceId(deployment.name)
-        })
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+            resourceId: this.getInstanceId(deployment.name)
+          })
           .then(context => {
             const opts = {};
             opts.context = context;
@@ -594,11 +594,11 @@ class ServiceFabrikAdminController extends FabrikBaseController {
           .value();
 
         return ScheduleManager.schedule(
-          req.params.name,
-          CONST.JOB.SCHEDULED_OOB_DEPLOYMENT_BACKUP,
-          req.body.repeatInterval,
-          data,
-          req.user)
+            req.params.name,
+            CONST.JOB.SCHEDULED_OOB_DEPLOYMENT_BACKUP,
+            req.body.repeatInterval,
+            data,
+            req.user)
           .then(body => res
             .status(201)
             .send(body));

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -736,44 +736,18 @@ class ServiceFabrikAdminController extends FabrikBaseController {
         .send(body));
   }
 
-  checkIfResourceExists(api_version, resourceType, resourceName) {
-    let resourceExists = false;
-    return eventmesh.apiServerClient.getConfigMap({
-      api_version: api_version,
-      resourceType: resourceType,
-      resourceName: resourceName
-    }).then((body) => {
-      if (body.metadata.name === resourceName) {
-        resourceExists = true;
-      }
-      return resourceExists;
-    });
-  }
-
   createUpdateConfig(req, res) {
     assert.ok(req.query.key, 'Key parameter must be defined for the Create Config request');
     assert.ok(req.query.value, 'Value parameter must be defind for the Create Config request');
     logger.info(`Creating config with key: ${req.query.key} and value: ${req.query.value}`);
-    let configParam = {};
-    _.set(configParam, req.query.key, req.query.value);
-    const configMapObject = {
-      api_version: CONST.APISERVER.CONFIG_MAP.API_VERSION,
-      resourceType: CONST.APISERVER.CONFIG_MAP.RESOURCE_TYPE,
-      resourceName: CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME,
-      data: configParam
+    const configObject = {
+      key: req.query.key,
+      value: req.query.value
     };
-
-    if (this.checkIfResourceExists(CONST.APISERVER.CONFIG_MAP.API_VERSION, CONST.APISERVER.CONFIG_MAP.RESOURCE_TYPE, CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME)) {
-      return eventmesh.apiServerClient.updateConfigMap(configMapObject)
-        .then(() => {
-          return res.status(200).send(`Creating config with key: ${req.query.key} and value: ${req.query.value}`);
-        });
-    } else {
-      return eventmesh.apiServerClient.createConfigMap(configMapObject)
-        .then(() => {
-          return res.status(200).send(`Creating config with key: ${req.query.key} and value: ${req.query.value}`);
-        });
-    }
+    return eventmesh.apiServerClient.createUpdateConfigMap(configObject)
+      .then(() => {
+        return res.status(200).send(`Created/Updated ${req.query.key} with value ${req.query.value}`);
+      });
   }
 
   getConfig(req, res) {

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -744,7 +744,7 @@ class ServiceFabrikAdminController extends FabrikBaseController {
       key: req.query.key,
       value: req.query.value
     };
-    return eventmesh.apiServerClient.createUpdateConfigMapResource(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME, config)
+    return eventmesh.apiServerClient.createUpdateConfigMapResource(CONST.CONFIG.RESOURCE_NAME, config)
       .then(() => {
         return res.status(201).send(`Created/Updated ${req.query.key} with value ${req.query.value}`);
       });
@@ -752,7 +752,7 @@ class ServiceFabrikAdminController extends FabrikBaseController {
 
   getConfig(req, res) {
     assert.ok(req.params.name, 'Key parameter must be defined for the Get Config request');
-    return eventmesh.apiServerClient.getConfigMap(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME, req.params.name)
+    return eventmesh.apiServerClient.getConfigMap(CONST.CONFIG.RESOURCE_NAME, req.params.name)
       .tap(value => logger.debug(`Returning config with key: ${req.params.name} and value: ${value}`))
       .then(value => {
         const body = {

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Promise = require('bluebird');
+const assert = require('assert');
 var moment = require('moment-timezone');
 const catalog = require('../common/models/catalog');
 const errors = require('../common/errors');
@@ -733,6 +734,32 @@ class ServiceFabrikAdminController extends FabrikBaseController {
       .then(body => res
         .status(200)
         .send(body));
+  }
+
+  createConfig(req, res) {
+    assert.ok(req.query.key, 'Key parameter must be defined for the Create Config request');
+    assert.ok(req.query.value, 'Value parameter must be defind for the Create Config request');
+    logger.info(`Creating config with key: ${req.query.key} and value: ${req.query.value}`);
+    return res.status(200).send(`Creating config with key: ${req.query.key} and value: ${req.query.value}`);
+  }
+
+  updateConfig(req, res) {
+    assert.ok(req.query.key, 'Key parameter must be defined for the Update Config request');
+    assert.ok(req.query.value, 'Value parameter must be defind for the Update Config request');
+    logger.info(`Updating config with key: ${req.query.key} and value: ${req.query.value}`);
+    return res.status(200).send(`Updating config with key: ${req.query.key} and value: ${req.query.value}`);
+  }
+
+  deleteConfig(req, res) {
+    assert.ok(req.query.key, 'Key parameter must be defined for the Delete Config request');
+    logger.info(`Deleting config with key: ${req.query.key}`);
+    return res.status(200).send(`Deleting config with key: ${req.query.key}`);
+  }
+
+  getConfig(req, res) {
+    assert.ok(req.params.name, 'Key parameter must be defined for the Get Config request');
+    logger.info(`Getting config with key: ${req.params.name}`);
+    return res.status(200).send(`Getting config with key: ${req.params.name}`);
   }
 
   getInstancesWithUpdateScheduled() {

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -738,22 +738,29 @@ class ServiceFabrikAdminController extends FabrikBaseController {
 
   createUpdateConfig(req, res) {
     assert.ok(req.query.key, 'Key parameter must be defined for the Create Config request');
-    assert.ok(req.query.value, 'Value parameter must be defind for the Create Config request');
+    assert.ok(req.query.value, 'Value parameter must be defined for the Create Config request');
     logger.info(`Creating config with key: ${req.query.key} and value: ${req.query.value}`);
-    const configObject = {
+    const config = {
       key: req.query.key,
       value: req.query.value
     };
-    return eventmesh.apiServerClient.createUpdateConfigMap(configObject)
+    return eventmesh.apiServerClient.createUpdateConfigMapResource(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME, config)
       .then(() => {
-        return res.status(200).send(`Created/Updated ${req.query.key} with value ${req.query.value}`);
+        return res.status(201).send(`Created/Updated ${req.query.key} with value ${req.query.value}`);
       });
   }
 
   getConfig(req, res) {
     assert.ok(req.params.name, 'Key parameter must be defined for the Get Config request');
-    logger.info(`Getting config with key: ${req.params.name}`);
-    return res.status(200).send(`Getting config with key: ${req.params.name}`);
+    return eventmesh.apiServerClient.getConfigMap(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME, req.params.name)
+      .tap(value => logger.debug(`Returning config with key: ${req.params.name} and value: ${value}`))
+      .then(value => {
+        const body = {
+          value: value,
+          key: req.params.name
+        };
+        return res.status(200).send(body);
+      });
   }
 
   getInstancesWithUpdateScheduled() {

--- a/api-controllers/routes/admin.js
+++ b/api-controllers/routes/admin.js
@@ -35,7 +35,7 @@ router.route('/backups/:backup_guid/delete')
 router.route('/config/create')
   .post(controller.handler('createUpdateConfig'))
   .all(commonMiddleware.methodNotAllowed(['POST']));
-router.route('/config/:name/get')
+router.route('/config/:name')
   .get(controller.handler('getConfig'))
   .all(commonMiddleware.methodNotAllowed(['GET']));
 router.route('/service-fabrik/db')

--- a/api-controllers/routes/admin.js
+++ b/api-controllers/routes/admin.js
@@ -32,9 +32,9 @@ router.route('/backups')
 router.route('/backups/:backup_guid/delete')
   .post(controller.handler('deleteBackup'))
   .all(commonMiddleware.methodNotAllowed(['POST']));
-router.route('/config/create')
-  .post(controller.handler('createUpdateConfig'))
-  .all(commonMiddleware.methodNotAllowed(['POST']));
+router.route('/config')
+  .put(controller.handler('createUpdateConfig'))
+  .all(commonMiddleware.methodNotAllowed(['PUT']));
 router.route('/config/:name')
   .get(controller.handler('getConfig'))
   .all(commonMiddleware.methodNotAllowed(['GET']));

--- a/api-controllers/routes/admin.js
+++ b/api-controllers/routes/admin.js
@@ -32,6 +32,18 @@ router.route('/backups')
 router.route('/backups/:backup_guid/delete')
   .post(controller.handler('deleteBackup'))
   .all(commonMiddleware.methodNotAllowed(['POST']));
+router.route('/config/create')
+  .post(controller.handler('createConfig'))
+  .all(commonMiddleware.methodNotAllowed(['POST']));
+router.route('/config/update')
+  .post(controller.handler('updateConfig'))
+  .all(commonMiddleware.methodNotAllowed(['POST']));
+router.route('/config/delete')
+  .post(controller.handler('deleteConfig'))
+  .all(commonMiddleware.methodNotAllowed(['POST']));
+router.route('/config/:name/get')
+  .get(controller.handler('getConfig'))
+  .all(commonMiddleware.methodNotAllowed(['GET']));
 router.route('/service-fabrik/db')
   .post(controller.handler('provisionDataBase'))
   .put(controller.handler('updateDatabaseDeployment'))

--- a/api-controllers/routes/admin.js
+++ b/api-controllers/routes/admin.js
@@ -33,13 +33,7 @@ router.route('/backups/:backup_guid/delete')
   .post(controller.handler('deleteBackup'))
   .all(commonMiddleware.methodNotAllowed(['POST']));
 router.route('/config/create')
-  .post(controller.handler('createConfig'))
-  .all(commonMiddleware.methodNotAllowed(['POST']));
-router.route('/config/update')
-  .post(controller.handler('updateConfig'))
-  .all(commonMiddleware.methodNotAllowed(['POST']));
-router.route('/config/delete')
-  .post(controller.handler('deleteConfig'))
+  .post(controller.handler('createUpdateConfig'))
   .all(commonMiddleware.methodNotAllowed(['POST']));
 router.route('/config/:name/get')
   .get(controller.handler('getConfig'))

--- a/common/constants.js
+++ b/common/constants.js
@@ -148,6 +148,9 @@ module.exports = Object.freeze({
     HUMAN_INTERVAL: 'human-readable-interval',
     CRON_EXPRESSION: 'cron_expression'
   },
+  CONFIG: {
+    SCHEDULED_UPDATE_CONFIG_PREFIX: 'disable_scheduled_update_'
+  },
   DB_MODEL: {
     //Define all DB Model names
     JOB: 'JobDetail',

--- a/common/constants.js
+++ b/common/constants.js
@@ -271,6 +271,12 @@ module.exports = Object.freeze({
     API_VERSION: 'v1alpha1',
     CRD_RESOURCE_GROUP: 'apiextensions.k8s.io',
     PATCH_CONTENT_TYPE: 'application/merge-patch+json',
+    CONFIG_MAP: {
+      API_VERSION: 'v1',
+      RESOURCE_TYPE: 'configmaps',
+      RESOURCE_NAME: 'sfconfig',
+      RESOURCE_KIND: 'ConfigMap'
+    },
     RESOURCE_GROUPS: {
       LOCK: 'lock.servicefabrik.io',
       DEPLOYMENT: 'deployment.servicefabrik.io',

--- a/common/constants.js
+++ b/common/constants.js
@@ -149,7 +149,8 @@ module.exports = Object.freeze({
     CRON_EXPRESSION: 'cron_expression'
   },
   CONFIG: {
-    SCHEDULED_UPDATE_CONFIG_PREFIX: 'disable_scheduled_update_'
+    DISABLE_SCHEDULED_UPDATE_CONFIG_PREFIX: 'disable_scheduled_update_',
+    RESOURCE_NAME: 'sfconfig'
   },
   DB_MODEL: {
     //Define all DB Model names
@@ -277,7 +278,6 @@ module.exports = Object.freeze({
     CONFIG_MAP: {
       API_VERSION: 'v1',
       RESOURCE_TYPE: 'configmaps',
-      RESOURCE_NAME: 'sfconfig',
       RESOURCE_KIND: 'ConfigMap'
     },
     RESOURCE_GROUPS: {

--- a/common/utils/ServiceBrokerClient.js
+++ b/common/utils/ServiceBrokerClient.js
@@ -98,6 +98,21 @@ class ServiceBrokerClient extends HttpClient {
       }, 202)
       .then(res => res.body);
   }
+
+  getConfigValue(key) {
+    logger.debug(`Getting the config value for key: ${key}`);
+    return this
+      .request({
+        method: 'GET',
+        url: `/admin/config/${key}`,
+        auth: {
+          user: config.username,
+          pass: config.password
+        },
+        json: true
+      }, 200)
+      .then(res => res.body.value);
+  }
 }
 
 module.exports = new ServiceBrokerClient();

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -41,24 +41,24 @@ function convertToHttpErrorAndThrow(err) {
     code = err.status;
   }
   switch (code) {
-    case CONST.HTTP_STATUS_CODE.BAD_REQUEST:
-      newErr = new BadRequest(message);
-      break;
-    case CONST.HTTP_STATUS_CODE.NOT_FOUND:
-      newErr = new NotFound(message);
-      break;
-    case CONST.HTTP_STATUS_CODE.CONFLICT:
-      newErr = new Conflict(message);
-      break;
-    case CONST.HTTP_STATUS_CODE.FORBIDDEN:
-      newErr = new errors.Forbidden(message);
-      break;
-    case CONST.HTTP_STATUS_CODE.GONE:
-      newErr = new errors.Gone(message);
-      break;
-    default:
-      newErr = new InternalServerError(message);
-      break;
+  case CONST.HTTP_STATUS_CODE.BAD_REQUEST:
+    newErr = new BadRequest(message);
+    break;
+  case CONST.HTTP_STATUS_CODE.NOT_FOUND:
+    newErr = new NotFound(message);
+    break;
+  case CONST.HTTP_STATUS_CODE.CONFLICT:
+    newErr = new Conflict(message);
+    break;
+  case CONST.HTTP_STATUS_CODE.FORBIDDEN:
+    newErr = new errors.Forbidden(message);
+    break;
+  case CONST.HTTP_STATUS_CODE.GONE:
+    newErr = new errors.Gone(message);
+    break;
+  default:
+    newErr = new InternalServerError(message);
+    break;
   }
   throw newErr;
 }
@@ -73,8 +73,8 @@ class ApiServerClient {
     return Promise.try(() => {
       if (!this.ready) {
         return Promise.map(_.values(config.apiserver.crds), crdTemplate => {
-          apiserver.addCustomResourceDefinition(yaml.safeLoad(Buffer.from(crdTemplate, 'base64')));
-        })
+            apiserver.addCustomResourceDefinition(yaml.safeLoad(Buffer.from(crdTemplate, 'base64')));
+          })
           .then(() => apiserver.loadSpec())
           .then(() => {
             this.ready = true;
@@ -189,11 +189,11 @@ class ApiServerClient {
     return Promise.try(() => this.init())
       .then(() => {
         return apiserver.apis[CONST.APISERVER.CRD_RESOURCE_GROUP].v1beta1.customresourcedefinitions(crdJson.metadata.name).patch({
-          body: crdJson,
-          headers: {
-            'content-type': CONST.APISERVER.PATCH_CONTENT_TYPE
-          }
-        })
+            body: crdJson,
+            headers: {
+              'content-type': CONST.APISERVER.PATCH_CONTENT_TYPE
+            }
+          })
           .catch(err => {
             return convertToHttpErrorAndThrow(err);
           });
@@ -322,8 +322,7 @@ class ApiServerClient {
           .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceName).patch({
             body: resourceBody
           });
-      }
-      )
+      })
       .catch(err => {
         return convertToHttpErrorAndThrow(err);
       });
@@ -345,43 +344,43 @@ class ApiServerClient {
     assert.ok(opts.resourceId, `Property 'resourceId' is required to update resource`);
     assert.ok(opts.metadata || opts.options || opts.status || opts.operatorMetadata, `Property 'metadata' or 'options' or 'status' or 'operatorMetadata'  is required to update resource`);
     return Promise.try(() => {
-      const patchBody = {};
-      if (opts.metadata) {
-        patchBody.metadata = opts.metadata;
-      }
-      if (opts.options) {
-        patchBody.spec = {
-          'options': JSON.stringify(opts.options)
-        };
-      }
-      if (opts.operatorMetadata) {
-        patchBody.operatorMetadata = opts.operatorMetadata;
-      }
-      if (opts.status) {
-        const statusJson = {};
-        _.forEach(opts.status, (val, key) => {
-          if (key === 'state') {
-            patchBody.metadata = _.merge(patchBody.metadata, {
-              labels: {
-                'state': val
-              }
-            });
-          }
-          statusJson[key] = _.isObject(val) ? JSON.stringify(val) : val;
-        });
-        patchBody.status = statusJson;
-      }
-      logger.info(`Updating - Resource ${opts.resourceId} with body - ${JSON.stringify(patchBody)}`);
-      return Promise.try(() => this.init())
-        .then(() => apiserver
-          .apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
-          .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).patch({
-            body: patchBody,
-            headers: {
-              'content-type': CONST.APISERVER.PATCH_CONTENT_TYPE
+        const patchBody = {};
+        if (opts.metadata) {
+          patchBody.metadata = opts.metadata;
+        }
+        if (opts.options) {
+          patchBody.spec = {
+            'options': JSON.stringify(opts.options)
+          };
+        }
+        if (opts.operatorMetadata) {
+          patchBody.operatorMetadata = opts.operatorMetadata;
+        }
+        if (opts.status) {
+          const statusJson = {};
+          _.forEach(opts.status, (val, key) => {
+            if (key === 'state') {
+              patchBody.metadata = _.merge(patchBody.metadata, {
+                labels: {
+                  'state': val
+                }
+              });
             }
-          }));
-    })
+            statusJson[key] = _.isObject(val) ? JSON.stringify(val) : val;
+          });
+          patchBody.status = statusJson;
+        }
+        logger.info(`Updating - Resource ${opts.resourceId} with body - ${JSON.stringify(patchBody)}`);
+        return Promise.try(() => this.init())
+          .then(() => apiserver
+            .apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+            .namespaces(CONST.APISERVER.NAMESPACE)[opts.resourceType](opts.resourceId).patch({
+              body: patchBody,
+              headers: {
+                'content-type': CONST.APISERVER.PATCH_CONTENT_TYPE
+              }
+            }));
+      })
       .catch(err => {
         return convertToHttpErrorAndThrow(err);
       });
@@ -651,10 +650,10 @@ class ApiServerClient {
    */
   getPlatformContext(opts) {
     return this.getResource({
-      resourceGroup: opts.resourceGroup,
-      resourceType: opts.resourceType,
-      resourceId: opts.resourceId
-    })
+        resourceGroup: opts.resourceGroup,
+        resourceType: opts.resourceType,
+        resourceId: opts.resourceId
+      })
       .then(resource => _.get(resource, 'spec.options.context'));
   }
 }

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -551,10 +551,7 @@ class ApiServerClient {
   }
 
   getConfigMap(configName, key) {
-    return this.getConfigMapResource(configName).then((body) => {
-      const configParam = body.data;
-      return _.get(configParam, key);
-    });
+    return this.getConfigMapResource(configName).then((body) => _.get(body.data, key));
   }
 
   /**

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -540,6 +540,7 @@ class ApiServerClient {
       .then(() => this.getConfigMapResource(configName))
       .then((oldResourceBody) => {
         resourceBody.data = oldResourceBody.data ? _.merge(oldResourceBody.data, data) : resourceBody.data;
+        resourceBody.metadata.resourceVersion = oldResourceBody.metadata.resourceVersion || undefined;
         return apiserver.api[CONST.APISERVER.CONFIG_MAP.API_VERSION]
           .namespaces(CONST.APISERVER.NAMESPACE)[CONST.APISERVER.CONFIG_MAP.RESOURCE_TYPE](configName).patch({
             body: resourceBody

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -540,7 +540,7 @@ class ApiServerClient {
       .then(() => this.getConfigMapResource(configName))
       .then((oldResourceBody) => {
         resourceBody.data = oldResourceBody.data ? _.merge(oldResourceBody.data, data) : resourceBody.data;
-        resourceBody.metadata.resourceVersion = oldResourceBody.metadata.resourceVersion || undefined;
+        resourceBody.metadata.resourceVersion = oldResourceBody.metadata.resourceVersion;
         return apiserver.api[CONST.APISERVER.CONFIG_MAP.API_VERSION]
           .namespaces(CONST.APISERVER.NAMESPACE)[CONST.APISERVER.CONFIG_MAP.RESOURCE_TYPE](configName).patch({
             body: resourceBody

--- a/jobs/ServiceInstanceUpdateJob.js
+++ b/jobs/ServiceInstanceUpdateJob.js
@@ -87,7 +87,7 @@ class ServiceInstanceUpdateJob extends BaseJob {
   static isInstanceUpdateDisabled(resourceDetails) {
     const serviceId = _.get(resourceDetails, 'service_id');
     const serviceName = catalog.getServiceName(serviceId);
-    const configKey = CONST.CONFIG.SCHEDULED_UPDATE_CONFIG_PREFIX + serviceName;
+    const configKey = CONST.CONFIG.DISABLE_SCHEDULED_UPDATE_CONFIG_PREFIX + serviceName;
     return serviceBrokerClient.getConfigValue(configKey);
   }
 

--- a/jobs/ServiceInstanceUpdateJob.js
+++ b/jobs/ServiceInstanceUpdateJob.js
@@ -51,9 +51,20 @@ class ServiceInstanceUpdateJob extends BaseJob {
         })
         .catch(errors.NotFound, () => undefined)
         .then(resource => _.get(resource, 'spec.options'))
-        .then(resourceDetails => (resourceDetails === undefined ?
-          this.handleInstanceDeletion(instanceDetails, operationResponse, done) :
-          this.updateInstanceIfOutdated(instanceDetails, resourceDetails, operationResponse)))
+        .then(resourceDetails => {
+          if (resourceDetails) {
+            return this.isInstanceUpdateDisabled(resourceDetails)
+              .then(disabled => {
+                if (!disabled) {
+                  return this.updateInstanceIfOutdated(instanceDetails, resourceDetails, operationResponse);
+                }
+                operationResponse.update_init = 'disabled';
+                return operationResponse;
+              });
+          } else {
+            return this.handleInstanceDeletion(instanceDetails, operationResponse, done);
+          }
+        })
         .then(opResponse => this.runSucceeded(opResponse, job, done))
         .catch((error) => {
           this.runFailed(error, operationResponse, job, done);
@@ -71,6 +82,13 @@ class ServiceInstanceUpdateJob extends BaseJob {
         operationResponse.instance_deleted = true;
         return operationResponse;
       });
+  }
+
+  static isInstanceUpdateDisabled(resourceDetails) {
+    const serviceId = _.get(resourceDetails, 'service_id');
+    const serviceName = catalog.getServiceName(serviceId);
+    const configKey = CONST.CONFIG.SCHEDULED_UPDATE_CONFIG_PREFIX + serviceName;
+    return serviceBrokerClient.getConfigValue(configKey);
   }
 
   static updateInstanceIfOutdated(instanceDetails, resourceDetails, operationResponse) {

--- a/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
@@ -6,6 +6,7 @@ const config = require('../../../common/config');
 const proxyquire = require('proxyquire');
 const CONST = require('../../../common/constants');
 const ServiceFabrikAdminController = require('../../../api-controllers/ServiceFabrikAdminController');
+const APIServerClient = require('../../../data-access-layer/eventmesh/ApiServerClient');
 const numOfInstances = 2 * config.mongodb.record_max_fetch_count;
 
 const getInstance = (instanceId) => {
@@ -68,6 +69,33 @@ describe('service-fabrik-admin', function () {
         .then(res => {
           expect(res.body).to.have.length(2);
           expect(res).to.have.status(200);
+        });
+    });
+  });
+
+  describe('#getConfig', function () {
+    let getConfigMapStub;
+
+    before(function () {
+      getConfigMapStub = sinon.stub(APIServerClient.prototype, 'getConfigMap');
+    });
+
+    after(function () {
+      getConfigMapStub.restore();
+    });
+
+    it('should get the config parameters (key/value) for the given config key name', function () {
+      getConfigMapStub.returns(Promise.resolve(true));
+      return chai
+        .request(app)
+        .get(`${base_url}/config/disable_scheduled_update_blueprint`)
+        .set('Accept', 'application/json')
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          expect(res).to.have.status(200);
+          expect(res.body.key).to.be.equal('disable_scheduled_update_blueprint');
+          expect(res.body.value).to.be.equal(true);
         });
     });
   });

--- a/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
@@ -100,6 +100,48 @@ describe('service-fabrik-admin', function () {
     });
   });
 
+  describe('#createUpdateConfig', function () {
+    let createUpdateConfigMapStub;
+
+    before(function () {
+      createUpdateConfigMapStub = sinon.stub(APIServerClient.prototype, 'createUpdateConfigMapResource');
+    });
+
+    after(function () {
+      createUpdateConfigMapStub.restore();
+    });
+
+    it('should create the config map resource for the given config parameters', function () {
+      createUpdateConfigMapStub.returns(Promise.resolve({
+        body: {
+          apiVersion: 'v1',
+          data: {
+            disable_scheduled_update_blueprint: 'true'
+          },
+          kind: 'ConfigMap',
+          metadata: {
+            creationTimestamp: '2018-12-05T11:31:28Z',
+            name: 'sfconfig',
+            namespace: 'default',
+            resourceVersion: '370255',
+            selfLink: '/api/v1/namespaces/default/configmaps/sfconfig',
+            uid: '4e47d831-f881-11e8-9055-123c04a61866'
+          }
+        }
+      }));
+      return chai
+        .request(app)
+        .put(`${base_url}/config?key=disable_scheduled_update_blueprint&value=false`)
+        .set('Accept', 'application/json')
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          expect(res).to.have.status(201);
+          expect(res.text).to.be.equal('Created/Updated disable_scheduled_update_blueprint with value false');
+        });
+    });
+  });
+
   describe('#getInstancesWithUpdateScheduled', function () {
     const adminController = proxyquire('../../../api-controllers/ServiceFabrikAdminController', {
       '../common/db': {

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -887,6 +887,12 @@ describe('eventmesh', () => {
         return apiserver.createConfigMapResource(CONST.CONFIG.RESOURCE_NAME, configParam)
           .then(res => {
             expect(res.body.apiVersion).to.eql(CONST.APISERVER.CONFIG_MAP.API_VERSION);
+            expect(res.body.data).to.eql({
+              disable_scheduled_update_blueprint: 'true'
+            });
+            expect(res.body.kind).to.eql(CONST.APISERVER.CONFIG_MAP.RESOURCE_KIND);
+            expect(res.body.metadata.resourceVersion).to.eql('370255');
+            expect(res.body.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
             verify();
           });
       });
@@ -920,6 +926,12 @@ describe('eventmesh', () => {
         return apiserver.getConfigMapResource(CONST.CONFIG.RESOURCE_NAME)
           .then(res => {
             expect(res.apiVersion).to.eql(CONST.APISERVER.CONFIG_MAP.API_VERSION);
+            expect(res.data).to.eql({
+              disable_scheduled_update_blueprint: 'true'
+            });
+            expect(res.kind).to.eql(CONST.APISERVER.CONFIG_MAP.RESOURCE_KIND);
+            expect(res.metadata.resourceVersion).to.eql('370255');
+            expect(res.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
             verify();
           });
       });
@@ -965,6 +977,12 @@ describe('eventmesh', () => {
         return apiserver.createUpdateConfigMapResource(CONST.CONFIG.RESOURCE_NAME, configParam)
           .then(res => {
             expect(res.body.apiVersion).to.eql(CONST.APISERVER.CONFIG_MAP.API_VERSION);
+            expect(res.body.data).to.eql({
+              disable_scheduled_update_blueprint: 'true'
+            });
+            expect(res.body.kind).to.eql(CONST.APISERVER.CONFIG_MAP.RESOURCE_KIND);
+            expect(res.body.metadata.resourceVersion).to.eql('370255');
+            expect(res.body.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
             verify();
           });
       });
@@ -974,7 +992,8 @@ describe('eventmesh', () => {
           apiVersion: 'v1',
           kind: 'ConfigMap',
           metadata: {
-            name: 'sfconfig'
+            name: 'sfconfig',
+            resourceVersion: '370255'
           },
           data: {
             disable_scheduled_update_blueprint: 'false'
@@ -988,6 +1007,12 @@ describe('eventmesh', () => {
         return apiserver.createUpdateConfigMapResource(CONST.CONFIG.RESOURCE_NAME, configParam)
           .then(res => {
             expect(res.body.apiVersion).to.eql(CONST.APISERVER.CONFIG_MAP.API_VERSION);
+            expect(res.body.data).to.eql({
+              disable_scheduled_update_blueprint: 'true'
+            });
+            expect(res.body.kind).to.eql(CONST.APISERVER.CONFIG_MAP.RESOURCE_KIND);
+            expect(res.body.metadata.resourceVersion).to.eql('370255');
+            expect(res.body.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
             verify();
           });
       });

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -36,54 +36,6 @@ const expectedGetDeploymentResponse = {
   }
 };
 
-const expectedCreateConfigMapResponse = {
-  apiVersion: 'v1',
-  data: {
-    disable_scheduled_update_blueprint: 'true'
-  },
-  kind: 'ConfigMap',
-  metadata: {
-    creationTimestamp: '2018-12-05T11:31:28Z',
-    name: 'sfconfig',
-    namespace: 'default',
-    resourceVersion: '370255',
-    selfLink: '/api/v1/namespaces/default/configmaps/sfconfig',
-    uid: '4e47d831-f881-11e8-9055-123c04a61866'
-  }
-};
-
-const expectedGetConfigMapResponseEnabled = {
-  apiVersion: 'v1',
-  data: {
-    disable_scheduled_update_blueprint: 'false'
-  },
-  kind: 'ConfigMap',
-  metadata: {
-    creationTimestamp: '2018-12-05T11:31:28Z',
-    name: 'sfconfig',
-    namespace: 'default',
-    resourceVersion: '370255',
-    selfLink: '/api/v1/namespaces/default/configmaps/sfconfig',
-    uid: '4e47d831-f881-11e8-9055-123c04a61866'
-  }
-};
-
-const expectedGetConfigMapResponseDisabled = {
-  apiVersion: 'v1',
-  data: {
-    disable_scheduled_update_blueprint: 'false'
-  },
-  kind: 'ConfigMap',
-  metadata: {
-    creationTimestamp: '2018-12-05T11:31:28Z',
-    name: 'sfconfig',
-    namespace: 'default',
-    resourceVersion: '370255',
-    selfLink: '/api/v1/namespaces/default/configmaps/sfconfig',
-    uid: '4e47d831-f881-11e8-9055-123c04a61866'
-  }
-};
-
 const sampleDeploymentResource = {
   metadata: {
     name: 'deployment1',
@@ -130,12 +82,6 @@ function nockCreateConfigMap(response, expectedStatusCode, payload) {
   nock(apiServerHost)
     .post(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps`, JSON.stringify(payload))
     .reply(expectedStatusCode || 200, response);
-}
-
-function nockGetConfigMap(expectedStatusCode, enabled) {
-  nock(apiServerHost)
-    .get(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps`)
-    .reply(expectedStatusCode || 200, enabled ? expectedGetConfigMapResponseEnabled : expectedGetConfigMapResponseDisabled);
 }
 
 function nockPatchResource(resourceGroup, resourceType, id, response, payload, expectedExpectedCode) {

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -118,13 +118,13 @@ function nockCreateConfigMap(response, expectedStatusCode, payload) {
 
 function nockGetConfigMap(response, expectedStatusCode) {
   nock(apiServerHost)
-    .get(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps/${CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME}`)
+    .get(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`)
     .reply(expectedStatusCode || 200, response);
 }
 
 function nockUpdateConfigMap(response, expectedStatusCode, payload) {
   nock(apiServerHost)
-    .patch(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps/${CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME}`, JSON.stringify(payload))
+    .patch(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`, JSON.stringify(payload))
     .reply(expectedStatusCode || 200, response);
 }
 
@@ -884,7 +884,7 @@ describe('eventmesh', () => {
           key: 'disable_scheduled_update_blueprint',
           value: 'true'
         };
-        return apiserver.createConfigMapResource(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME, configParam)
+        return apiserver.createConfigMapResource(CONST.CONFIG.RESOURCE_NAME, configParam)
           .then(res => {
             expect(res.body.apiVersion).to.eql(CONST.APISERVER.CONFIG_MAP.API_VERSION);
             verify();
@@ -906,7 +906,7 @@ describe('eventmesh', () => {
           key: 'disable_scheduled_update_blueprint',
           value: 'true'
         };
-        return apiserver.createConfigMapResource(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME, configParam)
+        return apiserver.createConfigMapResource(CONST.CONFIG.RESOURCE_NAME, configParam)
           .catch(err => {
             expect(err.status).to.eql(404);
             verify();
@@ -917,7 +917,7 @@ describe('eventmesh', () => {
     describe('getConfigMapResource', () => {
       it('Retrieves an existing config map resource object', () => {
         nockGetConfigMap(expectedConfigMapResponse);
-        return apiserver.getConfigMapResource(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME)
+        return apiserver.getConfigMapResource(CONST.CONFIG.RESOURCE_NAME)
           .then(res => {
             expect(res.apiVersion).to.eql(CONST.APISERVER.CONFIG_MAP.API_VERSION);
             verify();
@@ -925,7 +925,7 @@ describe('eventmesh', () => {
       });
       it('Throws a 404 error if config map resource doesnt exist', () => {
         nockGetConfigMap({}, 404);
-        return apiserver.getConfigMapResource(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME)
+        return apiserver.getConfigMapResource(CONST.CONFIG.RESOURCE_NAME)
           .catch(err => {
             expect(err.status).to.eql(404);
             verify();
@@ -936,7 +936,7 @@ describe('eventmesh', () => {
     describe('getConfigMap', () => {
       it('Retrieves the key-value pair in the existing config map resource object', () => {
         nockGetConfigMap(expectedConfigMapResponse);
-        return apiserver.getConfigMap(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME, 'disable_scheduled_update_blueprint')
+        return apiserver.getConfigMap(CONST.CONFIG.RESOURCE_NAME, 'disable_scheduled_update_blueprint')
           .then(res => {
             expect(res).to.eql('true');
             verify();
@@ -962,7 +962,7 @@ describe('eventmesh', () => {
           key: 'disable_scheduled_update_blueprint',
           value: 'true'
         };
-        return apiserver.createUpdateConfigMapResource(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME, configParam)
+        return apiserver.createUpdateConfigMapResource(CONST.CONFIG.RESOURCE_NAME, configParam)
           .then(res => {
             expect(res.body.apiVersion).to.eql(CONST.APISERVER.CONFIG_MAP.API_VERSION);
             verify();
@@ -985,7 +985,7 @@ describe('eventmesh', () => {
           key: 'disable_scheduled_update_blueprint',
           value: 'false'
         };
-        return apiserver.createUpdateConfigMapResource(CONST.APISERVER.CONFIG_MAP.RESOURCE_NAME, configParam)
+        return apiserver.createUpdateConfigMapResource(CONST.CONFIG.RESOURCE_NAME, configParam)
           .then(res => {
             expect(res.body.apiVersion).to.eql(CONST.APISERVER.CONFIG_MAP.API_VERSION);
             verify();

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -64,6 +64,22 @@ const sampleDeploymentResource = {
   }
 };
 
+const expectedCreateConfigMapResponse = {
+  apiVersion: 'v1',
+  data: {
+    disable_scheduled_update_blueprint: 'true'
+  },
+  kind: 'ConfigMap',
+  metadata: {
+    creationTimestamp: '2018-12-05T11:31:28Z',
+    name: 'sfconfig',
+    namespace: 'default',
+    resourceVersion: '370255',
+    selfLink: '/api/v1/namespaces/default/configmaps/sfconfig',
+    uid: '4e47d831-f881-11e8-9055-123c04a61866'
+  }
+};
+
 function verify() {
   /* jshint expr:true */
   if (!nock.isDone()) {

--- a/test/test_broker/iaas.GcpClient.spec.js
+++ b/test/test_broker/iaas.GcpClient.spec.js
@@ -45,7 +45,9 @@ const storageUrl = 'https://myaccounts.com/storage/v1';
 const bucketUrl = '/b';
 const region = 'EUROPE-WEST1';
 const storageClass = 'REGIONAL';
-const bucketMetadataResponse = [{ /* Bucket Object */ },
+const bucketMetadataResponse = [{
+    /* Bucket Object */
+  },
   {
     kind: 'storage#bucket',
     id: 'sample-container',

--- a/test/test_broker/jobs.ServiceInstanceUpdateJob.spec.js
+++ b/test/test_broker/jobs.ServiceInstanceUpdateJob.spec.js
@@ -195,7 +195,7 @@ describe('Jobs', function () {
     });
     it('if there is no update to be done on the instance, the job just succeeds with status as no_update_required', function (done) {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, resourceDetails());
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, []);
       const expectedResponse = {
@@ -216,6 +216,35 @@ describe('Jobs', function () {
           done();
         }).catch(done);
     });
+    it('if service-specific update flag is disabled, the job just succeeds with status as disabled', function (done) {
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, resourceDetails());
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      const diff = [
+        ['releases:', null],
+        ['- name: blueprint', null],
+        ['  version: 0.0.10', 'removed'],
+        ['  version: 0.0.11', 'added']
+      ];
+      mocks.director.getDeploymentManifest(1);
+      mocks.director.diffDeploymentManifest(1, diff);
+      const expectedResponse = {
+        instance_deleted: false,
+        job_cancelled: false,
+        deployment_outdated: 'TBD',
+        update_init: 'disabled',
+        diff: 'TBD'
+      };
+      return ServiceInstanceUpdateJob
+        .run(job, () => {})
+        .then(() => {
+          expect(cancelScheduleStub).not.to.be.called;
+          expect(baseJobLogRunHistoryStub.firstCall.args[0]).to.eql(undefined);
+          expect(baseJobLogRunHistoryStub.firstCall.args[1]).to.eql(expectedResponse);
+          expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
+          expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
+          done();
+        }).catch(done);
+    });
     it(`if instance is outdated, update must initiated successfully and schedule itself ${config.scheduler.jobs.reschedule_delay}`, function (done) {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, resourceDetails());
       const diff = [
@@ -224,7 +253,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       const expectedResponse = {
@@ -268,7 +297,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       const expectedResponse = {
@@ -310,7 +339,7 @@ describe('Jobs', function () {
         ['  instances: 1', 'removed'],
         ['  instances: 2', 'added']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       const expectedResponse = {
@@ -351,7 +380,7 @@ describe('Jobs', function () {
         ['  - name: broker-agent', 'removed'],
         ['    release: blueprint', 'removed']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       const expectedResponse = {
@@ -391,7 +420,7 @@ describe('Jobs', function () {
         ['  instances: 2', 'removed'],
         ['  instances: 1', 'added']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -433,7 +462,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -474,7 +503,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -516,7 +545,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -566,7 +595,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -612,7 +641,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
-      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', false);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {

--- a/test/test_broker/jobs.ServiceInstanceUpdateJob.spec.js
+++ b/test/test_broker/jobs.ServiceInstanceUpdateJob.spec.js
@@ -195,6 +195,7 @@ describe('Jobs', function () {
     });
     it('if there is no update to be done on the instance, the job just succeeds with status as no_update_required', function (done) {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, resourceDetails());
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, []);
       const expectedResponse = {
@@ -223,6 +224,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       const expectedResponse = {
@@ -266,6 +268,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       const expectedResponse = {
@@ -307,6 +310,7 @@ describe('Jobs', function () {
         ['  instances: 1', 'removed'],
         ['  instances: 2', 'added']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       const expectedResponse = {
@@ -347,6 +351,7 @@ describe('Jobs', function () {
         ['  - name: broker-agent', 'removed'],
         ['    release: blueprint', 'removed']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       const expectedResponse = {
@@ -386,6 +391,7 @@ describe('Jobs', function () {
         ['  instances: 2', 'removed'],
         ['  instances: 1', 'added']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -427,6 +433,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -467,6 +474,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -508,6 +516,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -557,6 +566,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {
@@ -602,6 +612,7 @@ describe('Jobs', function () {
         ['  version: 0.0.10', 'removed'],
         ['  version: 0.0.11', 'added']
       ];
+      mocks.serviceBrokerClient.getConfigValue(undefined, 'disable_scheduled_update_blueprint', true);
       mocks.director.getDeploymentManifest(1);
       mocks.director.diffDeploymentManifest(1, diff);
       mocks.serviceBrokerClient.updateServiceInstance(instance_id, (body) => {

--- a/test/test_broker/mocks/apiServerEventMesh.js
+++ b/test/test_broker/mocks/apiServerEventMesh.js
@@ -11,12 +11,45 @@ exports.nockLoadSpec = nockLoadSpec;
 exports.nockCreateResource = nockCreateResource;
 exports.nockPatchResource = nockPatchResource;
 exports.nockGetResource = nockGetResource;
+exports.nockGetConfigMap = nockGetConfigMap;
 exports.nockGetResourceRegex = nockGetResourceRegex;
 exports.nockDeleteResource = nockDeleteResource;
 exports.nockPatchResourceRegex = nockPatchResourceRegex;
 exports.nockGetResourceListByState = nockGetResourceListByState;
 exports.nockCreateCrd = nockCreateCrd;
 exports.nockPatchCrd = nockPatchCrd;
+
+const expectedGetConfigMapResponseEnabled = {
+  apiVersion: 'v1',
+  data: {
+    disable_scheduled_update_blueprint: 'false'
+  },
+  kind: 'ConfigMap',
+  metadata: {
+    creationTimestamp: '2018-12-05T11:31:28Z',
+    name: 'sfconfig',
+    namespace: 'default',
+    resourceVersion: '370255',
+    selfLink: '/api/v1/namespaces/default/configmaps/sfconfig',
+    uid: '4e47d831-f881-11e8-9055-123c04a61866'
+  }
+};
+
+const expectedGetConfigMapResponseDisabled = {
+  apiVersion: 'v1',
+  data: {
+    disable_scheduled_update_blueprint: 'false'
+  },
+  kind: 'ConfigMap',
+  metadata: {
+    creationTimestamp: '2018-12-05T11:31:28Z',
+    name: 'sfconfig',
+    namespace: 'default',
+    resourceVersion: '370255',
+    selfLink: '/api/v1/namespaces/default/configmaps/sfconfig',
+    uid: '4e47d831-f881-11e8-9055-123c04a61866'
+  }
+};
 
 function nockLoadSpec(times) {
   nock(apiServerHost)
@@ -53,6 +86,12 @@ function nockCreateResource(resourceGroup, resourceType, response, times, verifi
     .post(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}`, verifier)
     .times(times || 1)
     .reply(expectedStatusCode || 201, response);
+}
+
+function nockGetConfigMap(expectedStatusCode, enabled) {
+  nock(apiServerHost)
+    .get(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.NAMESPACE}/configmaps`)
+    .reply(expectedStatusCode || 200, enabled ? expectedGetConfigMapResponseEnabled : expectedGetConfigMapResponseDisabled);
 }
 
 function nockPatchResource(resourceGroup, resourceType, id, response, times, payload, expectedStatusCode) {

--- a/test/test_broker/mocks/serviceBrokerClient.js
+++ b/test/test_broker/mocks/serviceBrokerClient.js
@@ -12,6 +12,7 @@ exports.getDeploymentRestoreStatus = getDeploymentRestoreStatus;
 exports.startDeploymentBackup = startDeploymentBackup;
 exports.getDeploymentBackupStatus = getDeploymentBackupStatus;
 exports.updateServiceInstance = updateServiceInstance;
+exports.getConfigValue = getConfigValue;
 
 function isoDate(time) {
   return new Date(time).toISOString().replace(/\.\d*/, '').replace(/:/g, '-');
@@ -87,4 +88,11 @@ function updateServiceInstance(instace_id, payload, response) {
       accepts_incomplete: true
     })
     .reply(response.status || 202, response.body || {});
+}
+
+function getConfigValue(responseStatus, key, enabled) {
+  return nock(serviceBrokerUrl)
+    .replyContentLength()
+    .get(`/admin/config/${key}`)
+    .reply(responseStatus || 200, enabled);
 }

--- a/test/test_broker/mocks/serviceBrokerClient.js
+++ b/test/test_broker/mocks/serviceBrokerClient.js
@@ -90,9 +90,11 @@ function updateServiceInstance(instace_id, payload, response) {
     .reply(response.status || 202, response.body || {});
 }
 
-function getConfigValue(responseStatus, key, enabled) {
+function getConfigValue(responseStatus, key, disabled) {
   return nock(serviceBrokerUrl)
     .replyContentLength()
     .get(`/admin/config/${key}`)
-    .reply(responseStatus || 200, enabled);
+    .reply(responseStatus || 200, {
+      value: disabled
+    });
 }


### PR DESCRIPTION
The idea here is to have an easy way to enable/disable the `schedule_update` feature for service.
Thus, the approach here is to expose an admin API endpoint to pass a config parameter with pre-defined key (`disable_scheduled_update_` + service-name). This config is read at the run-time of the job and if the update is disabled, then the update doesn't run.
To make things generic, introducing a configMap resource to store the configs. This is to toggle any other feature in the future.
There are basically 2 endpoints:
1. Creating/Updating a config
2. Getting the config (this can be used for internal feature functions)