### PR TITLE
Cancel schedule update API

### DIFF
--- a/api-controllers/ServiceFabrikApiController.js
+++ b/api-controllers/ServiceFabrikApiController.js
@@ -927,7 +927,7 @@ class ServiceFabrikApiController extends FabrikBaseController {
 
   cancelScheduledBackup(req, res) {
     if (!_.get(req, 'cloudControllerScopes').includes('cloud_controller.admin')) {
-      throw new Forbidden(`Permission denined. Cancelling of backups can only be done by user with cloud_controller.admin scope.`);
+      throw new Forbidden(`Permission denied. Cancelling of backups can only be done by user with cloud_controller.admin scope.`);
     }
     return Promise
       .try(() => this.setPlan(req))
@@ -1028,7 +1028,7 @@ class ServiceFabrikApiController extends FabrikBaseController {
 
   cancelScheduledUpdate(req, res) {
     if (!_.get(req, 'cloudControllerScopes').includes('cloud_controller.admin')) {
-      throw new Forbidden(`Permission denined. Cancelling of scheduled updates can only be done by user with cloud_controller.admin scope.`);
+      throw new Forbidden(`Permission denied. Cancelling of scheduled updates can only be done by user with cloud_controller.admin scope.`);
     }
     // Cancel repeat and all onetime jobs as well
     // e.g. cancel both jobs 6dee3dd8-c990-40d8-93b7-efcaa2637c5e_ServiceInstanceAutoUpdate and 6dee3dd8-c990-40d8-93b7-efcaa2637c5e_ServiceInstanceAutoUpdate_30minutesfromnow_1543823280862

--- a/api-controllers/ServiceFabrikApiController.js
+++ b/api-controllers/ServiceFabrikApiController.js
@@ -1026,6 +1026,22 @@ class ServiceFabrikApiController extends FabrikBaseController {
         .send(body));
   }
 
+  cancelScheduledUpdate(req, res) {
+    if (!_.get(req, 'cloudControllerScopes').includes('cloud_controller.admin')) {
+      throw new Forbidden(`Permission denined. Cancelling of scheduled updates can only be done by user with cloud_controller.admin scope.`);
+    }
+    // Cancel schedule and all onetime jobs as well
+    // e.g. cancel both jobs 6dee3dd8-c990-40d8-93b7-efcaa2637c5e_ServiceInstanceAutoUpdate and 6dee3dd8-c990-40d8-93b7-efcaa2637c5e_ServiceInstanceAutoUpdate_30minutesfromnow_1543823280862
+    const useRegex = true; 
+    return Promise
+      .try(() => this.setPlan(req))
+      .then(() => ScheduleManager
+        .cancelSchedule(req.params.instance_id, CONST.JOB.SERVICE_INSTANCE_UPDATE, useRegex))
+      .then(() => res
+        .status(CONST.HTTP_STATUS_CODE.OK)
+        .send({}));
+  }
+
   static get version() {
     return '1.0';
   }

--- a/api-controllers/ServiceFabrikApiController.js
+++ b/api-controllers/ServiceFabrikApiController.js
@@ -1032,7 +1032,7 @@ class ServiceFabrikApiController extends FabrikBaseController {
     }
     // Cancel repeat and all onetime jobs as well
     // e.g. cancel both jobs 6dee3dd8-c990-40d8-93b7-efcaa2637c5e_ServiceInstanceAutoUpdate and 6dee3dd8-c990-40d8-93b7-efcaa2637c5e_ServiceInstanceAutoUpdate_30minutesfromnow_1543823280862
-    const cancelAllJobs = true; 
+    const cancelAllJobs = true;
     return Promise
       .try(() => this.setPlan(req))
       .then(() => ScheduleManager

--- a/api-controllers/ServiceFabrikApiController.js
+++ b/api-controllers/ServiceFabrikApiController.js
@@ -1030,13 +1030,13 @@ class ServiceFabrikApiController extends FabrikBaseController {
     if (!_.get(req, 'cloudControllerScopes').includes('cloud_controller.admin')) {
       throw new Forbidden(`Permission denined. Cancelling of scheduled updates can only be done by user with cloud_controller.admin scope.`);
     }
-    // Cancel schedule and all onetime jobs as well
+    // Cancel repeat and all onetime jobs as well
     // e.g. cancel both jobs 6dee3dd8-c990-40d8-93b7-efcaa2637c5e_ServiceInstanceAutoUpdate and 6dee3dd8-c990-40d8-93b7-efcaa2637c5e_ServiceInstanceAutoUpdate_30minutesfromnow_1543823280862
-    const useRegex = true; 
+    const cancelAllJobs = true; 
     return Promise
       .try(() => this.setPlan(req))
       .then(() => ScheduleManager
-        .cancelSchedule(req.params.instance_id, CONST.JOB.SERVICE_INSTANCE_UPDATE, useRegex))
+        .cancelSchedule(req.params.instance_id, CONST.JOB.SERVICE_INSTANCE_UPDATE, cancelAllJobs))
       .then(() => res
         .status(CONST.HTTP_STATUS_CODE.OK)
         .send({}));

--- a/api-controllers/ServiceFabrikApiController.js
+++ b/api-controllers/ServiceFabrikApiController.js
@@ -1037,6 +1037,7 @@ class ServiceFabrikApiController extends FabrikBaseController {
       .try(() => this.setPlan(req))
       .then(() => ScheduleManager
         .cancelSchedule(req.params.instance_id, CONST.JOB.SERVICE_INSTANCE_UPDATE, cancelAllJobs))
+      .tap(() => logger.info(`Scheduled update cancelled for '${req.params.instance_id}' by user '${req.user.name}'`))
       .then(() => res
         .status(CONST.HTTP_STATUS_CODE.OK)
         .send({}));

--- a/api-controllers/routes/api/v1.js
+++ b/api-controllers/routes/api/v1.js
@@ -60,7 +60,8 @@ instanceRouter.route('/schedule_update')
   .all(middleware.isFeatureEnabled(CONST.FEATURE.SCHEDULED_UPDATE))
   .put(controller.handler('scheduleUpdate'))
   .get(controller.handler('getUpdateSchedule'))
-  .all(commonMiddleware.methodNotAllowed(['PUT', 'GET']));
+  .delete(controller.handler('cancelScheduledUpdate'))
+  .all(commonMiddleware.methodNotAllowed(['PUT', 'GET', 'DELETE']));
 
 /* Backup Router */
 backupRouter.use(controller.handler('verifyTenantPermission'));

--- a/common/config/eventlog-config-external.yml
+++ b/common/config/eventlog-config-external.yml
@@ -140,3 +140,9 @@ defaults:
     description: Schedule update for a service instance
     tags:
     - schedule_update
+  DELETE:
+    enabled: true
+    event_name: cancel_automated_update
+    description: Cancel automated scheduled update for a service instance
+    tags:
+    - schedule_update

--- a/jobs/ScheduleManager.js
+++ b/jobs/ScheduleManager.js
@@ -114,17 +114,17 @@ class ScheduleManager {
       .then(jobInDB => this.getJobAttrs(jobInDB, agendaJob));
   }
 
-  static cancelSchedule(name, jobType, useRegex) {
-    logger.debug(`cancelling schedule : ${name}_${jobType}, using regex : ${useRegex}`);
+  static cancelSchedule(name, jobType, cancelAllJobs) {
+    logger.debug(`cancelling schedule : ${name}_${jobType}, with cancelAllJobs : ${cancelAllJobs}`);
     return scheduler
-      .cancelJob(name, jobType, useRegex)
-      .then(() => this.deleteJob(name, jobType, useRegex));
+      .cancelJob(name, jobType, cancelAllJobs)
+      .then(() => this.deleteJob(name, jobType, cancelAllJobs));
   }
 
-  static deleteJob(name, jobType, useRegex) {
-    logger.debug(`Deleting Job : ${name}_${jobType}, using regex : ${useRegex}`);
+  static deleteJob(name, jobType, cancelAllJobs) {
+    logger.debug(`Deleting Job : ${name}_${jobType}, with cancelAllJobs : ${cancelAllJobs}`);
     let typeCriteria = jobType;
-    if (useRegex) {
+    if (cancelAllJobs) {
       typeCriteria = {
         $regex: `^${jobType}.*`
       };

--- a/jobs/ScheduleManager.js
+++ b/jobs/ScheduleManager.js
@@ -128,7 +128,7 @@ class ScheduleManager {
       typeCriteria = {
         $regex: `^${jobType}.*`
       };
-    } 
+    }
     const criteria = {
       name: name,
       type: typeCriteria

--- a/jobs/ScheduleManager.js
+++ b/jobs/ScheduleManager.js
@@ -114,18 +114,24 @@ class ScheduleManager {
       .then(jobInDB => this.getJobAttrs(jobInDB, agendaJob));
   }
 
-  static cancelSchedule(name, jobType) {
-    logger.debug(`cancelling schedule : ${name}_${jobType}`);
+  static cancelSchedule(name, jobType, useRegex) {
+    logger.debug(`cancelling schedule : ${name}_${jobType}, using regex : ${useRegex}`);
     return scheduler
-      .cancelJob(name, jobType)
-      .then(() => this.deleteJob(name, jobType));
+      .cancelJob(name, jobType, useRegex)
+      .then(() => this.deleteJob(name, jobType, useRegex));
   }
 
-  static deleteJob(name, jobType) {
-    logger.debug(`Deleting Job : ${name}_${jobType}`);
+  static deleteJob(name, jobType, useRegex) {
+    logger.debug(`Deleting Job : ${name}_${jobType}, using regex : ${useRegex}`);
+    let typeCriteria = jobType;
+    if (useRegex) {
+      typeCriteria = {
+        $regex: `^${jobType}.*`
+      };
+    } 
     const criteria = {
       name: name,
-      type: jobType
+      type: typeCriteria
     };
     return Repository.delete(CONST.DB_MODEL.JOB, criteria);
   }

--- a/jobs/Scheduler.js
+++ b/jobs/Scheduler.js
@@ -333,19 +333,19 @@ class Scheduler {
       });
   }
 
-  cancelJob(name, jobType, useRegex) {
+  cancelJob(name, jobType, cancelAllJobs) {
     return Promise
       .try(() => {
         if (this.initialized !== MONGO_INIT_SUCCEEDED) {
           logger.error('Scheduler not yet initialized! MongoDB not operational');
           throw new ServiceUnavailable('MongoDB not operational');
         }
-        logger.info(`Cancelling schedule for job ${name} - ${jobType}, using regex : ${useRegex}`);
+        logger.info(`Cancelling schedule for job ${name} - ${jobType}, with cancelAllJobs : ${cancelAllJobs}`);
         const criteria = {
           name: jobType
         };
         const jobName = `${name}_${jobType}`;
-        if (useRegex) {
+        if (cancelAllJobs) {
           criteria[`data.${CONST.JOB_NAME_ATTRIB}`] = {
             $regex: `^${jobName}.*`
           };

--- a/jobs/Scheduler.js
+++ b/jobs/Scheduler.js
@@ -333,18 +333,25 @@ class Scheduler {
       });
   }
 
-  cancelJob(name, jobType) {
+  cancelJob(name, jobType, useRegex) {
     return Promise
       .try(() => {
         if (this.initialized !== MONGO_INIT_SUCCEEDED) {
           logger.error('Scheduler not yet initialized! MongoDB not operational');
           throw new ServiceUnavailable('MongoDB not operational');
         }
-        logger.info(`Cancelling schedule for job ${name} - ${jobType}`);
+        logger.info(`Cancelling schedule for job ${name} - ${jobType}, using regex : ${useRegex}`);
         const criteria = {
           name: jobType
         };
-        criteria[`data.${CONST.JOB_NAME_ATTRIB}`] = `${name}_${jobType}`;
+        const jobName = `${name}_${jobType}`;
+        if (useRegex) {
+          criteria[`data.${CONST.JOB_NAME_ATTRIB}`] = {
+            $regex: `^${jobName}.*`
+          };
+        } else {
+          criteria[`data.${CONST.JOB_NAME_ATTRIB}`] = `${name}_${jobType}`;
+        }
         return this
           .agenda
           .cancelAsync(criteria)

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -1978,9 +1978,11 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('should return 403 Forbidden if not admin', function () {
           mocks.uaa.tokenKey();
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
-            .set('Authorization', authHeaderInsufficientScopes)
+            .set('Authorization', authHeader)
             .catch(err => err.response)
             .then(res => {
               expect(cancelScheduleStub).to.be.not.called;
@@ -2215,9 +2217,11 @@ describe('service-fabrik-api-sf2.0', function () {
         });
         it('should return 403 Forbidden if not admin', function () {
           mocks.uaa.tokenKey();
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_update`)
-            .set('Authorization', authHeaderInsufficientScopes)
+            .set('Authorization', authHeader)
             .catch(err => err.response)
             .then(res => {
               expect(cancelScheduleStub).to.be.not.called;

--- a/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -1976,6 +1976,18 @@ describe('service-fabrik-api-sf2.0', function () {
               mocks.verify();
             });
         });
+        it('should return 403 Forbidden if not admin', function () {
+          mocks.uaa.tokenKey();
+          return chai.request(apps.external)
+            .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
+            .set('Authorization', authHeaderInsufficientScopes)
+            .catch(err => err.response)
+            .then(res => {
+              expect(cancelScheduleStub).to.be.not.called;
+              expect(res).to.have.status(403);
+              mocks.verify();
+            });
+        });
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
@@ -1984,6 +1996,9 @@ describe('service-fabrik-api-sf2.0', function () {
             .set('Authorization', adminAuthHeader)
             .catch(err => err.response)
             .then(res => {
+              expect(cancelScheduleStub).to.be.calledOnce;
+              expect(cancelScheduleStub.firstCall.args[0]).to.eql(instance_id);
+              expect(cancelScheduleStub.firstCall.args[1]).to.eql(CONST.JOB.SCHEDULED_BACKUP);
               expect(res).to.have.status(200);
               expect(res.body).to.eql({});
               mocks.verify();
@@ -2119,6 +2134,7 @@ describe('service-fabrik-api-sf2.0', function () {
             });
         });
       });
+
       describe('#GetUpdateSchedule', function () {
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
@@ -2174,6 +2190,38 @@ describe('service-fabrik-api-sf2.0', function () {
                 diff: diff
               }));
               expect(res.body).to.eql(expectedJobResponse);
+              mocks.verify();
+            });
+        });
+      });
+
+      describe('#CancelUpdateSchedule', function () {
+        it('should return 200 OK', function () {
+          mocks.uaa.tokenKey();
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          return chai.request(apps.external)
+            .delete(`${base_url}/service_instances/${instance_id}/schedule_update`)
+            .set('Authorization', adminAuthHeader)
+            .catch(err => err.response)
+            .then(res => {
+              expect(cancelScheduleStub).to.be.calledOnce;
+              expect(cancelScheduleStub.firstCall.args[0]).to.eql(instance_id);
+              expect(cancelScheduleStub.firstCall.args[1]).to.eql(CONST.JOB.SERVICE_INSTANCE_UPDATE);
+              expect(cancelScheduleStub.firstCall.args[2]).to.eql(true);
+              expect(res).to.have.status(200);
+              expect(res.body).to.eql({});
+              mocks.verify();
+            });
+        });
+        it('should return 403 Forbidden if not admin', function () {
+          mocks.uaa.tokenKey();
+          return chai.request(apps.external)
+            .delete(`${base_url}/service_instances/${instance_id}/schedule_update`)
+            .set('Authorization', authHeaderInsufficientScopes)
+            .catch(err => err.response)
+            .then(res => {
+              expect(cancelScheduleStub).to.be.not.called;
+              expect(res).to.have.status(403);
               mocks.verify();
             });
         });

--- a/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
@@ -362,9 +362,11 @@ describe('service-fabrik-api', function () {
         });
         it('should return 403 Forbidden if not admin', function () {
           mocks.uaa.tokenKey();
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
-            .set('Authorization', authHeaderInsufficientScopes)
+            .set('Authorization', authHeader)
             .catch(err => err.response)
             .then(res => {
               expect(cancelScheduleStub).to.be.not.called;
@@ -562,9 +564,11 @@ describe('service-fabrik-api', function () {
         });
         it('should return 403 Forbidden if not admin', function () {
           mocks.uaa.tokenKey();
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          mocks.cloudController.getSpaceDevelopers(space_guid);
           return chai.request(apps.external)
             .delete(`${base_url}/service_instances/${instance_id}/schedule_update`)
-            .set('Authorization', authHeaderInsufficientScopes)
+            .set('Authorization', authHeader)
             .catch(err => err.response)
             .then(res => {
               expect(cancelScheduleStub).to.be.not.called;

--- a/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-api.instances.director.spec.js
@@ -360,6 +360,18 @@ describe('service-fabrik-api', function () {
               mocks.verify();
             });
         });
+        it('should return 403 Forbidden if not admin', function () {
+          mocks.uaa.tokenKey();
+          return chai.request(apps.external)
+            .delete(`${base_url}/service_instances/${instance_id}/schedule_backup`)
+            .set('Authorization', authHeaderInsufficientScopes)
+            .catch(err => err.response)
+            .then(res => {
+              expect(cancelScheduleStub).to.be.not.called;
+              expect(res).to.have.status(403);
+              mocks.verify();
+            });
+        });
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
@@ -368,6 +380,9 @@ describe('service-fabrik-api', function () {
             .set('Authorization', adminAuthHeader)
             .catch(err => err.response)
             .then(res => {
+              expect(cancelScheduleStub).to.be.calledOnce;
+              expect(cancelScheduleStub.firstCall.args[0]).to.eql(instance_id);
+              expect(cancelScheduleStub.firstCall.args[1]).to.eql(CONST.JOB.SCHEDULED_BACKUP);
               expect(res).to.have.status(200);
               expect(res.body).to.eql({});
               mocks.verify();
@@ -466,6 +481,7 @@ describe('service-fabrik-api', function () {
             });
         });
       });
+
       describe('#GetUpdateSchedule', function () {
         it('should return 200 OK', function () {
           mocks.uaa.tokenKey();
@@ -521,6 +537,38 @@ describe('service-fabrik-api', function () {
                 diff: diff
               }));
               expect(res.body).to.eql(expectedJobResponse);
+              mocks.verify();
+            });
+        });
+      });
+
+      describe('#CancelUpdateSchedule', function () {
+        it('should return 200 OK', function () {
+          mocks.uaa.tokenKey();
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
+          return chai.request(apps.external)
+            .delete(`${base_url}/service_instances/${instance_id}/schedule_update`)
+            .set('Authorization', adminAuthHeader)
+            .catch(err => err.response)
+            .then(res => {
+              expect(cancelScheduleStub).to.be.calledOnce;
+              expect(cancelScheduleStub.firstCall.args[0]).to.eql(instance_id);
+              expect(cancelScheduleStub.firstCall.args[1]).to.eql(CONST.JOB.SERVICE_INSTANCE_UPDATE);
+              expect(cancelScheduleStub.firstCall.args[2]).to.eql(true);
+              expect(res).to.have.status(200);
+              expect(res.body).to.eql({});
+              mocks.verify();
+            });
+        });
+        it('should return 403 Forbidden if not admin', function () {
+          mocks.uaa.tokenKey();
+          return chai.request(apps.external)
+            .delete(`${base_url}/service_instances/${instance_id}/schedule_update`)
+            .set('Authorization', authHeaderInsufficientScopes)
+            .catch(err => err.response)
+            .then(res => {
+              expect(cancelScheduleStub).to.be.not.called;
+              expect(res).to.have.status(403);
               mocks.verify();
             });
         });

--- a/test/test_broker/jobs.ScheduleManager.spec.js
+++ b/test/test_broker/jobs.ScheduleManager.spec.js
@@ -510,7 +510,7 @@ describe('Jobs', function () {
     });
 
     describe('#cancelJobSchedule', function () {
-      it('should cancel the schedule for input job in agenda and delete the job from mongodb successfully', function () {
+      it('should cancel the schedule for only repeat job (not all jobs) in agenda and delete the job from mongodb successfully', function () {
         return ScheduleManager
           .cancelSchedule(instance_id, CONST.JOB.SCHEDULED_BACKUP)
           .then((jobResponse) => {
@@ -518,6 +518,29 @@ describe('Jobs', function () {
             expect(schedulerSpy.cancelJob).to.be.calledOnce;
             expect(schedulerSpy.cancelJob.firstCall.args[0][0]).to.eql(instance_id);
             expect(schedulerSpy.cancelJob.firstCall.args[0][1]).to.eql(jobType);
+            expect(schedulerSpy.cancelJob.firstCall.args[0][2]).to.eql(undefined);
+            expect(repoSpy.delete).to.be.calledOnce;
+            expect(repoSpy.delete.firstCall.args[0][0]).to.eql(CONST.DB_MODEL.JOB);
+            expect(repoSpy.delete.firstCall.args[0][1]).to.eql(criteria);
+          });
+      });
+
+      it('should cancel the schedule for all jobs in agenda and delete the job from mongodb successfully', function () {
+        const cancelAllJobs = true;
+        const criteria = {
+          name: instance_id,
+          type: {
+            $regex: `^${jobType}.*`
+          }
+        };
+        return ScheduleManager
+          .cancelSchedule(instance_id, CONST.JOB.SCHEDULED_BACKUP, cancelAllJobs)
+          .then((jobResponse) => {
+            expect(jobResponse).to.eql(DELETE_RESPONSE);
+            expect(schedulerSpy.cancelJob).to.be.calledOnce;
+            expect(schedulerSpy.cancelJob.firstCall.args[0][0]).to.eql(instance_id);
+            expect(schedulerSpy.cancelJob.firstCall.args[0][1]).to.eql(jobType);
+            expect(schedulerSpy.cancelJob.firstCall.args[0][2]).to.eql(true);
             expect(repoSpy.delete).to.be.calledOnce;
             expect(repoSpy.delete.firstCall.args[0][0]).to.eql(CONST.DB_MODEL.JOB);
             expect(repoSpy.delete.firstCall.args[0][1]).to.eql(criteria);
@@ -532,6 +555,7 @@ describe('Jobs', function () {
             expect(schedulerSpy.cancelJob).to.be.calledOnce;
             expect(schedulerSpy.cancelJob.firstCall.args[0][0]).to.eql('0625-6252-7654-9999');
             expect(schedulerSpy.cancelJob.firstCall.args[0][1]).to.eql(jobType);
+            expect(schedulerSpy.cancelJob.firstCall.args[0][2]).to.eql(undefined);
             expect(repoSpy.delete).to.be.calledOnce;
             expect(repoSpy.delete.firstCall.args[0][0]).to.eql(CONST.DB_MODEL.JOB);
             expect(repoSpy.delete.firstCall.args[0][1]).to.eql(_.set(criteria, 'name', '0625-6252-7654-9999'));


### PR DESCRIPTION
This PR:
- Adds a new DELETE /schedule_update API
- The API deletes all update jobs (repeat job and one time retry jobs) for the instance 
- Scheduler and ScheduleManager cancel/delete job functions are made parameterized to accept whether to cancel all jobs or only a particular repeat job
- Unit tests added for the same
- API documentation changes #553 