### PR TITLE
Adding errand and disk related API calls in BoshDirectorClient for bosh based restore

### DIFF
--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -898,6 +898,59 @@ class BoshDirectorClient extends HttpClient {
       });
   }
 
+  getDeploymentErrands(deploymentName) {
+    return this.makeRequest({
+        method: 'GET',
+        url: `/deployments/${deploymentName}/errands`
+      }, 200, deploymentName)
+      .then(res => JSON.parse(res.body));
+  }
+
+  /**
+   * Trigger the errand on specific instances and get the task id correspnding to errand
+   * @param {string} deploymentName - Deployment on which errand is to be started
+   * @param {string} errandName - errand name
+   * @param {Object[]}  instances - array of the instances on which the errand is to be triggered
+   * @param {string}  instances[].group - instance group
+   * @param {string}  instances[].id - instance index or id
+   */
+
+  runDeploymentErrand(deploymentName, errandName, instances) {
+    return this.makeRequest({
+        method: 'POST',
+        url: `/deployments/${deploymentName}/errands/${errandName}/runs`,
+        body: {
+          'keep-alive': true,
+          'instances': instances
+        }
+      }, 302, deploymentName)
+      .then(res => {
+        const taskId = this.lastSegment(res.headers.location);
+        logger.info(`Triggered errand ${errandName} on instances ${instances} of deployment ${deploymentName}. \
+      Task Id: ${taskId}.`);
+        return taskId;
+      });
+  }
+
+  createDiskAttachment(deploymentName, diskCid, jobName, instanceId) {
+    return this.makeRequest({
+        method: 'PUT',
+        url: `/disks/${diskCid}/attachments`,
+        qs: {
+          deployment: deploymentName,
+          job: jobName,
+          instance_id: instanceId,
+          disk_properties: 'copy'
+        }
+      }, 302, deploymentName)
+      .then(res => {
+        const taskId = this.lastSegment(res.headers.location);
+        logger.info(`Triggered disk attachment with paramaters --> \
+      deploymentName: ${deploymentName}, jobName: ${jobName}, instanceId: ${instanceId}, diskCid: ${diskCid}`);
+        return taskId;
+      });
+  }
+
   getTaskEvents(taskId) {
     const splitArray = this.parseTaskid(taskId);
     if (splitArray === null) {

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -926,8 +926,7 @@ class BoshDirectorClient extends HttpClient {
       }, 302, deploymentName)
       .then(res => {
         const taskId = this.lastSegment(res.headers.location);
-        logger.info(`Triggered errand ${errandName} on instances ${instances} of deployment ${deploymentName}. \
-      Task Id: ${taskId}.`);
+        logger.info(`Triggered errand ${errandName} on instances ${instances} of deployment ${deploymentName}. Task Id: ${taskId}.`);
         return taskId;
       });
   }
@@ -946,7 +945,7 @@ class BoshDirectorClient extends HttpClient {
       .then(res => {
         const taskId = this.lastSegment(res.headers.location);
         logger.info(`Triggered disk attachment with paramaters --> \
-      deploymentName: ${deploymentName}, jobName: ${jobName}, instanceId: ${instanceId}, diskCid: ${diskCid}`);
+        deploymentName: ${deploymentName}, jobName: ${jobName}, instanceId: ${instanceId}, diskCid: ${diskCid}. Task Id: ${taskId}.`);
         return taskId;
       });
   }


### PR DESCRIPTION
* Support for invoking bosh API for running errand and creating disk attachment is being added in this PR, which will be used in upcoming changes of bosh based restore.