### PR TITLE
LastOperation is removed from CRDs per SF2.1 changes.

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -181,7 +181,6 @@ class ServiceBrokerApiController extends FabrikBaseController {
             options: serviceFlowOptions,
             status: {
               state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-              lastOperation: {},
               response: {}
             }
           });

--- a/broker/config/crds/serviceflow.servicefabrik.io_v1alpha1_serialserviceflows.yaml
+++ b/broker/config/crds/serviceflow.servicefabrik.io_v1alpha1_serialserviceflows.yaml
@@ -29,11 +29,11 @@ spec:
           properties:
             error:
               type: string
-            lastOperation:
-              type: string
             response:
               type: string
             state:
+              type: string
+            description:
               type: string
           type: object
       type: object

--- a/broker/config/crds/serviceflow.servicefabrik.io_v1alpha1_tasks.yaml
+++ b/broker/config/crds/serviceflow.servicefabrik.io_v1alpha1_tasks.yaml
@@ -29,11 +29,11 @@ spec:
           properties:
             error:
               type: string
-            lastOperation:
-              type: string
             response:
               type: string
             state:
+              type: string
+            description:
               type: string
           type: object
       type: object

--- a/operators/serviceflow-operator/SerialServiceFlowOperator.js
+++ b/operators/serviceflow-operator/SerialServiceFlowOperator.js
@@ -67,7 +67,6 @@ class SerialServiceFlowOperator extends BaseOperator {
           options: _.merge(serviceFlowOptions, tasks[0]),
           status: {
             state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-            lastOperation: {},
             response: {}
           }
         })
@@ -107,11 +106,11 @@ class SerialServiceFlowOperator extends BaseOperator {
       const relayedStatus = {
         state: previousTaskResponse.state,
         response: previousTaskResponse,
-        message: `Last Task complete.`
+        description: `Last Task complete.`
       };
       if (previousTaskResponse.state !== CONST.OPERATION.SUCCEEDED) {
         logger.info(`Task ${resourceDetails.resourceId} has failed. service flow will be marked as failed.`);
-        relayedStatus.message = `Task - ${taskDetails.task_description} failed and service flow is also marked as failed.`;
+        relayedStatus.description = `Task - ${taskDetails.task_description} failed and service flow is also marked as failed.`;
         return task
           .updateStatus(resourceDetails, relayedStatus)
           .then(() => this.serviceFlowComplete(taskDetails, `${taskDetails.task_description} failed. ${previousTaskResponse.description}`, FAILED));
@@ -142,13 +141,12 @@ class SerialServiceFlowOperator extends BaseOperator {
             options: _.merge(taskDetails, tasks[taskDetails.task_order]),
             status: {
               state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-              lastOperation: {},
               response: {}
             }
           })
           .then(() => {
             logger.info('Created next task in the service flow. Updating the state of current task as Relayed.');
-            relayedStatus.message = `Task complete and next relayed task is ${relayedTaskId}`;
+            relayedStatus.description = `Task complete and next relayed task is ${relayedTaskId}`;
             return task.updateStatus(resourceDetails, relayedStatus);
           })
           .then(() => this.updateServiceFlowStatus(
@@ -167,10 +165,7 @@ class SerialServiceFlowOperator extends BaseOperator {
       resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW,
       resourceType: CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW,
       resourceId: taskDetails.serviceflow_id,
-      status: {
-        lastOperation: status,
-        state: status.state
-      }
+      status: status
     });
   }
 

--- a/operators/serviceflow-operator/task/ServiceInstanceUpdateTask.js
+++ b/operators/serviceflow-operator/task/ServiceInstanceUpdateTask.js
@@ -4,7 +4,6 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 const logger = require('../../../common/logger');
 const CONST = require('../../../common/constants');
-const catalog = require('../../../common/models/catalog');
 const Task = require('./Task');
 const apiServerClient = require('../../../data-access-layer/eventmesh').apiServerClient;
 
@@ -16,8 +15,6 @@ class ServiceInstanceUpdateTask extends Task {
       return true;
       //Throw exception if not entitled.
     }).then(() => {
-      const planId = taskDetails.operation_params.plan_id;
-      const plan = catalog.getPlan(planId);
       const params = _.cloneDeep(taskDetails.operation_params);
       const taskInfo = _.chain(taskDetails)
         .omit('operation_params')

--- a/operators/serviceflow-operator/task/ServiceInstanceUpdateTask.js
+++ b/operators/serviceflow-operator/task/ServiceInstanceUpdateTask.js
@@ -37,8 +37,8 @@ class ServiceInstanceUpdateTask extends Task {
         .tap(() => {
           logger.info(`Update task ${taskDetails.task_description} with task data -  ${JSON.stringify(taskDetails.task_data)} initiated successfully @ ${new Date()}`);
           taskDetails.resource = {
-            resourceGroup: plan.manager.resource_mappings.resource_group,
-            resourceType: plan.manager.resource_mappings.resource_type,
+            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
+            resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
             resourceId: taskDetails.instance_id
           };
           taskDetails.response = {

--- a/operators/serviceflow-operator/task/Task.js
+++ b/operators/serviceflow-operator/task/Task.js
@@ -24,11 +24,7 @@ class Task {
         resourceGroup: task.resourceGroup,
         resourceType: task.resourceType,
         resourceId: task.resourceId,
-        status: {
-          lastOperation: status,
-          response: status.response,
-          state: status.state
-        }
+        status: status
       })
       .tap(() => logger.info(`successfully updated state of task - ${task.resourceId} to ${JSON.stringify(status)}`));
   }

--- a/operators/serviceflow-operator/task/TaskOperator.js
+++ b/operators/serviceflow-operator/task/TaskOperator.js
@@ -53,11 +53,7 @@ class TaskOperator extends BaseOperator {
             resourceType: CONST.APISERVER.RESOURCE_TYPES.TASK,
             resourceId: resource.metadata.name,
             options: taskDetails,
-            status: {
-              response: taskDetails.response,
-              lastOperation: status,
-              state: status.state
-            }
+            status: status
           });
         })
         .tap(() => logger.info(`Status of task ${taskDetails.task_type} for ${resource.metadata.name} is now set to in-progress.`));
@@ -89,7 +85,7 @@ class TaskOperator extends BaseOperator {
         const state = _.get(operationStatus, 'state');
         if (utils.isServiceFabrikOperationFinished(state)) {
           logger.info(`TASK COMPLETE - on resource - ${taskDetails.task_type} - ${object.metadata.name} - ${JSON.stringify(resourceDetails)}  - ${JSON.stringify(taskDetails.resource)}`);
-          let description = _.get(operationStatus, 'lastOperation.description');
+          let description = _.get(operationStatus, 'description');
           description = description || _.get(operationStatus, 'response.description');
           const status = {
             description: description,

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -520,7 +520,6 @@ describe('service-broker-api-2.0', function () {
           },
           status: {
             state: 'in_queue',
-            lastOperation: '{}',
             response: '{}'
           }
         };

--- a/test/test_broker/operators.serviceflow.SerialServiceFlow.spec.js
+++ b/test/test_broker/operators.serviceflow.SerialServiceFlow.spec.js
@@ -162,10 +162,7 @@ describe('operators', function () {
               resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW,
               resourceType: CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW,
               resourceId: serviceflow_id,
-              status: {
-                lastOperation: status,
-                state: status.state
-              }
+              status: status
             });
           });
       });
