### PR TITLE
Fixing json-fying of response

### DIFF
--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -758,9 +758,12 @@ class ServiceFabrikAdminController extends FabrikBaseController {
       key: req.query.key,
       value: req.query.value
     };
+    const body = {
+      message: `Created/Updated ${req.query.key} with value ${req.query.value}`
+    };
     return eventmesh.apiServerClient.createUpdateConfigMapResource(CONST.CONFIG.RESOURCE_NAME, config)
       .then(() => {
-        return res.status(201).send(`Created/Updated ${req.query.key} with value ${req.query.value}`);
+        return res.status(201).send(body);
       });
   }
 

--- a/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
@@ -129,6 +129,9 @@ describe('service-fabrik-admin', function () {
           }
         }
       }));
+      const response_body = {
+        message: 'Created/Updated disable_scheduled_update_blueprint with value false'
+      };
       return chai
         .request(app)
         .put(`${base_url}/config?key=disable_scheduled_update_blueprint&value=false`)
@@ -137,7 +140,7 @@ describe('service-fabrik-admin', function () {
         .catch(err => err.response)
         .then(res => {
           expect(res).to.have.status(201);
-          expect(res.text).to.be.equal('Created/Updated disable_scheduled_update_blueprint with value false');
+          expect(res.body).to.deep.equal(response_body);
         });
     });
   });


### PR DESCRIPTION
Earlier one of the admin api-endpoints, responsible for creating or updating config, used to return a message in the response. However, this was not in json format. 
This was breaking some of other script utilities.
All other responses sent from broker are in json format, so, to maintain the convention and fix the failures of scripts, returning the response in json format, in this change request.