### PR TITLE
Enable service instance sharing via Service Fabrik

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -106,9 +106,11 @@ defaults: &defaults
   enable_circuit_breaker: true
   enable_swarm_manager: true
   enable_bosh_rate_limit: false # Global switch to enable/disable rate limiting against BOSH directors
+  enable_cross_organization_sharing: false
   feature:
     ServiceInstanceAutoUpdate: true #Switch to turn on / turn off schedule_update feature
     EnableSecurityGroupsOps: true
+    AllowInstanceSharing: true
   # this timeout is set to 175 secs by default because CF has a default timeout of 180 secs
   http_timeout: 175000
   deployment_action_timeout: 80000

--- a/common/errors.js
+++ b/common/errors.js
@@ -87,6 +87,20 @@ class NotImplementedBySubclass extends BaseError {
 }
 exports.NotImplementedBySubclass = NotImplementedBySubclass;
 
+class InstanceSharingNotAllowed extends BaseError {
+  constructor() {
+    super('Service instance sharing not enabled');
+  }
+}
+exports.InstanceSharingNotAllowed = InstanceSharingNotAllowed;
+
+class CrossOrganizationSharingNotAllowed extends BaseError {
+  constructor() {
+    super('Service instance cannot be shared across Cloud Foundry organizations');
+  }
+}
+exports.CrossOrganizationSharingNotAllowed = CrossOrganizationSharingNotAllowed;
+
 class HttpError extends BaseError {
   constructor(status, reason, message) {
     super(message);

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -694,14 +694,28 @@ class DirectorService extends BaseDirectorService {
   }
 
   bind(params) {
-    return this
-      .initialize({
-        type: 'bind'
+    let bindingCredentials;
+    return this.platformManager.preBindOperations({
+        context: params.context,
+        bind_resource: params.bind_resource,
+        bindingId: params.binding_id
       })
+      .then(() => this
+        .initialize({
+          type: 'bind'
+        }))
       .then(() => this.createBinding(this.deploymentName, {
         id: params.binding_id,
         parameters: params.parameters || {}
       }))
+      .tap(credentials => bindingCredentials = credentials)
+      .then(() => this.platformManager.postBindOperations({
+        context: params.context,
+        bind_resource: params.bind_resource,
+        bindingId: params.binding_id,
+        ipRuleOptions: this.buildIpRules()
+      }))
+      .then(()=> bindingCredentials)
       .tap(() => {
         if (this.platformManager.platformName === CONST.PLATFORM.CF) {
           return this
@@ -751,6 +765,9 @@ class DirectorService extends BaseDirectorService {
       .initialize({
         type: 'unbind'
       })
+      .then(() => this.platform.preUnbindOperations({
+        bindingId: params.binding_id
+      }))
       .then(() => this.deleteBinding(this.deploymentName, params.binding_id));
   }
 

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -715,7 +715,7 @@ class DirectorService extends BaseDirectorService {
         bindingId: params.binding_id,
         ipRuleOptions: this.buildIpRules()
       }))
-      .then(()=> bindingCredentials)
+      .then(() => bindingCredentials)
       .tap(() => {
         if (this.platformManager.platformName === CONST.PLATFORM.CF) {
           return this

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -765,7 +765,7 @@ class DirectorService extends BaseDirectorService {
       .initialize({
         type: 'unbind'
       })
-      .then(() => this.platform.preUnbindOperations({
+      .then(() => this.platformManager.preUnbindOperations({
         bindingId: params.binding_id
       }))
       .then(() => this.deleteBinding(this.deploymentName, params.binding_id));

--- a/platform-managers/BasePlatformManager.js
+++ b/platform-managers/BasePlatformManager.js
@@ -27,6 +27,18 @@ class BasePlatformManager {
     return modifiedCatalog;
   }
 
+  preUnbindOperations(options) {
+    /* jshint unused:false */
+  }
+
+  preBindOperations(options) {
+    /* jshint unused:false */
+  }
+
+  postBindOperations(options) {
+    /* jshint unused:false */
+  }
+
   postInstanceProvisionOperations(options) {
     /* jshint unused:false */
   }

--- a/platform-managers/CfPlatformManager.js
+++ b/platform-managers/CfPlatformManager.js
@@ -44,7 +44,7 @@ class CfPlatformManager extends BasePlatformManager {
       .then(targetSpaceDetails => options.context.organization_guid === targetSpaceDetails.entity.organization_guid);
   }
 
-  preUnbindOperations(options){
+  preUnbindOperations(options) {
     return this.deleteSecurityGroupForShare(options);
   }
 
@@ -162,7 +162,7 @@ class CfPlatformManager extends BasePlatformManager {
       });
   }
 
-  deleteSecurityGroupForShare(options){
+  deleteSecurityGroupForShare(options) {
     const name = this.getSecurityGroupName(options.bindingId);
     return this.deleteApplicationSecurityGroup(name);
   }

--- a/platform-managers/CfPlatformManager.js
+++ b/platform-managers/CfPlatformManager.js
@@ -51,7 +51,6 @@ class CfPlatformManager extends BasePlatformManager {
   }
 
   preBindOperations(options) {
-    console.log("---------------------->", JSON.stringify(options));
     const isSharing = this.isInstanceSharingRequest(options);
     const instanceSharingEnabled = _.get(config, 'feature.AllowInstanceSharing', true);
 

--- a/test/test_broker/fabrik.CfPlatformManager.spec.js
+++ b/test/test_broker/fabrik.CfPlatformManager.spec.js
@@ -19,10 +19,9 @@ describe('fabrik', function () {
       let sandbox, createSecurityGroupStub, deleteSecurityGroupStub, ensureSecurityGroupExistsStub;
 
       before(function () {
-
         _.set(config, 'feature.EnableSecurityGroupsOps', false);
         sandbox = sinon.sandbox.create();
-        createSecurityGroupStub = sandbox.stub(cfPlatformManager, 'createSecurityGroup');
+        createSecurityGroupStub = sandbox.stub(cfPlatformManager, 'createSecurityGroupForInstance');
         createSecurityGroupStub
           .withArgs({
             'dummy': 'dummy'
@@ -33,7 +32,7 @@ describe('fabrik', function () {
             };
           }));
 
-        deleteSecurityGroupStub = sandbox.stub(cfPlatformManager, 'deleteSecurityGroup');
+        deleteSecurityGroupStub = sandbox.stub(cfPlatformManager, 'deleteSecurityGroupForInstance');
         deleteSecurityGroupStub
           .withArgs({
             'dummy': 'dummy'
@@ -135,10 +134,10 @@ describe('fabrik', function () {
       });
     });
 
-    describe('#bindOperations', function () {
+    describe('#isInstanceSharingRequest', function () {
       let cfPlatformManager = new CfPlatformManager('cf');
 
-      it('should be true if binding is for shared instance', function () {
+      it('should be false for normal service binding', function () {
         let options = {
           bind_resource: {
             space_guid: 'abcd',
@@ -149,6 +148,171 @@ describe('fabrik', function () {
           }
         };
         expect(cfPlatformManager.isInstanceSharingRequest(options)).to.equal(false);
+      });
+      it('should be true for binding for shared instance', function () {
+        let options = {
+          bind_resource: {
+            space_guid: 'abcd',
+            app_guid: 'app'
+          },
+          context: {
+            space_guid: 'source'
+          }
+        };
+        expect(cfPlatformManager.isInstanceSharingRequest(options)).to.equal(true);
+      });
+      it('should be false for service key', function () {
+        let options = {
+          bind_resource: {},
+          context: {
+            space_guid: 'source'
+          }
+        };
+        expect(cfPlatformManager.isInstanceSharingRequest(options)).to.equal(false);
+      });
+    });
+
+    describe('#ensureValidShareRequest', function () {
+      const allow_org_sharing = {
+        AllowCrossOrganizationSharing: true
+      };
+      const disallow_org_sharing = {
+        AllowCrossOrganizationSharing: false
+      };
+      const CfPlatformManagerAllowOrgSharing = proxyquire('../../platform-managers/CfPlatformManager', {
+        '../common/config': allow_org_sharing
+      });
+      const CfPlatformManagerDisallowOrgSharing = proxyquire('../../platform-managers/CfPlatformManager', {
+        '../common/config': disallow_org_sharing
+      });
+      let getSpaceStub;
+      before(function () {
+        getSpaceStub = sinon.stub(cloudController, 'getSpace', () => {
+          return Promise.resolve({
+            entity: {
+              organization_guid: 'target'
+            }
+          });
+        });
+      });
+      after(function () {
+        getSpaceStub.restore();
+      });
+
+      it('should be true if cross organization sharing is enabled', function () {
+        let options = {};
+        let cfPlatformManager = new CfPlatformManagerAllowOrgSharing('cf');
+        return cfPlatformManager.ensureValidShareRequest(options)
+          .then(res => expect(res).to.equal(true));
+      });
+      it('should be false if cross organization sharing is disabled and cross org binding is received', function () {
+        let options = {
+          bind_resource: {
+            space_guid: 'abcd',
+            app_guid: 'app'
+          },
+          context: {
+            space_guid: 'source',
+            organization_guid: 'source'
+          }
+        };
+        let cfPlatformManager = new CfPlatformManagerDisallowOrgSharing('cf');
+        return cfPlatformManager.ensureValidShareRequest(options)
+          .then(res => {
+            expect(res).to.equal(false);
+          });
+      });
+      it('should be true if cross organization sharing is disabled and same org binding is received', function () {
+        let options = {
+          bind_resource: {
+            space_guid: 'abcd',
+            app_guid: 'app'
+          },
+          context: {
+            space_guid: 'source',
+            organization_guid: 'target'
+          }
+        };
+        let cfPlatformManager = new CfPlatformManagerDisallowOrgSharing('cf');
+        return cfPlatformManager.ensureValidShareRequest(options)
+          .then(res => {
+            expect(res).to.equal(true);
+          });
+      });
+    });
+
+    describe('#postBindOperations', function () {
+      const cfPlatformManager = new CfPlatformManager('cf');
+
+      it('should create security group for sharing', () => {
+        cfPlatformManager.isInstanceSharingRequest = () => true;
+        cfPlatformManager.createSecurityGroupForShare = () => Promise.resolve(123);
+
+        return cfPlatformManager.postBindOperations({})
+          .then(res => {
+            expect(res).to.equal(123);
+          });
+      });
+
+      it('should not create security group for non-sharing', () => {
+        cfPlatformManager.isInstanceSharingRequest = () => false;
+        cfPlatformManager.createSecurityGroupForShare = () => Promise.resolve(123);
+
+        return cfPlatformManager.postBindOperations({})
+          .then(res => {
+            expect(res).to.not.equal(123);
+          });
+      });
+    });
+
+    describe('#preBindOperations', function () {
+      const allowSharingConfig = {
+        feature: {
+          AllowInstanceSharing: true
+        }
+      };
+      const disallowSharingConfig = {
+        feature: {
+          AllowInstanceSharing: false
+        }
+      };
+      const CfPlatformManagerAllowSharing = proxyquire('../../platform-managers/CfPlatformManager', {
+        '../common/config': allowSharingConfig
+      });
+      const CfPlatformManagerDisallowSharing = proxyquire('../../platform-managers/CfPlatformManager', {
+        '../common/config': disallowSharingConfig
+      });
+
+      it('should run successfully for shared instance and enabled sharing', function () {
+        let cfPlatformManager = new CfPlatformManagerAllowSharing('cf');
+        cfPlatformManager.isInstanceSharingRequest = () => true;
+        cfPlatformManager.ensureValidShareRequest = () => Promise.resolve(true);
+        return cfPlatformManager.preBindOperations({});
+      });
+
+      it('should run successfully for non-shared instance and enabled sharing', function () {
+        let cfPlatformManager = new CfPlatformManagerAllowSharing('cf');
+        cfPlatformManager.isInstanceSharingRequest = () => false;
+        return cfPlatformManager.preBindOperations({});
+      });
+
+      it('should fail for enabled sharing and invalid sharing request', function () {
+        let cfPlatformManager = new CfPlatformManagerAllowSharing('cf');
+        cfPlatformManager.isInstanceSharingRequest = () => true;
+        cfPlatformManager.ensureValidShareRequest = () => Promise.resolve(false);
+        return cfPlatformManager.preBindOperations({})
+          .catch(err => {
+            expect(err instanceof errors.CrossOrganizationSharingNotAllowed).to.equal(true);
+          });
+      });
+
+      it('should fail for disabled sharing and invalid sharing request', function () {
+        let cfPlatformManager = new CfPlatformManagerDisallowSharing('cf');
+        cfPlatformManager.isInstanceSharingRequest = () => true;
+        return cfPlatformManager.preBindOperations({})
+          .catch(err => {
+            expect(err instanceof errors.InstanceSharingNotAllowed).to.equal(true);
+          });
       });
     });
 

--- a/test/test_broker/fabrik.CfPlatformManager.spec.js
+++ b/test/test_broker/fabrik.CfPlatformManager.spec.js
@@ -135,6 +135,23 @@ describe('fabrik', function () {
       });
     });
 
+    describe('#bindOperations', function(){
+      let cfPlatformManager = new CfPlatformManager('cf');
+
+      it('should be true if binding is for shared instance', function(){
+        let options = {
+          bind_resource: {
+            space_guid: 'abcd',
+            app_guid: 'app'
+          },
+          context: {
+            space_guid: 'abcd'
+          }
+        };
+        expect(cfPlatformManager.isInstanceSharingRequest(options)).to.equal(false);
+      });
+    });
+
     describe('multiAzEnablement', function () {
       const multi_az_internal_config = {
         multi_az_enabled: CONST.INTERNAL,

--- a/test/test_broker/fabrik.CfPlatformManager.spec.js
+++ b/test/test_broker/fabrik.CfPlatformManager.spec.js
@@ -172,12 +172,12 @@ describe('fabrik', function () {
       });
     });
 
-    describe('#ensureValidShareRequest', function () {
+    describe('#isCrossOrganizationSharingAllowed', function () {
       const allow_org_sharing = {
-        AllowCrossOrganizationSharing: true
+        enable_cross_organization_sharing: true
       };
       const disallow_org_sharing = {
-        AllowCrossOrganizationSharing: false
+        enable_cross_organization_sharing: false
       };
       const CfPlatformManagerAllowOrgSharing = proxyquire('../../platform-managers/CfPlatformManager', {
         '../common/config': allow_org_sharing
@@ -202,7 +202,7 @@ describe('fabrik', function () {
       it('should be true if cross organization sharing is enabled', function () {
         let options = {};
         let cfPlatformManager = new CfPlatformManagerAllowOrgSharing('cf');
-        return cfPlatformManager.ensureValidShareRequest(options)
+        return cfPlatformManager.isCrossOrganizationSharingEnabled(options)
           .then(res => expect(res).to.equal(true));
       });
       it('should be false if cross organization sharing is disabled and cross org binding is received', function () {
@@ -217,9 +217,9 @@ describe('fabrik', function () {
           }
         };
         let cfPlatformManager = new CfPlatformManagerDisallowOrgSharing('cf');
-        return cfPlatformManager.ensureValidShareRequest(options)
-          .then(res => {
-            expect(res).to.equal(false);
+        return cfPlatformManager.isCrossOrganizationSharingEnabled(options)
+          .catch(err => {
+            expect(err instanceof errors.CrossOrganizationSharingNotAllowed).to.equal(true);
           });
       });
       it('should be true if cross organization sharing is disabled and same org binding is received', function () {
@@ -234,7 +234,7 @@ describe('fabrik', function () {
           }
         };
         let cfPlatformManager = new CfPlatformManagerDisallowOrgSharing('cf');
-        return cfPlatformManager.ensureValidShareRequest(options)
+        return cfPlatformManager.isCrossOrganizationSharingEnabled(options)
           .then(res => {
             expect(res).to.equal(true);
           });
@@ -286,7 +286,7 @@ describe('fabrik', function () {
       it('should run successfully for shared instance and enabled sharing', function () {
         let cfPlatformManager = new CfPlatformManagerAllowSharing('cf');
         cfPlatformManager.isInstanceSharingRequest = () => true;
-        cfPlatformManager.ensureValidShareRequest = () => Promise.resolve(true);
+        cfPlatformManager.isCrossOrganizationSharingEnabled = () => Promise.resolve(true);
         return cfPlatformManager.preBindOperations({});
       });
 
@@ -299,7 +299,7 @@ describe('fabrik', function () {
       it('should fail for enabled sharing and invalid sharing request', function () {
         let cfPlatformManager = new CfPlatformManagerAllowSharing('cf');
         cfPlatformManager.isInstanceSharingRequest = () => true;
-        cfPlatformManager.ensureValidShareRequest = () => Promise.resolve(false);
+        cfPlatformManager.isCrossOrganizationSharingEnabled = () => Promise.reject(new errors.CrossOrganizationSharingNotAllowed());
         return cfPlatformManager.preBindOperations({})
           .catch(err => {
             expect(err instanceof errors.CrossOrganizationSharingNotAllowed).to.equal(true);

--- a/test/test_broker/fabrik.CfPlatformManager.spec.js
+++ b/test/test_broker/fabrik.CfPlatformManager.spec.js
@@ -135,10 +135,10 @@ describe('fabrik', function () {
       });
     });
 
-    describe('#bindOperations', function(){
+    describe('#bindOperations', function () {
       let cfPlatformManager = new CfPlatformManager('cf');
 
-      it('should be true if binding is for shared instance', function(){
+      it('should be true if binding is for shared instance', function () {
         let options = {
           bind_resource: {
             space_guid: 'abcd',

--- a/test/test_broker/mocks/cloudController.js
+++ b/test/test_broker/mocks/cloudController.js
@@ -57,8 +57,17 @@ function createSecurityGroup(guid) {
     });
 }
 
-function findSecurityGroupByName(guid) {
+function findSecurityGroupByName(guid, resources) {
   const name = getSecurityGroupName(guid);
+  const defaults = [{
+    metadata: {
+      guid: guid
+    },
+    entity: {
+      name: name
+    }
+  }];
+  resources = resources || defaults;
   return nock(cloudControllerUrl)
     .replyContentLength()
     .get('/v2/security_groups')
@@ -66,14 +75,7 @@ function findSecurityGroupByName(guid) {
       q: `name:${name}`
     })
     .reply(200, {
-      resources: [{
-        metadata: {
-          guid: guid
-        },
-        entity: {
-          name: name
-        }
-      }]
+      resources: resources
     });
 }
 

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -24,6 +24,7 @@ describe('#DirectorService', function () {
       const plan_id_update = 'd616b00a-5949-4b1c-bc73-0d3c59f3954a';
       const organization_guid = 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a';
       const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
+      const target_space_guid = 'target-e7c0a437-7585-4d75-addf-aa4d45b49f3a';
       const instance_id = mocks.director.uuidByIndex(index);
       const deployment_name = mocks.director.deploymentNameByIndex(index);
       const binding_id = 'd336b15c-37d6-4249-b3c7-430d5153a0d8';
@@ -1012,7 +1013,67 @@ describe('#DirectorService', function () {
             app_guid: app_guid,
             context: context,
             bind_resource: {
-              app_guid: app_guid
+              app_guid: app_guid,
+              space_guid: space_guid
+            }
+          };
+          return DirectorService.createInstance(instance_id, options)
+            .then(service => service.bind(options))
+            .then(res => {
+              expect(res).to.eql(mocks.agent.credentials);
+              setTimeout(() => {
+                delete config.mongodb.provision.plan_id;
+                expect(getScheduleStub).to.be.calledOnce;
+                expect(getScheduleStub.firstCall.args[0]).to.eql(instance_id);
+                expect(getScheduleStub.firstCall.args[1]).to.eql(CONST.JOB.SCHEDULED_BACKUP);
+                mocks.verify();
+                done();
+                //Schedule operation is performed in background after response has been returned,
+                //hence added this delay of 500 ms which should work in all cases.
+                //In case asserts are failing, try increasing the timeout first & then debug. :-)
+              }, WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION);
+            });
+        });
+        it('shared instance: returns 201 Created', function (done) {
+          config.mongodb.provision.plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
+          deferred.reject(new errors.NotFound('Schedule not found'));
+          const WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION = 0;
+          const context = {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          };
+          const expectedRequestBody = _.cloneDeep(deploymentHookRequestBody);
+          expectedRequestBody.context = _.chain(expectedRequestBody.context)
+            .set('id', binding_id)
+            .set('parameters', {})
+            .omit('params')
+            .omit('sf_operations_args')
+            .value();
+          expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_BIND;
+          mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
+          mocks.director.getDeploymentInstances(deployment_name);
+          mocks.agent.getInfo();
+          mocks.agent.createCredentials();
+          mocks.serviceFabrikClient.scheduleBackup(instance_id, {
+            type: CONST.BACKUP.TYPE.ONLINE,
+            repeatInterval: '8 hours'
+          });
+          mocks.cloudController.getSpace(target_space_guid, {
+            'organization_guid': organization_guid
+          });
+          mocks.cloudController.createSecurityGroup(binding_id);
+          const options = {
+            binding_id: binding_id,
+            service_id: service_id,
+            plan_id: plan_id,
+            app_guid: app_guid,
+            context: context,
+            bind_resource: {
+              app_guid: app_guid,
+              space_guid: target_space_guid
             }
           };
           return DirectorService.createInstance(instance_id, options)
@@ -1066,7 +1127,8 @@ describe('#DirectorService', function () {
             app_guid: app_guid,
             context: context,
             bind_resource: {
-              app_guid: app_guid
+              app_guid: app_guid,
+              space_guid: space_guid
             }
           };
           return DirectorService.createInstance(instance_id, options)
@@ -1109,6 +1171,7 @@ describe('#DirectorService', function () {
             }
           };
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.cloudController.findSecurityGroupByName(binding_id, []);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
@@ -1122,7 +1185,53 @@ describe('#DirectorService', function () {
             app_guid: app_guid,
             context: context,
             bind_resource: {
-              app_guid: app_guid
+              app_guid: app_guid,
+              space_guid: space_guid
+            }
+          };
+          return DirectorService.createInstance(instance_id, options)
+            .then(service => service.unbind(options))
+            .then(() => {
+              mocks.verify();
+            });
+        });
+        it('returns 200 OK: shared instance unbinding', function () {
+          const context = {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          };
+          const expectedRequestBody = _.cloneDeep(deploymentHookRequestBody);
+          expectedRequestBody.context = _.chain(expectedRequestBody.context)
+            .set('id', binding_id)
+            .omit('params')
+            .omit('sf_operations_args')
+            .value();
+          expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
+          let dummyBindResource = {
+            status: {
+              response: utils.encodeBase64(mocks.agent.credentials),
+              state: 'succeeded'
+            }
+          };
+          mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.cloudController.findSecurityGroupByName(binding_id);
+          mocks.cloudController.deleteSecurityGroup(binding_id);
+          mocks.director.getDeploymentInstances(deployment_name);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BIND, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND, binding_id, dummyBindResource, 1, 200);
+          mocks.agent.getInfo();
+          mocks.agent.deleteCredentials();
+          const options = {
+            binding_id: binding_id,
+            service_id: service_id,
+            plan_id: plan_id,
+            app_guid: app_guid,
+            context: context,
+            bind_resource: {
+              app_guid: app_guid,
+              space_guid: space_guid
             }
           };
           return DirectorService.createInstance(instance_id, options)
@@ -1152,6 +1261,7 @@ describe('#DirectorService', function () {
           };
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.cloudController.findSecurityGroupByName(binding_id, []);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
@@ -1166,7 +1276,8 @@ describe('#DirectorService', function () {
             app_guid: app_guid,
             context: context,
             bind_resource: {
-              app_guid: app_guid
+              app_guid: app_guid,
+              space_guid: space_guid
             }
           };
           return DirectorService.createInstance(instance_id, options)
@@ -1191,6 +1302,7 @@ describe('#DirectorService', function () {
 
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.cloudController.findSecurityGroupByName(binding_id, []);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
@@ -1205,7 +1317,8 @@ describe('#DirectorService', function () {
             app_guid: app_guid,
             context: context,
             bind_resource: {
-              app_guid: app_guid
+              app_guid: app_guid,
+              space_guid: space_guid
             }
           };
           return DirectorService.createInstance(instance_id, options)
@@ -1229,6 +1342,7 @@ describe('#DirectorService', function () {
           };
           expectedRequestBody.phase = CONST.SERVICE_LIFE_CYCLE.PRE_UNBIND;
           mocks.deploymentHookClient.executeDeploymentActions(200, expectedRequestBody);
+          mocks.cloudController.findSecurityGroupByName(binding_id, []);
           mocks.director.getDeploymentProperty(deployment_name, false, 'platform-context', undefined);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithoutContext, 2);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
@@ -1242,7 +1356,8 @@ describe('#DirectorService', function () {
             plan_id: plan_id,
             app_guid: app_guid,
             bind_resource: {
-              app_guid: app_guid
+              app_guid: app_guid,
+              space_guid: space_guid
             }
           };
           return DirectorService.createInstance(instance_id, options)


### PR DESCRIPTION
- Allow sharing of service instances across spaces/organizations. Sharing of instances across organizations is controlled by a configuration flag
- Introduce pre-bind/post-bind operations. In Cloud Foundry sharing, pre-bind is used for validation and detection of a shared instance binding request, while post-bind is used for creation of CF Application Security Group corresponding to the target space and shared instance. The model creates a new CF security group per binding (with the same naming convention as for normal ASGs for instances).
- Introduce pre-unbind operation. In Cloud Foundry sharing, pre-unbind is responsible for deleting the security group if found
- Test specs updated to reflect cloud foundry native sharing