@@ -196,7 +193,6 @@ describe('operators', function () {
               }),
               status: {
                 state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-                lastOperation: {},
                 response: {}
               }
             });
@@ -206,10 +202,7 @@ describe('operators', function () {
               resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW,
               resourceType: CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW,
               resourceId: serviceflow_id,
-              status: {
-                lastOperation: status,
-                state: status.state
-              }
+              status: status
             });
           });
       });
@@ -224,19 +217,12 @@ describe('operators', function () {
               resourceType: CONST.APISERVER.RESOURCE_TYPES.TASK,
               resourceId: task_id,
               status: {
-                lastOperation: {
-                  state: CONST.OPERATION.SUCCEEDED,
-                  response: {
-                    state: CONST.OPERATION.SUCCEEDED,
-                    description: ''
-                  },
-                  message: 'Last Task complete.'
-                },
                 response: {
                   state: CONST.OPERATION.SUCCEEDED,
                   description: ''
                 },
-                state: CONST.OPERATION.SUCCEEDED
+                state: CONST.OPERATION.SUCCEEDED,
+                description: 'Last Task complete.'
               }
             });
             expect(updateResourceStub.secondCall.args[0]).to.eql({
@@ -244,11 +230,8 @@ describe('operators', function () {
               resourceType: CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW,
               resourceId: serviceflow_id,
               status: {
-                lastOperation: {
-                  state: CONST.OPERATION.SUCCEEDED,
-                  description: `Blueprint Service Flow succeeded @ ${new Date()}`
-                },
-                state: CONST.OPERATION.SUCCEEDED
+                state: CONST.OPERATION.SUCCEEDED,
+                description: `Blueprint Service Flow succeeded @ ${new Date()}`
               }
             });
           });
