### PR TITLE
Removing CF CC dependencies in extension APIs code flow except authentication and authorization

### DIFF
--- a/api-controllers/ServiceFabrikApiController.js
+++ b/api-controllers/ServiceFabrikApiController.js
@@ -758,11 +758,13 @@ class ServiceFabrikApiController extends FabrikBaseController {
               resourceId: options.instance_id
             })
             .then(resource => {
+              /* TODO: Conditional statement to fetch plan_id below is needed to be backwards compatible       
+              as appliedOptions was added afterwards. Should be removed once all the older resources are updated. */
               options.plan_id = _.isEmpty(_.get(resource, 'status.appliedOptions')) ? resource.spec.options.plan_id :
                 _.get(resource, 'status.appliedOptions.plan_id');
             })
             .catch(NotFound, () => {
-              logger.info(`+-> Instance ${options.instance_id} not found, continue listing backups for the deleted instance`);
+              logger.info(`+-> Instance ${options.instance_id} not found in ApiServer, continue listing backups for the deleted instance`);
             });
         }
       })

--- a/common/utils/index.js
+++ b/common/utils/index.js
@@ -605,10 +605,7 @@ function deploymentStaggered(err) {
 
 function getPlatformManager(context) {
   const BasePlatformManager = require('../../platform-managers/BasePlatformManager');
-  let platform = context.platform;
-  if (platform === CONST.PLATFORM.SM) {
-    platform = context.origin;
-  }
+  let platform = getPlatformFromContext(context);
   const PlatformManager = (platform && CONST.PLATFORM_MANAGER[platform]) ? require(`../../platform-managers/${CONST.PLATFORM_MANAGER[platform]}`) : ((platform && CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]) ? require(`../../platform-managers/${CONST.PLATFORM_MANAGER[CONST.PLATFORM_ALIAS_MAPPINGS[platform]]}`) : undefined);
   if (PlatformManager === undefined) {
     return new BasePlatformManager(platform);

--- a/common/utils/index.js
+++ b/common/utils/index.js
@@ -59,6 +59,7 @@ exports.parseServiceInstanceIdFromDeployment = parseServiceInstanceIdFromDeploym
 exports.verifyFeatureSupport = verifyFeatureSupport;
 exports.isRestorePossible = isRestorePossible;
 exports.getPlatformManager = getPlatformManager;
+exports.getPlatformFromContext = getPlatformFromContext;
 
 function isRestorePossible(plan_id, plan) {
   const settings = plan.manager.settings;
@@ -95,6 +96,15 @@ function streamToPromise(stream, options) {
     });
     stream.on('error', reject);
   });
+}
+
+function getPlatformFromContext(context) {
+  let platform = _.get(context, 'platform');
+  if (platform === CONST.PLATFORM.SM) {
+    return _.get(context, 'origin');
+  } else {
+    return platform;
+  }
 }
 
 function initializeEventListener(appConfig, appType) {

--- a/jobs/BackupReaperJob.js
+++ b/jobs/BackupReaperJob.js
@@ -68,16 +68,7 @@ class BackupReaperJob extends BaseJob {
       return true;
     });
   }
