### PR TITLE
Fix: Unbind/delete failure leads to timeout of unbind/delete operation

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -235,7 +235,14 @@ class ServiceBrokerApiController extends FabrikBaseController {
       res.status(CONST.HTTP_STATUS_CODE.GONE).send({});
     }
     req.operation_type = CONST.OPERATION_TYPE.DELETE;
-    return eventmesh.apiServerClient.patchOSBResource({
+    // Delete resource before patching state to delete
+    // As interoperator reacts on state change and deletionTimeStamp
+    return eventmesh.apiServerClient.deleteResource({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
+        resourceId: req.params.instance_id
+      })
+      .then(() => eventmesh.apiServerClient.patchOSBResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
         resourceId: req.params.instance_id,
@@ -243,11 +250,6 @@ class ServiceBrokerApiController extends FabrikBaseController {
           state: CONST.APISERVER.RESOURCE_STATE.DELETE,
           description: ''
         }
-      })
-      .then(() => eventmesh.apiServerClient.deleteResource({
-        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
-        resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
-        resourceId: req.params.instance_id
       }))
       .then(() => {
         if (!plan.manager.async) {
@@ -394,8 +396,15 @@ class ServiceBrokerApiController extends FabrikBaseController {
       /* jshint unused:false */
       res.status(CONST.HTTP_STATUS_CODE.GONE).send({});
     }
-
-    return eventmesh.apiServerClient.updateOSBResource({
+    // Delete resource before patching state to delete
+    // As interoperator reacts on state change and deletionTimeStamp
+    return eventmesh.apiServerClient.deleteResource({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
+        resourceId: params.binding_id,
+        namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id)
+      })
+      .then(() => eventmesh.apiServerClient.updateOSBResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
         resourceId: params.binding_id,
@@ -403,12 +412,6 @@ class ServiceBrokerApiController extends FabrikBaseController {
         status: {
           state: CONST.APISERVER.RESOURCE_STATE.DELETE
         }
-      })
-      .then(() => eventmesh.apiServerClient.deleteResource({
-        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
-        resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
-        resourceId: params.binding_id,
-        namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id)
       }))
       .then(() => eventmesh.apiServerClient.getOSBResourceOperationStatus({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,

--- a/broker/config/samples/templates/gotemplates/director/status.yaml
+++ b/broker/config/samples/templates/gotemplates/director/status.yaml
@@ -62,7 +62,7 @@ bind:
 {{- with .directorbind.status.response }}
   {{- $response = (b64dec . | quote) }}
 {{- end }}
-{{- $stateString = "delete" }} 
+{{- $stateString = "in progress" }} 
 {{- with .directorbind }}
   {{- with .status }}
     {{- if eq .state "succeeded" }}

--- a/broker/config/samples/templates/gotemplates/docker/status.yaml
+++ b/broker/config/samples/templates/gotemplates/docker/status.yaml
@@ -56,7 +56,7 @@ bind:
 {{- with .dockerbind.status.response }}
   {{- $response = (b64dec . | quote) }}
 {{- end }}
-{{- $stateString = "delete" }} 
+{{- $stateString = "in progress" }} 
 {{- with .dockerbind }}
   {{- with .status }}
     {{- if eq .state "succeeded" }}
@@ -78,11 +78,11 @@ unbind:
 {{- end }}
   response: {{ $response }}
 {{- $response := "" }}
-{{- $stateString = "delete" }} 
+{{- $stateString = "in progress" }} 
 {{- with .docker }}
   {{- with .status }}
     {{- if eq .state "delete" }}
-      {{- $stateString = "delete" }}
+      {{- $stateString = "in progress" }}
     {{- else }}
       {{- if eq .state "failed" }}
         {{- $stateString = "failed" }}

--- a/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller_test.go
+++ b/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller_test.go
@@ -147,6 +147,9 @@ var binding = &osbv1alpha1.SFServiceBinding{
 		ServiceID:         "service-id",
 		AcceptsIncomplete: true,
 	},
+	Status: osbv1alpha1.SFServiceBindingStatus{
+		State: "in_queue",
+	},
 }
 
 var c client.Client
@@ -233,6 +236,11 @@ func TestReconcile(t *testing.T) {
 
 	// Delete the service binding
 	g.Expect(c.Delete(context.TODO(), binding)).NotTo(gomega.HaveOccurred())
+	g.Expect(drainAllRequests(requests, timeout)).NotTo(gomega.BeZero())
+	g.Expect(c.Get(context.TODO(), bindingKey, serviceBinding)).NotTo(gomega.HaveOccurred())
+	serviceBinding.SetState("delete")
+	g.Expect(c.Update(context.TODO(), serviceBinding)).NotTo(gomega.HaveOccurred())
+	g.Expect(c.Delete(context.TODO(), secret)).NotTo(gomega.HaveOccurred())
 
 	g.Expect(drainAllRequests(requests, timeout)).NotTo(gomega.BeZero())
 

--- a/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller_test.go
+++ b/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller_test.go
@@ -135,6 +135,9 @@ var instance = &osbv1alpha1.SFServiceInstance{
 		RawParameters:    nil,
 		PreviousValues:   nil,
 	},
+	Status: osbv1alpha1.SFServiceInstanceStatus{
+		State: "in_queue",
+	},
 }
 
 var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: "default"}
@@ -211,6 +214,10 @@ func TestReconcile(t *testing.T) {
 
 	// Delete the service instance
 	g.Expect(c.Delete(context.TODO(), instance)).NotTo(gomega.HaveOccurred())
+	g.Expect(drainAllRequests(requests, timeout)).NotTo(gomega.BeZero())
+	g.Expect(c.Get(context.TODO(), instanceKey, serviceInstance)).NotTo(gomega.HaveOccurred())
+	serviceInstance.SetState("delete")
+	g.Expect(c.Update(context.TODO(), serviceInstance)).NotTo(gomega.HaveOccurred())
 
 	g.Expect(drainAllRequests(requests, timeout)).NotTo(gomega.BeZero())
 

--- a/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
@@ -497,7 +497,7 @@ describe('service-broker-api', function () {
         });
 
         it('returns 410 Gone', function () {
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, 404);
+          mocks.apiServerEventMesh.nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, 404);
           return chai.request(app)
             .delete(`${base_url}/service_instances/${instance_id}`)
             .query({


### PR DESCRIPTION
* Delete resource before patching `state = delete` in SBAC
* Handle state management using `lastOperation` label