### PR TITLE
Adding postgresql service and plan samples

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -18,6 +18,7 @@ const Conflict = errors.Conflict;
 const CONST = require('../common/constants');
 const eventmesh = require('../data-access-layer/eventmesh');
 const formatUrl = require('url').format;
+const lib = require('../broker/lib');
 
 class ServiceBrokerApiController extends FabrikBaseController {
   constructor() {
@@ -41,9 +42,10 @@ class ServiceBrokerApiController extends FabrikBaseController {
 
   getCatalog(req, res) {
     /* jshint unused:false */
-    res.status(CONST.HTTP_STATUS_CODE.OK).json(utils.getPlatformManager({
-      platform: req.params.platform
-    }).getCatalog(catalog));
+    return Promise.try(() => lib.loadServices())
+      .then(() => res.status(CONST.HTTP_STATUS_CODE.OK).json(utils.getPlatformManager({
+        platform: req.params.platform
+      }).getCatalog(catalog)));
   }
 
   putInstance(req, res) {

--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -73,8 +73,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     return Promise
       .try(() => {
         return eventmesh.apiServerClient.createOSBResource({
-          resourceGroup: 'osb.servicefabrik.io',
-          resourceType: 'serviceinstances',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
           resourceId: req.params.instance_id,
           spec: params,
           status: {
@@ -213,8 +213,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     return Promise
       .try(() => {
         return eventmesh.apiServerClient.patchOSBResource({
-          resourceGroup: 'osb.servicefabrik.io',
-          resourceType: 'serviceinstances',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
           resourceId: req.params.instance_id,
           spec: params,
           status: {
@@ -273,8 +273,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     }
     const planId = req.query.plan_id;
     const plan = catalog.getPlan(planId);
-    const resourceGroup = operation.serviceflow_id ? CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW : 'osb.servicefabrik.io';
-    const resourceType = operation.serviceflow_id ? CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW : 'serviceinstances';
+    const resourceGroup = operation.serviceflow_id ? CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW : CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR;
+    const resourceType = operation.serviceflow_id ? CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW : CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES;
     const resourceId = operation.serviceflow_id ? operation.serviceflow_id : req.params.instance_id;
     return eventmesh.apiServerClient.getLastOperation({
         resourceGroup: resourceGroup,

--- a/common/constants.js
+++ b/common/constants.js
@@ -272,6 +272,7 @@ module.exports = Object.freeze({
     CRD_RESOURCE_GROUP: 'apiextensions.k8s.io',
     PATCH_CONTENT_TYPE: 'application/merge-patch+json',
     RESOURCE_GROUPS: {
+      INTEROPERATOR: 'osb.servicefabrik.io',
       LOCK: 'lock.servicefabrik.io',
       DEPLOYMENT: 'deployment.servicefabrik.io',
       BIND: 'bind.servicefabrik.io',
@@ -280,6 +281,9 @@ module.exports = Object.freeze({
       SERVICE_FLOW: 'serviceflow.servicefabrik.io'
     },
     RESOURCE_TYPES: {
+      INTEROPERATOR_SERVICEINSTANCES: 'serviceinstances',
+      INTEROPERATOR_SERVICES: 'services',
+      INTEROPERATOR_PLANS: 'plans',
       DEPLOYMENT_LOCKS: 'deploymentlocks',
       DIRECTOR: 'directors',
       DOCKER: 'dockers',

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -745,8 +745,8 @@ class ApiServerClient {
 
   getAllServices() {
     return Promise.try(() => this.init())
-      .then(() => apiserver.apis['osb.servicefabrik.io'][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE).services.get())
+      .then(() => apiserver.apis[CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR][CONST.APISERVER.API_VERSION]
+        .namespaces(CONST.APISERVER.NAMESPACE)[CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES].get())
       .then(serviceList => serviceList.body.items)
       .then(serviceList => {
         let services = [];
@@ -762,8 +762,8 @@ class ApiServerClient {
 
   getAllPlansForService(serviceId) {
     return Promise.try(() => this.init())
-      .then(() => apiserver.apis['osb.servicefabrik.io'][CONST.APISERVER.API_VERSION]
-        .namespaces(CONST.APISERVER.NAMESPACE).plans.get({
+      .then(() => apiserver.apis[CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR][CONST.APISERVER.API_VERSION]
+        .namespaces(CONST.APISERVER.NAMESPACE)[CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS].get({
           qs: {
             labelSelector: `serviceId=${serviceId}`
           }

--- a/interoperator/config/samples/osb_v1alpha1_plan4.yaml
+++ b/interoperator/config/samples/osb_v1alpha1_plan4.yaml
@@ -1,0 +1,47 @@
+apiVersion: osb.servicefabrik.io/v1alpha1
+kind: Plan
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    serviceId: '24731fb8-7b84-5f57-914f-c3d55d793dd4'
+  name: &name 'v9.4-dev'
+spec:
+  name: *name
+  id: 'bba8beae-5699-12e7-b35c-02a8da424bc3'
+  description: 'Postgresql service running inside a k8s container (for non-productive usage)'
+  metadata:
+    service-inventory-key: SERVICE-161
+    costs:
+    - amount:
+        usd: 0.0
+      unit: 'MONTHLY'
+    bullets:
+    - 'Container Deployment'
+    - '128 MB Memory'
+    - '100 MB Disk'
+  free: true
+  bindable: true
+  planUpdatable: false
+  templates:
+  - action: properties
+    type: helm
+    path: "config/samples/templates/postgresqlProperties"
+  - action: provision
+    type: helm
+    path: "config/samples/templates/postgresql"
+  - action: bind
+    type: helm
+    path: "config/samples/templates/postgresql"
+  serviceId: '24731fb8-7b84-5f57-914f-c3d55d793dd4'
+  context:
+    operator:
+      image: "servicefabrikjenkins/blueprint"
+      tag: "latest"
+      port: 8080
+      memory: '128m'
+      persistent_volumes:
+      - name: 'data'
+        path: '/data'
+        size: '100m'
+    serviceFabrik:
+      backupEnabled: false

--- a/interoperator/config/samples/osb_v1alpha1_plan4.yaml
+++ b/interoperator/config/samples/osb_v1alpha1_plan4.yaml
@@ -25,13 +25,13 @@ spec:
   templates:
   - action: properties
     type: helm
-    path: "config/samples/templates/postgresqlProperties"
+    url: "config/samples/templates/postgresqlProperties"
   - action: provision
     type: helm
-    path: "config/samples/templates/postgresql"
+    url: "config/samples/templates/postgresql"
   - action: bind
     type: helm
-    path: "config/samples/templates/postgresql"
+    url: "config/samples/templates/postgresql"
   serviceId: '24731fb8-7b84-5f57-914f-c3d55d793dd4'
   context:
     operator:

--- a/interoperator/config/samples/osb_v1alpha1_service2.yaml
+++ b/interoperator/config/samples/osb_v1alpha1_service2.yaml
@@ -1,0 +1,34 @@
+apiVersion: osb.servicefabrik.io/v1alpha1
+kind: Service
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: &name postgresql
+spec:
+  name: *name
+  id: '24731fb8-7b84-5f57-914f-c3d55d793dd4'
+  description: &description 'Postgresql for internal development, testing, and documentation purposes of the Service Fabrik'
+  tags:
+  - 'postgresql'
+  requires: []
+  bindable: true
+  instanceRetrievable: true
+  bindingRetrievable: true
+  metadata:
+    displayName: 'PostgreSQL'
+    longDescription: *description
+    providerDisplayName: 'SAP SE'
+    documentationUrl: 'https://sap.com/'
+    supportUrl: 'https://sap.com/'
+  dashboardClient:
+    id: postgresql-dashboard-client-id
+    secret: postgresql-dashboard-client-secret
+    redirectURI: 'https://sap.com/'
+  planUpdatable: true
+  context:
+    serviceFabrik:
+      backupEnabled: false
+    operator:
+      image: "servicefabrikjenkins/postgresql"
+      tag: "latest"
+      port: 8080


### PR DESCRIPTION
- Adding postgresql service and plan samples
- Changing path to url
- Constant creation for all interoperator resources and groups 
- Loading catalog during broker registration as well.