-/*
-  static isServiceInstanceDeleted(instanceId) {
-    return cloudController.findServicePlanByInstanceId(instanceId)
-      .then(() => false)
-      .catch(ServiceInstanceNotFound, () => {
-        logger.warn(`service instance : ${instanceId} deleted`);
-        return true;
-      });
-  }
-*/
+  
   static isDeploymentDeleted(deploymentName) {
     const director = bosh.director;
     return director.getDeployment(deploymentName)

--- a/jobs/BackupReaperJob.js
+++ b/jobs/BackupReaperJob.js
@@ -8,14 +8,13 @@ const CONST = require('../common/constants');
 const moment = require('moment');
 const BaseJob = require('./BaseJob');
 const errors = require('../common/errors');
-const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const NotFound = errors.NotFound;
-const cloudController = require('../data-access-layer/cf').cloudController;
 const backupStoreForInstance = require('../data-access-layer/iaas').backupStore;
 const backupStoreForOob = require('../data-access-layer/iaas').backupStoreForOob;
 const ScheduleManager = require('./ScheduleManager');
 const EventLogInterceptor = require('../common/EventLogInterceptor');
 const bosh = require('../data-access-layer/bosh');
+const eventmesh = require('../data-access-layer/eventmesh');
 
 class BackupReaperJob extends BaseJob {
 
@@ -58,17 +57,17 @@ class BackupReaperJob extends BaseJob {
 
   static isServiceInstanceDeleted(instanceId) {
     return eventmesh.apiServerClient.getResource({
-      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-      resourceId: instanceId
-    })
-    .then(() => false)
-    .catch(errors.NotFound, () => {
-      logger.warn(`service instance : ${instanceId} deleted`);
-      return true;
-    });
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+        resourceId: instanceId
+      })
+      .then(() => false)
+      .catch(errors.NotFound, () => {
+        logger.warn(`service instance : ${instanceId} deleted`);
+        return true;
+      });
   }
-  
+
   static isDeploymentDeleted(deploymentName) {
     const director = bosh.director;
     return director.getDeployment(deploymentName)

--- a/jobs/BackupReaperJob.js
+++ b/jobs/BackupReaperJob.js
@@ -57,6 +57,19 @@ class BackupReaperJob extends BaseJob {
   }
 
   static isServiceInstanceDeleted(instanceId) {
+    return eventmesh.apiServerClient.getResource({
+      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+      resourceId: instanceId
+    })
+    .then(() => false)
+    .catch(errors.NotFound, () => {
+      logger.warn(`service instance : ${instanceId} deleted`);
+      return true;
+    });
+  }
+/*
+  static isServiceInstanceDeleted(instanceId) {
     return cloudController.findServicePlanByInstanceId(instanceId)
       .then(() => false)
       .catch(ServiceInstanceNotFound, () => {
@@ -64,7 +77,7 @@ class BackupReaperJob extends BaseJob {
         return true;
       });
   }
-
+*/
   static isDeploymentDeleted(deploymentName) {
     const director = bosh.director;
     return director.getDeployment(deploymentName)

--- a/jobs/BackupReaperJob.js
+++ b/jobs/BackupReaperJob.js
@@ -61,7 +61,7 @@ class BackupReaperJob extends BaseJob {
         resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
         resourceId: instanceId
       })
-      .then(() => false)
+      .then(resource => _.get(resource, 'metadata.deletionTimestamp') ? true : false)
       .catch(errors.NotFound, () => {
         logger.warn(`service instance : ${instanceId} deleted`);
         return true;

--- a/jobs/ScheduleBackupJob.js
+++ b/jobs/ScheduleBackupJob.js
@@ -9,9 +9,7 @@ const CONST = require('../common/constants');
 const errors = require('../common/errors');
 const utils = require('../common/utils');
 const retry = utils.retry;
-const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const catalog = require('../common/models').catalog;
-const cloudController = require('../data-access-layer/cf').cloudController;
 const eventmesh = require('../data-access-layer/eventmesh');
 const backupStore = require('../data-access-layer/iaas').backupStore;
 const ScheduleManager = require('./ScheduleManager');
@@ -77,15 +75,15 @@ class ScheduleBackupJob extends BaseJob {
 
   static isServiceInstanceDeleted(instanceId) {
     return eventmesh.apiServerClient.getResource({
-      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-      resourceId: instanceId
-    })
-    .then(() => false)
-    .catch(errors.NotFound, () => {
-      logger.warn(`service instance : ${instanceId} deleted`);
-      return true;
-    });
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+        resourceId: instanceId
+      })
+      .then(() => false)
+      .catch(errors.NotFound, () => {
+        logger.warn(`service instance : ${instanceId} deleted`);
+        return true;
+      });
   }
 
   static deleteOldBackup(job, instanceDeleted) {

--- a/jobs/ScheduleBackupJob.js
+++ b/jobs/ScheduleBackupJob.js
@@ -79,7 +79,7 @@ class ScheduleBackupJob extends BaseJob {
         resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
         resourceId: instanceId
       })
-      .then(() => false)
+      .then(resource => _.get(resource, 'metadata.deletionTimestamp') ? true : false)
       .catch(errors.NotFound, () => {
         logger.warn(`service instance : ${instanceId} deleted`);
         return true;

--- a/jobs/ScheduleBackupJob.js
+++ b/jobs/ScheduleBackupJob.js
@@ -87,15 +87,6 @@ class ScheduleBackupJob extends BaseJob {
       return true;
     });
   }
-  /*
-  static isServiceInstanceDeleted(instanceId) {
-    return cloudController.findServicePlanByInstanceId(instanceId)
-      .then(() => false)
-      .catch(ServiceInstanceNotFound, () => {
-        logger.warn(`service instance : ${instanceId} deleted`);
-        return true;
-      });
-  }*/
 
   static deleteOldBackup(job, instanceDeleted) {
     let transactionLogsBefore;

--- a/operators/BaseService.js
+++ b/operators/BaseService.js
@@ -2,6 +2,7 @@
 
 const CONST = require('../common/constants');
 const Agent = require('../data-access-layer/service-agent');
+const utils = require('../common/utils');
 
 class BaseService {
   constructor(plan) {
@@ -18,10 +19,7 @@ class BaseService {
   }
 
   getTenantGuid(context) {
-    let platform = context.platform;
-    if (platform === CONST.PLATFORM.SM) {
-      platform = context.origin;
-    }
+    let platform = utils.getPlatformFromContext(context);
     if (platform === CONST.PLATFORM.CF) {
       return context.space_guid;
     } else if (platform === CONST.PLATFORM.K8S) {

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
@@ -18,7 +18,6 @@ describe('service-fabrik-api-2.0', function () {
       const backup_guid2 = 'abcdefab-66a3-471b-af3c-8bbf1e4180be';
       const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
       const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
-      const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
       const container = backupStore.containerName;
       const instance_id = 'ab0ed6d6-42d9-4318-9b65-721f34719499';
       const instance_id1 = '6666666-42d9-4318-9b65-721f34719499';

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
@@ -200,7 +200,7 @@ describe('service-fabrik-api-2.0', function () {
                 context: {
                   platform: 'cloudfoundry',
                 },
-                space_guid: space_guid,
+                space_guid: space_guid
               })
             },
             status: {
@@ -214,6 +214,27 @@ describe('service-fabrik-api-2.0', function () {
           mocks.cloudProvider.list(container, prefix, [filename, filename1]);
           mocks.cloudProvider.download(pathname, data);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, resource);
+          return chai.request(app)
+            .get(`${base_url}/backups`)
+            .query({
+              space_guid: space_guid,
+              instance_id: instance_id
+            })
+            .set('Authorization', authHeader)
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              const body = [_.omit(data, 'logs')];
+              expect(res.body).to.eql(body);
+              mocks.verify();
+            });
+        });
+        it('should return 200 OK - with deleted instance', function () {
+          mocks.uaa.tokenKey();
+          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.cloudProvider.list(container, prefix, [filename, filename1]);
+          mocks.cloudProvider.download(pathname, data);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, 404);
           return chai.request(app)
             .get(`${base_url}/backups`)
             .query({

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.backups.director.spec.js
@@ -18,6 +18,7 @@ describe('service-fabrik-api-2.0', function () {
       const backup_guid2 = 'abcdefab-66a3-471b-af3c-8bbf1e4180be';
       const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
       const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
+      const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
       const container = backupStore.containerName;
       const instance_id = 'ab0ed6d6-42d9-4318-9b65-721f34719499';
       const instance_id1 = '6666666-42d9-4318-9b65-721f34719499';
@@ -185,11 +186,35 @@ describe('service-fabrik-api-2.0', function () {
             });
         });
         it('should return 200 OK - with instance_id parameter, returns only one metadata file data', function () {
+          const resource = {
+            apiVersion: 'deployment.servicefabrik.io/v1alpha1',
+            kind: 'Director',
+            metadata: {
+              name: instance_id,
+              labels: {
+                state: 'succeeded'
+              }
+            },
+            spec: {
+              options: JSON.stringify({
+                service_id: service_id,
+                context: {
+                  platform: 'cloudfoundry',
+                },
+                space_guid: space_guid,
+              })
+            },
+            status: {
+              state: 'succeeded',
+              lastOperation: '{}',
+              response: '{}'
+            }
+          };
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, undefined, undefined, []);
           mocks.cloudProvider.list(container, prefix, [filename, filename1]);
           mocks.cloudProvider.download(pathname, data);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, resource);
           return chai.request(app)
             .get(`${base_url}/backups`)
             .query({

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -1972,7 +1972,8 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.director.getDeployments();
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -1995,7 +1996,8 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.director.getDeployments();
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -2016,7 +2018,8 @@ describe('service-fabrik-api-sf2.0', function () {
       describe('#GetUpdateSchedule', function () {
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_update`)
             .set('Authorization', authHeader)

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -295,6 +295,43 @@ describe('service-fabrik-api-sf2.0', function () {
             });
         });
 
+        it('should fail if resource could not be fetched from ApiServer and request does not contain plan_id', function(done) {
+          mocks.uaa.tokenKey();
+          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1 , 404);
+          return chai
+            .request(apps.external)
+            .post(`${base_url}/service_instances/${instance_id}/backup`)
+            .set('Authorization', authHeader)
+            .send({
+              type: type,
+              space_guid: space_guid
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(422);
+              mocks.verify();
+              done();
+            });
+        });
+
+        it('should fail if resource could not be fetched from ApiServer and request does not contain space_guid', function(done) {
+          mocks.uaa.tokenKey();
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1 , 404);
+          return chai
+            .request(apps.external)
+            .post(`${base_url}/service_instances/${instance_id}/backup`)
+            .set('Authorization', authHeader)
+            .send({
+              type: type
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(422);
+              mocks.verify();
+              done();
+            });
+        });
 
         it('should initiate a start-backup operation with optional space_guid', function (done) {
           mocks.uaa.tokenKey();

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -48,12 +48,40 @@ describe('service-fabrik-api-sf2.0', function () {
       const repeatTimezone = 'America/New_York';
       const dummyDeploymentResource = {
         metadata: {
-          annotations: {
-            labels: 'dummy'
+          labels: {
+            last_backup_defaultbackups: backup_guid,
+            last_restore_defaultrestores: restore_guid
           }
+        },
+        spec: {
+          options: JSON.stringify({
+            service_id: service_id,
+            plan_id: plan_id,
+            context: {
+              platform: 'cloudfoundry',
+            },
+            space_guid: space_guid,
+          })
         }
       };
 
+      const dummyDeploymentResourceAbort = {
+        metadata: {
+          labels: {
+            last_backup_defaultbackups: 'b4719e7c-e8d3-4f7f-c515-769ad1c3ebfa'
+          }
+        },
+        spec: {
+          options: JSON.stringify({
+            service_id: service_id,
+            plan_id: plan_id,
+            context: {
+              platform: 'cloudfoundry',
+            },
+            space_guid: space_guid,
+          })
+        }
+      };
       const getJob = (name, type) => {
         return Promise.resolve({
           name: `${instance_id}_${type === undefined ? CONST.JOB.SCHEDULED_BACKUP : type}`,
@@ -119,13 +147,8 @@ describe('service-fabrik-api-sf2.0', function () {
             number_of_files: 5
           };
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
@@ -174,7 +197,6 @@ describe('service-fabrik-api-sf2.0', function () {
         it('should initiate a start-backup with SF2.0 not via cloud controller', function (done) {
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudProvider.list(container, list_prefix, [
             list_filename
           ]);
@@ -227,7 +249,6 @@ describe('service-fabrik-api-sf2.0', function () {
         it('should fail start-backup with SF2.0 not via cloud controller with unlocking', function (done) {
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudProvider.list(container, list_prefix, [
             list_filename
           ]);
@@ -278,7 +299,6 @@ describe('service-fabrik-api-sf2.0', function () {
         it('should initiate a start-backup operation with optional space_guid', function (done) {
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudProvider.list(container, list_prefix, [
             list_filename
           ]);
@@ -331,7 +351,6 @@ describe('service-fabrik-api-sf2.0', function () {
         it('should initiate a start-backup operation with context', function (done) {
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudProvider.list(container, list_prefix, [
             list_filename
           ]);
@@ -392,7 +411,6 @@ describe('service-fabrik-api-sf2.0', function () {
           ]);
           mocks.cloudProvider.download(list_pathname, data);
           mocks.cloudProvider.download(list_pathname2, data);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
             spec: {
@@ -580,20 +598,8 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 200 Ok - backup state is retrieved from agent while in \'processing\' state', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_backup_defaultbackups: backup_guid
-              }
-            }
-          }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, backup_guid, {
             status: {
               response: JSON.stringify(_.chain(backupState)
@@ -624,19 +630,8 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 200 Ok - backup state retrieved from meta information itself even when in-processing state', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_backup_defaultbackups: backup_guid
-              }
-            }
-          }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, backup_guid, {
             status: {
               response: JSON.stringify(data)
@@ -659,15 +654,8 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 200 Ok - backup state retrieved from meta information with space_guid', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_backup_defaultbackups: backup_guid
-              }
-            }
-          }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, backup_guid, {
             status: {
               response: JSON.stringify(data)
@@ -693,15 +681,8 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 200 Ok - backup state retrieved from meta information with platform and tenant_id', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_backup_defaultbackups: backup_guid
-              }
-            }
-          }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, backup_guid, {
             status: {
               response: JSON.stringify(data)
@@ -728,9 +709,19 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 404  - if last backup label is not set in deployment resource', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                service_id: service_id,
+                plan_id: plan_id,
+                context: {
+                  platform: 'cloudfoundry',
+                },
+                space_guid: space_guid,
+              })
+            }
+          }, 2);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/backup`)
             .set('Authorization', authHeader)
@@ -747,15 +738,8 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 404 if Not Found in apiserver', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_backup_defaultbackups: backup_guid
-              }
-            }
-          }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, backup_guid, {
             status: {
               response: JSON.stringify(data)
@@ -789,19 +773,8 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('should return 202 Accepted', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_backup_defaultbackups: 'b4719e7c-e8d3-4f7f-c515-769ad1c3ebfa'
-              }
-            }
-          }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResourceAbort, 2);
           mocks.apiServerEventMesh.nockGetResourceRegex(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, {
             status: {
               state: 'in_progress',
@@ -828,19 +801,8 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_backup_defaultbackups: 'b4719e7c-e8d3-4f7f-c515-769ad1c3ebfa'
-              }
-            }
-          }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResourceAbort, 2);
           mocks.apiServerEventMesh.nockGetResourceRegex(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, {
             status: {
               state: 'in_progress',
@@ -867,19 +829,8 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('should return skip abort if state is not "in_progress"', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_backup_defaultbackups: 'b4719e7c-e8d3-4f7f-c515-769ad1c3ebfa'
-              }
-            }
-          }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResourceAbort, 2);
           mocks.apiServerEventMesh.nockGetResourceRegex(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, {
             status: {
               state: 'succeeded',
@@ -921,13 +872,8 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('Bad Request at start-restore with time_stamp operation for non PITR service', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           return chai
             .request(apps.external)
             .post(`${base_url}/service_instances/${instance_id}/restore`)
@@ -988,12 +934,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 400 Bad Request (no backup_guid or time_stamp given)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai
             .request(apps.external)
@@ -1008,12 +949,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 400 Bad Request (invalid backup_guid given)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai
             .request(apps.external)
@@ -1031,12 +967,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 400 Bad Request (invalid time_stamp format given)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai
             .request(apps.external)
@@ -1054,12 +985,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 400 Bad Request (invalid time_stamp older than 14 days given)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           const requestTimeStamp = `${Date.now() - (config.backup.retention_period_in_days + 2) * 60 * 60 * 24 * 1000}`;
           return chai
@@ -1079,12 +1005,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 422 Unprocessable Entity (no backup with this guid found)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix, []);
           return chai
@@ -1103,12 +1024,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 422 Unprocessable Entity (no backup found before given time_stamp)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix1, []);
           return chai
@@ -1127,12 +1043,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 422 Unprocessable Entity (no backup found before given time_stamp - Cross instance restore)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, citrBackupPrefix1, []);
           return chai
@@ -1152,12 +1063,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 422 Unprocessable Entity (backup still in progress)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix, [backupFilename]);
           mocks.cloudProvider.download(backupPathname, {
@@ -1179,12 +1085,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 422 Unprocessable Entity PITR based (backup still in progress)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix1, [backupFilename]);
           mocks.cloudProvider.download(backupPathname, {
@@ -1206,12 +1107,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 422 Unprocessable Entity (plan ids do not match)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix, [backupFilename]);
           mocks.cloudProvider.download(backupPathname, {
@@ -1237,12 +1133,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 422 Unprocessable Entity PITR based (plan ids do not match)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix1, [backupFilename]);
           mocks.cloudProvider.download(backupPathname, {
@@ -1268,12 +1159,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 400 BadRequest : backup_guid based (quota exceeded)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.download(restorePathname, _.chain(_.cloneDeep(restoreMetadata))
             .set('restore_dates', getDateHistory(11))
@@ -1294,12 +1180,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 400 BadRequest : PITR (quota exceeded)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.download(restorePathname, _.assign(_.cloneDeep(restoreMetadata), {
             restore_dates: getDateHistory(11)
@@ -1369,8 +1250,6 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should initiate a start-restore operation via apiserver', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix, [backupFilename]);
           mocks.cloudProvider.download(backupPathname, backupMetadata);
@@ -1388,7 +1267,9 @@ describe('service-fabrik-api-sf2.0', function () {
                   platform: CONST.PLATFORM.CF,
                   space_guid: space_guid,
                   organization_guid: organization_guid
-                }
+                },
+                space_guid: space_guid,
+                plan_id: plan_id
               })
             }
           });
@@ -1410,8 +1291,6 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should initiate a start-restore operation via apiserver:PITR', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix1, [backupFilename]);
           mocks.cloudProvider.download(backupPathname, backupMetadata);
@@ -1427,7 +1306,9 @@ describe('service-fabrik-api-sf2.0', function () {
                   platform: CONST.PLATFORM.CF,
                   space_guid: space_guid,
                   organization_guid: organization_guid
-                }
+                },
+                space_guid: space_guid,
+                plan_id: plan_id
               })
             }
           });
@@ -1451,8 +1332,6 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should initiate a start-restore operation via apiserver :PITR (within quota)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix1, [backupFilename]);
           mocks.cloudProvider.download(backupPathname, backupMetadata);
@@ -1469,7 +1348,9 @@ describe('service-fabrik-api-sf2.0', function () {
                   platform: CONST.PLATFORM.CF,
                   space_guid: space_guid,
                   organization_guid: organization_guid
-                }
+                },
+                space_guid: space_guid,
+                plan_id: plan_id
               })
             }
           });
@@ -1493,8 +1374,6 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should initiate a start-restore operation via apiserver:PITR (within quota - no history)', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, backupPrefix1, [backupFilename]);
           mocks.cloudProvider.download(backupPathname, backupMetadata);
@@ -1513,7 +1392,9 @@ describe('service-fabrik-api-sf2.0', function () {
                   platform: CONST.PLATFORM.CF,
                   space_guid: space_guid,
                   organization_guid: organization_guid
-                }
+                },
+                space_guid: space_guid,
+                plan_id: plan_id
               })
             }
           });
