### PR TITLE
Changes for returning complete catalog with /sm/v2/catalog endpoint

### DIFF
--- a/platform-managers/BasePlatformManager.js
+++ b/platform-managers/BasePlatformManager.js
@@ -20,9 +20,9 @@ class BasePlatformManager {
     const platform = this.platform;
     _.remove(modifiedCatalog.services, function (service) {
       _.remove(service.plans, function (plan) {
-        return !_.includes(_.get(plan, 'supported_platform', ['cf']), platform);
+        return !_.includes(_.get(plan, 'supported_platform', ['cf', 'sm']), platform);
       });
-      return !_.includes(_.get(service, 'supported_platform', ['cf']), platform);
+      return !_.includes(_.get(service, 'supported_platform', ['cf', 'sm']), platform);
     });
     return modifiedCatalog;
   }


### PR DESCRIPTION
* Currently entire catalog is returned by default for /cf/v2/catalog endpoint. However with introduction of service manager, /sm/v2/catalog endpoint will be used instead for broker registration. Therefore, this PR adds minor modifications so that entire catalog will be returned for /sm/v2/catalog as well.