@@ -268,19 +251,12 @@ describe('operators', function () {
               resourceType: CONST.APISERVER.RESOURCE_TYPES.TASK,
               resourceId: `${serviceflow_id}.0`,
               status: {
-                lastOperation: {
-                  state: CONST.OPERATION.SUCCEEDED,
-                  response: {
-                    state: CONST.OPERATION.SUCCEEDED,
-                    description: ''
-                  },
-                  message: `Task complete and next relayed task is ${serviceflow_id}.1`
-                },
                 response: {
                   state: CONST.OPERATION.SUCCEEDED,
                   description: ''
                 },
-                state: CONST.OPERATION.SUCCEEDED
+                state: CONST.OPERATION.SUCCEEDED,
+                description: `Task complete and next relayed task is ${serviceflow_id}.1`
               }
             });
             expect(updateResourceStub.secondCall.args[0]).to.eql({
@@ -288,11 +264,8 @@ describe('operators', function () {
               resourceType: CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW,
               resourceId: serviceflow_id,
               status: {
-                lastOperation: {
-                  state: CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS,
-                  description: `Void blueprint task is complete. Initiated Void blueprint task2 @ ${new Date()}`
-                },
-                state: CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS
+                state: CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS,
+                description: `Void blueprint task is complete. Initiated Void blueprint task2 @ ${new Date()}`
               }
             });
           });
@@ -314,19 +287,12 @@ describe('operators', function () {
               resourceType: CONST.APISERVER.RESOURCE_TYPES.TASK,
               resourceId: `${serviceflow_id}.0`,
               status: {
-                lastOperation: {
-                  state: CONST.OPERATION.SUCCEEDED,
-                  response: {
-                    state: CONST.OPERATION.SUCCEEDED,
-                    description: ''
-                  },
-                  message: `Task complete and next relayed task is ${serviceflow_id}.1`
-                },
                 response: {
                   state: CONST.OPERATION.SUCCEEDED,
                   description: ''
                 },
-                state: CONST.OPERATION.SUCCEEDED
+                state: CONST.OPERATION.SUCCEEDED,
+                description: `Task complete and next relayed task is ${serviceflow_id}.1`
               }
             });
           });
@@ -345,19 +311,12 @@ describe('operators', function () {
               resourceType: CONST.APISERVER.RESOURCE_TYPES.TASK,
               resourceId: task_id,
               status: {
-                lastOperation: {
-                  state: CONST.OPERATION.FAILED,
-                  response: {
-                    state: CONST.OPERATION.FAILED,
-                    description: 'Task Failed'
-                  },
-                  message: 'Task - Void blueprint task failed and service flow is also marked as failed.'
-                },
                 response: {
                   state: CONST.OPERATION.FAILED,
                   description: 'Task Failed'
                 },
-                state: CONST.OPERATION.FAILED
+                state: CONST.OPERATION.FAILED,
+                description: 'Task - Void blueprint task failed and service flow is also marked as failed.'
               }
             });
             expect(updateResourceStub.secondCall.args[0]).to.eql({
@@ -365,11 +324,8 @@ describe('operators', function () {
               resourceType: CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW,
               resourceId: serviceflow_id,
               status: {
-                lastOperation: {
-                  state: CONST.OPERATION.FAILED,
-                  description: `Void blueprint task failed. ${failedTask.object.status.response.description}`
-                },
-                state: CONST.OPERATION.FAILED
+                state: CONST.OPERATION.FAILED,
+                description: `Void blueprint task failed. ${failedTask.object.status.response.description}`
               }
             });
           });

--- a/test/test_broker/operators.serviceflow.tasks.ServiceInstanceUpdateTask.spec.js
+++ b/test/test_broker/operators.serviceflow.tasks.ServiceInstanceUpdateTask.spec.js
@@ -34,8 +34,8 @@ describe('operators', function () {
           return ServiceInstanceUpdateTask.run(taskId, taskDetails)
             .then(taskResponse => {
               expect(taskResponse.resource).to.eql({
-                resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-                resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+                resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
+                resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
                 resourceId: instanceId
               });
               expect(taskResponse.response.description.indexOf('TEST_TASK initiated successfully') === 0).to.equal(true);

--- a/test/test_broker/operators.serviceflow.tasks.Task.spec.js
+++ b/test/test_broker/operators.serviceflow.tasks.Task.spec.js
@@ -61,11 +61,12 @@ describe('operators', function () {
           };
           const status = {
             state: CONST.OPERATION.SUCCEEDED,
+            response: undefined,
             description: 'Task complete.'
           };
           return Task.updateStatus(taskDetails.resource, status).then(() => {
             expect(apiServerClientUpdateStub.firstCall.args[0].status).to.eql({
-              lastOperation: status,
+              description: 'Task complete.',
               response: undefined,
               state: CONST.OPERATION.SUCCEEDED
             });


### PR DESCRIPTION
SF 2.1 changes had some changes which broke service flows. Following are those 2.1 changes which caused the functionality to break:
1. APIServerClient.getLastOperation() changed. It no longer returns the ‘lastOperation’ attrib from CRD as that is removed. Due to this state of the operation does not reflect back on service as part  last operation poll.
2. ServiceInstanceUpdateTask - lockForResourceDetails object was still referring to Director CRD whereas it should be referring to sfserviceinstances CRD. 

With the fixes to address the above discrepancies, service flows are back to normal. 

