### PR TITLE
Add functions for creating volume from snapshot and fetching disk metadata for AWS, GCP and Azure

### DIFF
--- a/data-access-layer/iaas/BaseCloudClient.js
+++ b/data-access-layer/iaas/BaseCloudClient.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const uuid = require('uuid');
 const errors = require('../../common/errors');
 const CONST = require('../../common/constants');
 const NotImplementedBySubclass = errors.NotImplementedBySubclass;
@@ -43,6 +44,14 @@ class BaseCloudClient {
     return _.nth(/^(.+)-broker$/.exec(this.containerName), 1);
   }
 
+  createDiskFromSnapshot(snapshotId, zones, options) {
+    throw new NotImplementedBySubclass(`createDiskFromSnapshot - ${snapshotId}, ${zones}, ${options}`);
+  }
+
+  getDiskMetadata(diskCid, zone) {
+    throw new NotImplementedBySubclass(`getDiskMetadata: ${diskCid}, ${zone}`);
+  }
+
   getContainer() {
     throw new NotImplementedBySubclass('getContainer');
   }
@@ -73,6 +82,10 @@ class BaseCloudClient {
 
   deleteSnapshot() {
     throw new NotImplementedBySubclass('deleteSnapshot');
+  }
+
+  getRandomDiskId() {
+    return `sf-disk-${uuid.v4()}`;
   }
 
   static createStorageClient() {

--- a/data-access-layer/iaas/GcpClient.js
+++ b/data-access-layer/iaas/GcpClient.js
@@ -33,22 +33,22 @@ class GcpClient extends BaseCloudClient {
   getDiskMetadata(diskCid, zone) {
     return Promise.try(() =>
       this.computeClient
-        .zone(zone)
-        .disk(diskCid)
-        .get()
-        .then(diskData => diskData[0].metadata)
-        .then(metadata => {
-          return {
-            volumeId: metadata.name,
-            size: metadata.sizeGb,
-            zone: metadata.zone.substring(metadata.zone.lastIndexOf('/') + 1),
-            type: metadata.type.substring(metadata.type.lastIndexOf('/') + 1),
-            extra: {
-              tags: metadata.labels,
-              type: metadata.type
-            }
-          };
-        })
+      .zone(zone)
+      .disk(diskCid)
+      .get()
+      .then(diskData => diskData[0].metadata)
+      .then(metadata => {
+        return {
+          volumeId: metadata.name,
+          size: metadata.sizeGb,
+          zone: metadata.zone.substring(metadata.zone.lastIndexOf('/') + 1),
+          type: metadata.type.substring(metadata.type.lastIndexOf('/') + 1),
+          extra: {
+            tags: metadata.labels,
+            type: metadata.type
+          }
+        };
+      })
     );
   }
 
@@ -106,12 +106,12 @@ class GcpClient extends BaseCloudClient {
     }
     return Promise.try(() =>
       this.storageClient
-        .bucket(container)
-        .get()
-        .then(result => {
-          // return the bucket metadata
-          return result[1];
-        })
+      .bucket(container)
+      .get()
+      .then(result => {
+        // return the bucket metadata
+        return result[1];
+      })
     );
   }
 
@@ -127,14 +127,14 @@ class GcpClient extends BaseCloudClient {
     queryOptions.autoPaginate = true;
     return Promise.try(() =>
       this.storageClient
-        .bucket(container)
-        .getFiles(queryOptions)
-        .then(results => {
-          return _.get(results, 0, []).map(file => ({
-            name: file.name,
-            lastModified: file.metadata.updated
-          }));
-        })
+      .bucket(container)
+      .getFiles(queryOptions)
+      .then(results => {
+        return _.get(results, 0, []).map(file => ({
+          name: file.name,
+          lastModified: file.metadata.updated
+        }));
+      })
     );
   }
 
@@ -145,12 +145,12 @@ class GcpClient extends BaseCloudClient {
     }
     logger.debug(`Deleting file ${file} in container ${container} `);
     return Promise.try(() =>
-      this.storageClient
+        this.storageClient
         .bucket(container)
         .file(file)
         .delete()
         .then(() => logger.info(`Deleted file ${file} in container ${container}`))
-    )
+      )
       .catchThrow(BaseCloudClient.providerErrorTypes.Unauthorized,
         new Unauthorized(`Authorization at google cloud storage provider failed while deleting blob ${file} in container ${container}`))
       .catchThrow(BaseCloudClient.providerErrorTypes.Forbidden,
@@ -161,9 +161,9 @@ class GcpClient extends BaseCloudClient {
 
   download(options) {
     return utils.streamToPromise(this.storageClient
-      .bucket(options.container)
-      .file(options.remote)
-      .createReadStream())
+        .bucket(options.container)
+        .file(options.remote)
+        .createReadStream())
       .catchThrow(BaseCloudClient.providerErrorTypes.NotFound, new NotFound(`Object '${options.remote}' not found`));
   }
 

--- a/test/test_broker/iaas.CloudProviderClient.js
+++ b/test/test_broker/iaas.CloudProviderClient.js
@@ -13,6 +13,191 @@ describe('iaas', function () {
       createClientSpy.reset();
     });
 
+    describe('#createDiskFromSnapshot', function () {
+      const diskId = 'sample-disk';
+      const snapshotId = 'sample-snapshot';
+      const volType = 'gp2';
+      const zone = 'zone';
+      const response = {
+        Volumes: [{
+          VolumeId: diskId,
+          Size: '4',
+          AvailabilityZone: 'zone',
+          VolumeType: 'type'
+        }]
+      };
+      it('should create disk from snapshot for aws', function () {
+        const client = new CloudProviderClient({
+          name: 'aws',
+          key: 'key',
+          keyId: 'keyId',
+          region: 'region'
+        });
+        const createVolStub = sinon.stub(client.blockstorage, 'createVolume');
+        createVolStub.withArgs({
+          AvailabilityZone: zone,
+          SnapshotId: snapshotId,
+          VolumeType: volType,
+          TagSpecifications: [{
+            ResourceType: 'volume',
+            Tags: [{
+              Key: 'customkey',
+              Value: 'customvalue'
+            }]
+          }]
+        }).returns({
+          promise: () => Promise.resolve(response)
+        });
+        const waitForStub = sinon.stub(client.blockstorage, 'waitFor');
+        waitForStub.withArgs('volumeAvailable', {
+            VolumeIds: [diskId]
+          })
+          .returns({
+            promise: () => Promise.resolve(response)
+          });
+        return client
+          .createDiskFromSnapshot(snapshotId, zone, {
+            volumeType: 'gp2',
+            tags: {
+              customkey: 'customvalue'
+            }
+          })
+          .then(disk => {
+            expect(disk.volumeId).to.eql(diskId);
+            expect(disk.size).to.eql('4');
+            expect(disk.zone).to.eql('zone');
+            expect(disk.type).to.eql('type');
+          });
+      });
+      it('should fail on creating disk from snapshot for aws', function () {
+        const client = new CloudProviderClient({
+          name: 'aws',
+          key: 'key',
+          keyId: 'keyId',
+          region: 'region'
+        });
+        const createVolStub = sinon.stub(client.blockstorage, 'createVolume');
+        createVolStub.withArgs({
+          AvailabilityZone: zone,
+          SnapshotId: snapshotId,
+          VolumeType: volType,
+          TagSpecifications: [{
+            ResourceType: 'volume',
+            Tags: [{
+              Key: 'customkey',
+              Value: 'customvalue'
+            }]
+          }]
+        }).returns({
+          promise: () => Promise.reject(new Error('diskerror'))
+        });
+        return client
+          .createDiskFromSnapshot(snapshotId, zone, {
+            volumeType: 'gp2',
+            tags: {
+              customkey: 'customvalue'
+            }
+          })
+          .catch(err => {
+            expect(err.message).to.eql('diskerror');
+          });
+      });
+      it('should fail on waiting for disk from snapshot for aws', function () {
+        const client = new CloudProviderClient({
+          name: 'aws',
+          key: 'key',
+          keyId: 'keyId',
+          region: 'region'
+        });
+        const createVolStub = sinon.stub(client.blockstorage, 'createVolume');
+        createVolStub.withArgs({
+          AvailabilityZone: zone,
+          SnapshotId: snapshotId,
+          VolumeType: volType,
+          TagSpecifications: [{
+            ResourceType: 'volume',
+            Tags: [{
+              Key: 'customkey',
+              Value: 'customvalue'
+            }]
+          }]
+        }).returns({
+          promise: () => Promise.resolve(response)
+        });
+        const waitForStub = sinon.stub(client.blockstorage, 'waitFor');
+        waitForStub.withArgs('volumeAvailable', {
+            VolumeIds: [diskId]
+          })
+          .returns({
+            promise: () => Promise.reject(new Error('diskwaiterror'))
+          });
+        return client
+          .createDiskFromSnapshot(snapshotId, zone, {
+            volumeType: 'gp2',
+            tags: {
+              customkey: 'customvalue'
+            }
+          })
+          .catch(err => {
+            expect(err.message).to.eql('diskwaiterror');
+          });
+      });
+    });
+
+    describe('#getDiskMetadata', function () {
+      const diskId = 'sample-disk';
+      const response = {
+        Volumes: [{
+          VolumeId: diskId,
+          Size: '4',
+          AvailabilityZone: 'zone',
+          VolumeType: 'type'
+        }]
+      };
+      it('should fetch disk metadata for aws', function () {
+        const client = new CloudProviderClient({
+          name: 'aws',
+          key: 'key',
+          keyId: 'keyId',
+          region: 'region'
+        });
+        const describeVolumesStub = sinon.stub(client.blockstorage, 'describeVolumes');
+        describeVolumesStub.withArgs({
+          VolumeIds: [diskId]
+        }).returns({
+          promise: () => Promise.resolve(response)
+        });
+        return client
+          .getDiskMetadata(diskId)
+          .then(disk => {
+            expect(disk.volumeId).to.eql(diskId);
+            expect(disk.size).to.eql('4');
+            expect(disk.zone).to.eql('zone');
+            expect(disk.type).to.eql('type');
+          });
+      });
+
+      it('should throw error while fetching disk metadata for aws', function () {
+        const client = new CloudProviderClient({
+          name: 'aws',
+          key: 'key',
+          keyId: 'keyId',
+          region: 'region'
+        });
+        const describeVolumesStub = sinon.stub(client.blockstorage, 'describeVolumes');
+        describeVolumesStub.withArgs({
+          VolumeIds: [diskId]
+        }).returns({
+          promise: () => Promise.reject(new Error('diskerror'))
+        });
+        return client
+          .getDiskMetadata(diskId)
+          .catch(err => {
+            expect(err.message).to.eql('diskerror');
+          });
+      });
+    });
+
     describe('#deleteSnapshot', function () {
       it('bubbles up the error if cloudprovider throws error', function () {
         const client = new CloudProviderClient({

--- a/test/test_broker/iaas.GcpClient.spec.js
+++ b/test/test_broker/iaas.GcpClient.spec.js
@@ -45,6 +45,64 @@ const storageUrl = 'https://myaccounts.com/storage/v1';
 const bucketUrl = '/b';
 const region = 'EUROPE-WEST1';
 const storageClass = 'REGIONAL';
+const diskMetadataResponse = [{
+  metadata: {
+    kind: 'compute#disk',
+    id: 'sample-disk',
+    creationTimestamp: '2019-01-20T22:53:39.112-08:00',
+    name: 'disk-sample',
+    description: 'disk sample',
+    sizeGb: '4',
+    zone: 'https://myaccounts.com/compute/v1/projects/my-gcp-dev/zones/europe-west1-c',
+    status: 'READY',
+    sourceSnapshot: 'https://myaccounts.com/compute/v1/projects/my-gcp-dev/global/snapshots/snappy',
+    sourceSnapshotId: 'sample-snapshot',
+    selfLink: 'https://myaccounts.com/compute/v1/projects/my-gcp-dev/zones/europe-west1-c/disks/disk-sample',
+    type: 'https://myaccounts.com/compute/v1/projects/my-gcp-dev/zones/europe-west1-c/diskTypes/pd-ssd',
+    labels: {
+      operation: 'testboshrestore'
+    }
+  }
+}, {}];
+let createDiskEventHandlers = {};
+const createDiskFailedMsg = 'disk create failed';
+const createDiskResponse = [{
+  on: (event, callback) => {
+    _.set(createDiskEventHandlers, event, callback);
+    return true;
+  },
+  removeAllListeners: () => {
+    createDiskEventHandlers = {};
+    return true;
+  }
+}, diskMetadataResponse];
+const diskStub = {
+  get: () => {
+    return Promise.resolve(diskMetadataResponse);
+  }
+};
+const diskFailedStub = {
+  get: () => {
+    return Promise.reject(new Error('diskFailed'));
+  }
+};
+const zoneFailedStub = {
+  disk: () => {
+    return diskFailedStub;
+  },
+  createDisk: () => {
+    return Promise.reject(new Error(createDiskFailedMsg));
+  }
+};
+const zoneStub = {
+  disk: () => {
+    return diskStub;
+  },
+  createDisk: () => {
+    return Promise.resolve(createDiskResponse);
+  }
+};
+
 const bucketMetadataResponse = [{
     /* Bucket Object */
   },
@@ -503,16 +561,91 @@ describe('iaas', function () {
 
     describe('#ComputeOperations', function () {
       let sandbox, client;
-      before(function () {
+      const diskName = 'disk-sample';
+      const zone = 'zone';
+      const snapshotName = 'snappy';
+      beforeEach(function () {
         sandbox = sinon.sandbox.create();
         client = new GcpClient(settings);
         sandbox.stub(GcpCompute.prototype, 'snapshot').returns(snapshotStub);
-      });
-      after(function () {
-        sandbox.restore();
+        sandbox.stub(GcpCompute.prototype, 'zone').returns(zoneStub);
+        sandbox.stub(GcpClient.prototype, 'getRandomDiskId').returns(diskName);
       });
       afterEach(function () {
         deleteSnapshotEventHandlers = {};
+        sandbox.restore();
+      });
+
+      it('disk metadata should fail if get fails', function () {
+        sandbox.restore();
+        sandbox.stub(GcpCompute.prototype, 'zone').returns(zoneFailedStub);
+        return client.getDiskMetadata(diskName, zone)
+          .catch(err => {
+            expect(err.message).to.equal('diskFailed');
+          });
+      });
+
+      it('disk metadata should be fetched successfully', function () {
+        return client.getDiskMetadata(diskName, zone).then(disk => {
+          expect(disk.volumeId).to.equal(diskName);
+          expect(disk.zone).to.equal('europe-west1-c');
+          expect(disk.type).to.equal('pd-ssd');
+          expect(disk.size).to.equal('4');
+        });
+      });
+
+      it('disk should be created successfully', function () {
+        let createDiskPromise = client.createDiskFromSnapshot(snapshotName, zone);
+        return Promise.delay(CONNECTION_WAIT_SIMULATED_DELAY)
+          .then(() => {
+            if (createDiskEventHandlers.complete && _.isFunction(createDiskEventHandlers.complete)) {
+              return createDiskEventHandlers.complete.call(createDiskEventHandlers.complete);
+            } else {
+              throw new Error('Event handlers not registered in create disk from snapshot');
+            }
+          })
+          .then(() => {
+            return createDiskPromise
+              .then(disk => {
+                expect(disk.volumeId).to.equal(diskName);
+                expect(disk.zone).to.equal('europe-west1-c');
+                expect(disk.type).to.equal('pd-ssd');
+                expect(disk.size).to.equal('4');
+              })
+              .catch(() => {
+                throw new Error('expected create disk to be successful');
+              });
+          });
+      });
+
+      it('disk create should fail', function () {
+        let createDiskPromise = client.createDiskFromSnapshot(snapshotName, zone);
+        return Promise.delay(CONNECTION_WAIT_SIMULATED_DELAY)
+          .then(() => {
+            if (createDiskEventHandlers.error && _.isFunction(createDiskEventHandlers.error)) {
+              return createDiskEventHandlers.error.call(createDiskEventHandlers.error, createDiskFailedMsg);
+            } else {
+              throw new Error('Event Handlers not registered in create disk from snapshot');
+            }
+          })
+          .then(() => {
+            return createDiskPromise
+              .then(() => {
+                throw new Error('expected disk create to fail');
+              })
+              .catch(err => expect(err).to.eql(createDiskFailedMsg));
+          });
+      });
+
+      it('disk create should fail if promise throws', function () {
+        sandbox.restore();
+        sandbox.stub(GcpCompute.prototype, 'zone').returns(zoneFailedStub);
+
+        return client.createDiskFromSnapshot(snapshotName, zone)
+          .then(() => {
+            throw new Error('expected disk create request to fail');
+          })
+          .catch(err => expect(err.message).to.eql(createDiskFailedMsg));
       });
 
       it('snapshot should be deleted successfully', function () {

--- a/test/test_broker/mocks/azureClient.js
+++ b/test/test_broker/mocks/azureClient.js
@@ -36,13 +36,16 @@ exports.getContainer = getContainer;
 exports.list = list;
 exports.remove = remove;
 exports.deleteSnapshot = deleteSnapshot;
+exports.getSnapshot = getSnapshot;
+exports.createDisk = createDisk;
+exports.getDisk = getDisk;
 exports.config = config;
 
 function encodePath(pathname) {
   return pathname.replace(/:/g, '%3A');
 }
 
-function auth() {
+function auth(times) {
   const token = {
     type: 'update',
     parameters: {},
@@ -51,6 +54,7 @@ function auth() {
   return nock('https://login.microsoftonline.com')
     .replyContentLength()
     .post(`/${provider.tenant_id}/oauth2/token?api-version=1.0`, body => _.isObject(body))
+    .times(times || 1)
     .reply(200, '{\"token_type\":\"Bearer\",\"resource\":\"https://management.core.windows.net/\",\"access_token\":\"' + utils.encodeBase64(token) + '\"}', {
       'cache-control': 'no-cache, no-store',
       pragma: 'no-cache',
@@ -123,6 +127,43 @@ function deleteSnapshot(remote, expectedResponse, errorMessage) {
   } else {
     return nock('https://management.azure.com')
       .delete(remote)
+      .replyWithError(errorMessage);
+  }
+}
+
+function getSnapshot(remote, expectedResponse, errorMessage) {
+  if (errorMessage === undefined) {
+    return nock('https://management.azure.com')
+      .get(remote)
+      .reply(expectedResponse.status || 200, expectedResponse.body, expectedResponse.headers);
+  } else {
+    return nock('https://management.azure.com')
+      .get(remote)
+      .replyWithError(errorMessage);
+  }
+}
+
+function getDisk(remote, expectedResponse, errorMessage) {
+  if (errorMessage === undefined) {
+    return nock('https://management.azure.com')
+      .get(remote)
+      .reply(expectedResponse.status || 200, expectedResponse.body, expectedResponse.headers);
+  } else {
+    return nock('https://management.azure.com')
+      .get(remote)
+      .replyWithError(errorMessage);
+  }
+}
+
+function createDisk(remote, requestBody, expectedResponse, errorMessage) {
+  if (errorMessage === undefined) {
+    return nock('https://management.azure.com')
+      .replyContentLength()
+      .put(remote, requestBody)
+      .reply(expectedResponse.status || 200, expectedResponse.body, expectedResponse.headers);
+  } else {
+    return nock('https://management.azure.com')
+      .put(remote, requestBody)
       .replyWithError(errorMessage);
   }
 }


### PR DESCRIPTION
- For the new BOSH restore approach to improve recovery times, Service Fabrik must be available to create disks from snapshots and fetch disk metadata for various IaaSes. This is required for quickening the process of recovery by ultimately attaching these disks to the instance(s) via BOSH.