### PR TITLE
Define multi az downgrade service flow definition

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -430,6 +430,7 @@ module.exports = Object.freeze({
     TYPE: {
       BLUEPRINT_SERVICEFLOW: 'blueprint_serviceflow',
       UPGRADE_MULTI_AZ: 'upgrade_to_multi_az',
+      DOWNGRADE_TO_SINGLE_AZ: 'downgrade_to_single_az',
       MAJOR_VERSION_UPGRADE: 'major_version_upgrade'
     }
   },

--- a/common/utils/ServiceFlowMapper.js
+++ b/common/utils/ServiceFlowMapper.js
@@ -20,8 +20,12 @@ class ServiceFlowMapper {
   _checkForMultiAz(params) {
     logger.debug(`Checking for multi-az-migrate - `);
     if (_.get(params, 'parameters.multi_az') !== undefined) {
-      logger.info(`Multi-AZ_Upgrade Service Flow is to be executed`);
-      return CONST.SERVICE_FLOW.TYPE.UPGRADE_MULTI_AZ;
+      if (_.get(params, 'parameters.multi_az') === true || _.get(params, 'parameters.multi_az') === 'true') {
+        logger.info(`Multi-AZ_Upgrade Service Flow is to be executed`);
+        return CONST.SERVICE_FLOW.TYPE.UPGRADE_MULTI_AZ;
+      }
+      logger.info(`Multi-AZ_Downgrade Service Flow is to be executed`);
+      return CONST.SERVICE_FLOW.TYPE.DOWNGRADE_TO_SINGLE_AZ;
     }
     return undefined;
   }

--- a/operators/serviceflow-operator/serial-serviceflow-definition.yml
+++ b/operators/serviceflow-operator/serial-serviceflow-definition.yml
@@ -22,6 +22,17 @@ upgrade_to_multi_az:
     task_description: 'phase: scale down'
     task_data:
       vms_scale: downgrade
+downgrade_to_single_az:
+  description: 'Downgrade deployment back to single availability zone'
+  tasks: 
+  - task_type: ServiceInstanceUpdateTask
+    task_description: 'Deployment update for single-az, phase: scale up'
+    task_data:
+      vms_scale: upgrade
+  - task_type: ServiceInstanceUpdateTask
+    task_description: 'phase: scale down'
+    task_data:
+      vms_scale: downgrade
 major_version_upgrade:
   description: 'Major version upgrade'
   tasks: 

--- a/test/test_broker/utils.ServiceflowMapper.js
+++ b/test/test_broker/utils.ServiceflowMapper.js
@@ -5,13 +5,27 @@ const CONST = require('../../common/constants');
 
 describe('utils', function () {
   describe('ServiceFlowMapper', function () {
-    it('Should return back blueprint Service Flow', () => {
-      const serviceFlowName = serviceFlowMapper.getServiceFlow({
+    it('Should return back upgrade to multi-az Service Flow', () => {
+      let serviceFlowName = serviceFlowMapper.getServiceFlow({
         parameters: {
           multi_az: true
         }
       });
       expect(serviceFlowName).to.equal(CONST.SERVICE_FLOW.TYPE.UPGRADE_MULTI_AZ);
+      serviceFlowName = serviceFlowMapper.getServiceFlow({
+        parameters: {
+          multi_az: 'true'
+        }
+      });
+      expect(serviceFlowName).to.equal(CONST.SERVICE_FLOW.TYPE.UPGRADE_MULTI_AZ);
+    });
+    it('Should return back downgrade to single-az Service Flow', () => {
+      const serviceFlowName = serviceFlowMapper.getServiceFlow({
+        parameters: {
+          multi_az: false
+        }
+      });
+      expect(serviceFlowName).to.equal(CONST.SERVICE_FLOW.TYPE.DOWNGRADE_TO_SINGLE_AZ);
     });
     it('Should return back blueprint ServiceFlow', () => {
       const serviceFlowName = serviceFlowMapper.getServiceFlow({


### PR DESCRIPTION
Earlier as part of service flows implementation only the flow for upgrade to multi-az was defined. As part of the below PR, we are defining the flow definition for bringing the deployment back to single az. In order to activate this flow user needs to input the -c param 'multi_az' with false as the value,  as part of the instance update operation.

ex: 
```
cf update-service bleuprint01  -c '{"multi_az" : false}'
```