@@ -1537,8 +1418,6 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should initiate a start-restore operation at cloud controller via a service instance update: PITR - Cross Instance restore', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.findServicePlanByInstanceId(instance_id, plan_guid, plan_id);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.cloudProvider.list(container, citrBackupPrefix1, [citrBackupFilename]);
           mocks.cloudProvider.download(citrBackupPathname, backupMetadata);
@@ -1557,7 +1436,9 @@ describe('service-fabrik-api-sf2.0', function () {
                   platform: CONST.PLATFORM.CF,
                   space_guid: space_guid,
                   organization_guid: organization_guid
-                }
+                },
+                space_guid: space_guid,
+                plan_id: plan_id
               })
             }
           });
@@ -1595,11 +1476,6 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 200 Ok', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           // mocks.cloudProvider.download(pathname, data);
           // mocks.agent.lastRestoreOperation(restoreState);
@@ -1608,14 +1484,7 @@ describe('service-fabrik-api-sf2.0', function () {
               response: JSON.stringify(restoreState)
             }
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_restore_defaultrestores: restore_guid
-              }
-            }
-          }, 2);
-
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/restore`)
             .set('Authorization', authHeader)
@@ -1629,19 +1498,8 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 404 Not Found', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
-            metadata: {
-              labels: {
-                last_restore_defaultrestores: restore_guid
-              }
-            }
-          }, 2);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/restore`)
             .set('Authorization', authHeader)
