### PR TITLE
Handling cases where the configmap/config doesnt exist

### DIFF
--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -553,7 +553,10 @@ class ApiServerClient {
   }
 
   getConfigMap(configName, key) {
-    return this.getConfigMapResource(configName).then((body) => _.get(body.data, key));
+    return this.getConfigMapResource(configName).then((body) => _.get(body.data, key))
+      .catch(errors.NotFound, () => {
+        return undefined;
+      });
   }
 
   /**

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -954,6 +954,14 @@ describe('eventmesh', () => {
             verify();
           });
       });
+      it('If a config map is not found, the function returns undefined ', () => {
+        nockGetConfigMap({}, 404);
+        return apiserver.getConfigMap(CONST.CONFIG.RESOURCE_NAME, 'disable_scheduled_update_blueprint')
+          .then(res => {
+            expect(res).to.eql(undefined);
+            verify();
+          });
+      });
     });
 
     describe('createUpdateConfigMapResource', () => {


### PR DESCRIPTION
This change fixes a bug introduced by the selective-update feature.
As per the feature, there could be instances where the config, `sfconfig` mightn't be present. So also, it could happen, any particular config mightn't be present at all. For those scenarios, an `undefined` value is retained and is treated same as `false`.

Handling such a getConfig scenario where `NOT FOUND` error should be handled.