### PR TITLE
Including update params in manifest 

### DIFF
--- a/broker/config/templates/blueprint-manifest.yml.ejs
+++ b/broker/config/templates/blueprint-manifest.yml.ejs
@@ -48,6 +48,7 @@ if(!spec.actions && spec.previous_manifest){
 else{
   properties.blueprint.actionResponse = JSON.stringify(spec.actions);
 }
+properties.blueprint.update_params = JSON.stringify(spec.parameters);
 %>
 - name: blueprint
   migrated_from:
@@ -77,3 +78,6 @@ else{
       username: <%= p('agent.auth.username') %>
       password: <%= p('agent.auth.password') %>
       provider: <%= JSON.stringify(p('agent.provider')) %>
+      <% if (spec.parameters.multi_az && spec.parameters.serviceflow_name !== undefined) { %>
+      update_params: <%= properties.blueprint.update_params %>
+      <% } %>


### PR DESCRIPTION
During service flow execution, service flow params are passed as cparams. As part of showing service flow example, including its params in manifest. Individual services teams not include these params in the manifest, rather its just an example of how to access the flow params.