@@ -1663,6 +1521,21 @@ describe('service-fabrik-api-sf2.0', function () {
         //   agent_ip: mocks.agent.ip
         // };
         let sandbox, delayStub;
+        const directorResourceAbort = {
+          metadata: {
+            labels: {}
+          },
+          spec: {
+            options: JSON.stringify({
+              service_id: service_id,
+              plan_id: plan_id,
+              context: {
+                platform: 'cloudfoundry',
+              },
+              space_guid: space_guid,
+            })
+          }
+        };
         before(function () {
           sandbox = sinon.sandbox.create();
           delayStub = sandbox.stub(Promise, 'delay', () => Promise.resolve(true));
@@ -1673,19 +1546,9 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('should return 202 Accepted', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          const directorResource = {
-            metadata: {
-              labels: {}
-            }
-          };
-          directorResource.metadata.labels[`last_${CONST.OPERATION_TYPE.RESTORE}_${CONST.APISERVER.RESOURCE_TYPES.DEFAULT_RESTORE}`] = restore_guid;
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, directorResource, 2);
+          directorResourceAbort.metadata.labels[`last_${CONST.OPERATION_TYPE.RESTORE}_${CONST.APISERVER.RESOURCE_TYPES.DEFAULT_RESTORE}`] = restore_guid;
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, directorResourceAbort, 2);
           mocks.apiServerEventMesh.nockGetResourceRegex(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_RESTORE, {
             status: {
               state: CONST.RESTORE_OPERATION.PROCESSING,
@@ -1712,21 +1575,10 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-
-          const directorResource = {
-            metadata: {
-              labels: {}
-            }
-          };
-          directorResource.metadata.labels[`last_${CONST.OPERATION_TYPE.RESTORE}_${CONST.APISERVER.RESOURCE_TYPES.DEFAULT_RESTORE}`] = restore_guid;
+          directorResourceAbort.metadata.labels[`last_${CONST.OPERATION_TYPE.RESTORE}_${CONST.APISERVER.RESOURCE_TYPES.DEFAULT_RESTORE}`] = restore_guid;
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            instance_id, directorResource, 2);
+            instance_id, directorResourceAbort, 2);
           mocks.apiServerEventMesh.nockGetResourceRegex(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_RESTORE, {
             status: {
               state: 'succeeded',
@@ -1936,11 +1788,8 @@ describe('service-fabrik-api-sf2.0', function () {
           delete config.mongodb.url;
           delete config.mongodb.provision;
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
           mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
             .set('Authorization', authHeader)
@@ -1961,10 +1810,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 400 - Bad request on skipping mandatory params', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -1980,18 +1826,12 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 201 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            service_guid: service_id,
-            space_guid: space_guid,
-            service_plan_guid: plan_id
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpace(space_guid, {
             organization_guid: organization_guid
           });
           mocks.cloudController.getOrganization(organization_guid);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
             .set('Authorization', authHeader)
@@ -2015,10 +1855,7 @@ describe('service-fabrik-api-sf2.0', function () {
           const mongodbprovision = config.mongodb.provision;
           mocks.uaa.tokenKey();
           delete config.mongodb.provision;
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -2035,11 +1872,7 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -2060,10 +1893,7 @@ describe('service-fabrik-api-sf2.0', function () {
           delete config.mongodb.url;
           delete config.mongodb.provision;
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -2080,11 +1910,7 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
             .set('Authorization', adminAuthHeader)
@@ -2104,10 +1930,7 @@ describe('service-fabrik-api-sf2.0', function () {
           delete config.mongodb.url;
           delete config.mongodb.provision;
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -2129,10 +1952,7 @@ describe('service-fabrik-api-sf2.0', function () {
 
         it('should return 400 - Badrequest on skipping mandatory params', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -2152,8 +1972,7 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);          mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.director.getDeployments();
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -2176,8 +1995,7 @@ describe('service-fabrik-api-sf2.0', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);          mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.director.getDeployments();
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -2198,12 +2016,7 @@ describe('service-fabrik-api-sf2.0', function () {
       describe('#GetUpdateSchedule', function () {
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
-          mocks.cloudController.getSpaceDevelopers(space_guid);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);          mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_update`)
             .set('Authorization', authHeader)
@@ -2225,7 +2038,8 @@ describe('service-fabrik-api-sf2.0', function () {
                   space_guid: space_guid,
                   organization_guid: organization_guid
                 },
-                plan_id: plan_id
+                plan_id: plan_id,
+                space_guid: space_guid
               })
             }
           }, 2);

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -295,10 +295,10 @@ describe('service-fabrik-api-sf2.0', function () {
             });
         });
 
-        it('should fail if resource could not be fetched from ApiServer and request does not contain plan_id', function(done) {
+        it('should fail if resource could not be fetched from ApiServer and request does not contain plan_id', function (done) {
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1 , 404);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, 404);
           return chai
             .request(apps.external)
             .post(`${base_url}/service_instances/${instance_id}/backup`)
@@ -315,9 +315,9 @@ describe('service-fabrik-api-sf2.0', function () {
             });
         });
 
-        it('should fail if resource could not be fetched from ApiServer and request does not contain space_guid', function(done) {
+        it('should fail if resource could not be fetched from ApiServer and request does not contain space_guid', function (done) {
           mocks.uaa.tokenKey();
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1 , 404);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, 404);
           return chai
             .request(apps.external)
             .post(`${base_url}/service_instances/${instance_id}/backup`)

--- a/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
@@ -41,9 +41,19 @@ describe('service-fabrik-api', function () {
       const repeatTimezone = 'America/New_York';
       const dummyDeploymentResource = {
         metadata: {
-          annotations: {
-            labels: 'dummy'
+          labels: {
+            last_backup_defaultbackups: backup_guid
           }
+        },
+        spec: {
+          options: JSON.stringify({
+            service_id: service_id,
+            plan_id: plan_id,
+            context: {
+              platform: 'cloudfoundry',
+            },
+            space_guid: space_guid,
+          })
         }
       };
       const getJob = (name, type) => {
@@ -112,13 +122,8 @@ describe('service-fabrik-api', function () {
             number_of_files: 5
           };
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
@@ -240,10 +245,7 @@ describe('service-fabrik-api', function () {
           delete config.mongodb.url;
           delete config.mongodb.provision;
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -265,10 +267,7 @@ describe('service-fabrik-api', function () {
 
         it('should return 400 - Bad request on skipping mandatory params', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -284,16 +283,11 @@ describe('service-fabrik-api', function () {
 
         it('should return 201 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            service_guid: service_id,
-            space_guid: space_guid,
-            service_plan_guid: plan_id
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpace(space_guid, {
             organization_guid: organization_guid
           });
           mocks.cloudController.getOrganization(organization_guid);
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
           mocks.cloudController.getSpaceDevelopers(space_guid);
 
           return chai.request(apps.external)
@@ -319,10 +313,7 @@ describe('service-fabrik-api', function () {
           const mongodbprovision = config.mongodb.provision;
           mocks.uaa.tokenKey();
           delete config.mongodb.provision;
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -339,11 +330,7 @@ describe('service-fabrik-api', function () {
         });
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -364,10 +351,7 @@ describe('service-fabrik-api', function () {
           delete config.mongodb.url;
           delete config.mongodb.provision;
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
@@ -384,11 +368,7 @@ describe('service-fabrik-api', function () {
         });
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
             .set('Authorization', adminAuthHeader)
@@ -408,10 +388,7 @@ describe('service-fabrik-api', function () {
           delete config.mongodb.url;
           delete config.mongodb.provision;
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -433,10 +410,7 @@ describe('service-fabrik-api', function () {
 
         it('should return 400 - Badrequest on skipping mandatory params', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .put(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -456,7 +430,7 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.director.getDeployments();
           return chai.request(apps.external)
@@ -479,7 +453,7 @@ describe('service-fabrik-api', function () {
             space_guid: space_guid,
             service_plan_guid: plan_guid
           });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.director.getDeployments();
           return chai.request(apps.external)
@@ -501,11 +475,7 @@ describe('service-fabrik-api', function () {
       describe('#GetUpdateSchedule', function () {
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
-          mocks.cloudController.getServiceInstance(instance_id, {
-            space_guid: space_guid,
-            service_plan_guid: plan_guid
-          });
-          mocks.cloudController.findServicePlan(instance_id, plan_id);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .get(`${base_url}/service_instances/${instance_id}/schedule_update`)
@@ -528,7 +498,8 @@ describe('service-fabrik-api', function () {
                   space_guid: space_guid,
                   organization_guid: organization_guid
                 },
-                plan_id: plan_id
+                plan_id: plan_id,
+                space_guid: space_guid
               })
             }
           }, 2);

--- a/test/test_broker/jobs.BackupReaperJobs.spec.js
+++ b/test/test_broker/jobs.BackupReaperJobs.spec.js
@@ -53,6 +53,18 @@ describe('Jobs', function () {
     const repeatTimezone = 'America/New_York';
     const time = Date.now();
     const username = 'admin';
+    const dummyDeploymentResource = {
+      spec: {
+        options: JSON.stringify({
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'cloudfoundry',
+          },
+          space_guid: space_guid,
+        })
+      }
+    };
     const scheduled_data = {
       trigger: CONST.BACKUP.TRIGGER.SCHEDULED,
       type: 'online',
@@ -248,7 +260,7 @@ describe('Jobs', function () {
           throw new NotFound('Schedulde not found.');
         });
       });
-      mocks.cloudController.findServicePlan(instance_id, plan_id);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
       mocks.director.getDeployment(deploymentName, true);
       return BackupReaperJob.run(job, () => {
         mocks.verify();
@@ -297,7 +309,7 @@ describe('Jobs', function () {
           throw new NotFound('Schedulde not found.');
         });
       });
-      mocks.cloudController.findServicePlan(instance_id);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, 404);
       mocks.director.getDeployment(deploymentName, false, undefined, 2);
       return BackupReaperJob.run(job, () => {
         mocks.verify();

--- a/test/test_broker/jobs.ScheduleBackupJob.spec.js
+++ b/test/test_broker/jobs.ScheduleBackupJob.spec.js
@@ -59,6 +59,18 @@ describe('Jobs', function () {
       const transactionLogsPathname19 = `/${serviceContainer}/${transactionLogsFileName19Daysprior}`;
       const transactionLogsPathname16 = `/${serviceContainer}/${transactionLogsFileName16DaysPrior}`;
       const transactionLogsPathname18 = `/${serviceContainer}/${transactionLogsFileName18DaysPrior}`;
+      const dummyDeploymentResource = {
+        spec: {
+          options: JSON.stringify({
+            service_id: service_id,
+            plan_id: plan_id,
+            context: {
+              platform: 'cloudfoundry',
+            },
+            space_guid: space_guid,
+          })
+        }
+      };
       const scheduled_data = {
         trigger: CONST.BACKUP.TRIGGER.SCHEDULED,
         type: 'online',
@@ -169,7 +181,7 @@ describe('Jobs', function () {
         const backupResponse = {
           backup_guid: backup_guid
         };
-        mocks.cloudController.findServicePlan(instance_id, plan_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
         mocks.serviceFabrikClient.startBackup(instance_id, {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
@@ -235,7 +247,7 @@ describe('Jobs', function () {
         const backupResponse = {
           backup_guid: backup_guid
         };
-        mocks.cloudController.findServicePlan(instance_id, plan_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
         mocks.serviceFabrikClient.startBackup(instance_id, {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
@@ -304,7 +316,7 @@ describe('Jobs', function () {
         const backupResponse = {
           backup_guid: backup_guid
         };
-        mocks.cloudController.findServicePlan(instance_id, plan_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
         mocks.serviceFabrikClient.startBackup(instance_id, {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
@@ -370,7 +382,7 @@ describe('Jobs', function () {
         const backupResponse = {
           backup_guid: backup_guid
         };
-        mocks.cloudController.findServicePlan(instance_id, plan_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
         mocks.serviceFabrikClient.startBackup(instance_id, {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
@@ -441,7 +453,7 @@ describe('Jobs', function () {
         const backupResponse = {
           backup_guid: backup_guid
         };
-        mocks.cloudController.findServicePlan(instance_id, plan_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
         mocks.serviceFabrikClient.startBackup(instance_id, {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
@@ -500,7 +512,7 @@ describe('Jobs', function () {
         }, {
           status: 500
         });
-        mocks.cloudController.findServicePlan(instance_id, plan_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
         return ScheduleBackupJob.run(job, () => {
           mocks.verify();
           const errStatusCode = 500;
@@ -523,7 +535,7 @@ describe('Jobs', function () {
         }, {
           status: 409
         });
-        mocks.cloudController.findServicePlanByInstanceId(instance_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
         return ScheduleBackupJob.run(job, () => {})
           .then(() => {
             mocks.verify();
@@ -557,7 +569,7 @@ describe('Jobs', function () {
         }, {
           status: 409
         });
-        mocks.cloudController.findServicePlan(failed_instance_id, plan_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, failed_instance_id, dummyDeploymentResource);
         return ScheduleBackupJob.run(_.chain(_.cloneDeep(job)).set('attrs.data.attempt', max_attmpts).value(), () => {})
           .then(() => {
             mocks.verify();
@@ -583,7 +595,7 @@ describe('Jobs', function () {
         }, {
           status: 409
         });
-        mocks.cloudController.findServicePlan(failed_instance_id, plan_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, failed_instance_id, dummyDeploymentResource);
         return ScheduleBackupJob.run(job, () => {})
           .then(() => {
             mocks.verify();
@@ -604,7 +616,7 @@ describe('Jobs', function () {
         const backupResponse = {
           backup_guid: backup_guid
         };
-        mocks.cloudController.findServicePlan(instance_id, plan_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
         mocks.serviceFabrikClient.startBackup(instance_id, {
           type: 'online',
           trigger: CONST.BACKUP.TRIGGER.SCHEDULED
@@ -629,7 +641,7 @@ describe('Jobs', function () {
         });
       });
       it('should delete scheduled backup & any on-demand backups even when service instance is deleted', function () {
-        mocks.cloudController.findServicePlan(instance_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, 404);
         mocks.cloudProvider.list(container, prefix, [
           fileName14Daysprior,
           fileName16DaysPrior,
@@ -697,7 +709,7 @@ describe('Jobs', function () {
         });
       });
       it('should cancel backup job (itself) when there are no more backups or transaction-logs to delete & instance is deleted', function () {
-        mocks.cloudController.findServicePlan(instance_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, 404);
         mocks.cloudProvider.list(container, prefix, []);
         mocks.cloudProvider.list(container, prefix, []);
         //Since, all the backups are deleted the list is returning empty.
@@ -725,7 +737,7 @@ describe('Jobs', function () {
       });
       it('should handle errors when cancelling backup job (itself)', function () {
         job.attrs.data.instance_id = failed_instance_id;
-        mocks.cloudController.findServicePlan(failed_instance_id);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, failed_instance_id, {}, 1, 404);
         mocks.cloudProvider.list(container, failed_prefix, []);
         mocks.cloudProvider.list(container, failed_prefix, []);
         mocks.cloudProvider.listBlobs(serviceContainer, transactionLogsPrefixFailedInstance, [], 2);

--- a/test/test_broker/jobs.ScheduleBackupJob.spec.js
+++ b/test/test_broker/jobs.ScheduleBackupJob.spec.js
@@ -788,7 +788,6 @@ describe('Jobs', function () {
         }, {
           status: 500
         });
-        mocks.cloudController.findServicePlan(instance_id, plan_id);
         return ScheduleBackupJob.run(job, () => {
           expect(baseJobLogRunHistoryStub).not.to.be.called;
         });

--- a/test/test_broker/utils.spec.js
+++ b/test/test_broker/utils.spec.js
@@ -426,4 +426,27 @@ describe('utils', function () {
       expect(platformManager.platform).to.eql('cf');
     });
   });
+
+  describe('#getPlatformFromContext', function () {
+    it('should handle context originating from CF/k8s platform', function () {
+      let context = {
+        platform: 'cloudfoundry',
+        organization_guid: 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a',
+        space_guid: 'e7c0a437-7585-4d75-addf-aa4d45b49f3a'
+      }
+
+      expect(utils.getPlatformFromContext(context)).to.eql('cloudfoundry');
+    });
+
+    it('should handle the context originating from SM platform', function () {
+      let context = {
+        platform: 'sapcp',
+        origin: 'cloudfoundry',
+        organization_guid: 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a',
+        space_guid: 'e7c0a437-7585-4d75-addf-aa4d45b49f3a'
+      }
+
+      expect(utils.getPlatformFromContext(context)).to.eql('cloudfoundry');
+    });
+  });
 });

--- a/test/test_broker/utils.spec.js
+++ b/test/test_broker/utils.spec.js
@@ -433,7 +433,7 @@ describe('utils', function () {
         platform: 'cloudfoundry',
         organization_guid: 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a',
         space_guid: 'e7c0a437-7585-4d75-addf-aa4d45b49f3a'
-      }
+      };
 
       expect(utils.getPlatformFromContext(context)).to.eql('cloudfoundry');
     });
@@ -444,7 +444,7 @@ describe('utils', function () {
         origin: 'cloudfoundry',
         organization_guid: 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a',
         space_guid: 'e7c0a437-7585-4d75-addf-aa4d45b49f3a'
-      }
+      };
 
       expect(utils.getPlatformFromContext(context)).to.eql('cloudfoundry');
     });


### PR DESCRIPTION
* Related backlog is: HCPCFS-2167.

* We can get rid of hard dependencies on Cloud Foundry CC by making use of ApiServer to fetch `space_guid`, `plan_id` and `context`.
 
* Filewise changes are as follows:

**1.  ServiceFabrikApiController**
* We fetch and store `context`, `space_guid` and `plan_id` at the start of processing of `/service_instances/:instance_id` requests, if not present already in the request.
* As the `space_guid` and `plan_id` would _always_ be present in requests now, the calls to CC to fetch them in `setPlan`, `verifyTenantPermission`(only `getServiceInstance` call is removed `getSpaceDeveloper` call still exists) and `startRestore` are removed.
* In `scheduleBackup`, information such as `org_name`, `space_name` etc is used in job parameters. Currently, this logic is slightly altered to fetch this information _conditionally_, i.e., if the platform is Cloud Foundry. 
* Similarly in `scheduleUpdate`, the `instance_name` will be fetched conditionally based on platform value.
* Above two cases can be alternatively dealt by removing this information from job data. Comments on this are requested.
* In `listBackupFiles` the plan details will be fetched from ApiServer instead of CC.

**2.  BackupReaperJob and ScheduleBackupJob**
* `isServiceInstanceDeleted` check will be done using ApiServer.