### PR TITLE
Disk Metadata fetch for Azure should expect disk name in BOSH CPI Format

### DIFF
--- a/data-access-layer/iaas/AzureClient.js
+++ b/data-access-layer/iaas/AzureClient.js
@@ -55,9 +55,8 @@ class AzureClient extends BaseCloudClient {
             caching: 'None',
             resource_group_name: this.settings.resource_group
           }),
-          sku: _.assign({}, opts.type || {
-            name: 'Premium_LRS',
-            tier: 'Premium'
+          sku: _.assign({}, {
+            name: opts.type || 'Premium_LRS'
           }),
           creationData: {
             createOption: 'Copy',

--- a/data-access-layer/iaas/AzureClient.js
+++ b/data-access-layer/iaas/AzureClient.js
@@ -36,10 +36,15 @@ class AzureClient extends BaseCloudClient {
       .then(snapshotResponse => _.pick(snapshotResponse, ['location', 'creationData', 'id']));
   }
 
-  createDiskFromSnapshot(snapshotId, zones, opts = {}) {
-    const diskName = `bosh-disk-data-${uuid.v4()}`;
+  convertToBoshDiskFormat(diskName) {
     const boshDiskSegments = ['caching:None', `disk_name:${diskName}`, `resource_group_name:${this.settings.resource_group}`];
     const boshDiskName = _.join(boshDiskSegments, encodeURIComponent(';'));
+    return boshDiskName;
+  }
+
+  createDiskFromSnapshot(snapshotId, zones, opts = {}) {
+    const diskName = `bosh-disk-data-${uuid.v4()}`;
+    const boshDiskName = this.convertToBoshDiskFormat(diskName);
     return Promise.try(() => this.getSnapshot(snapshotId))
       .then(snapshotData => {
         const options = {
@@ -75,10 +80,23 @@ class AzureClient extends BaseCloudClient {
   }
 
   getDiskMetadata(diskId) {
+    const decodedDiskId = decodeURIComponent(diskId);
+    const boshDiskSegments = _.split(decodedDiskId, ';');
+    let diskName;
+    if (boshDiskSegments.length > 1) {
+      diskName = _.chain(boshDiskSegments)
+        .filter(seg => _.startsWith(seg, 'disk_name:'))
+        .head()
+        .split(':')
+        .last()
+        .value();
+    } else {
+      diskName = decodedDiskId;
+    }
     return this.computeClient.disks
-      .getAsync(this.settings.resource_group, diskId)
+      .getAsync(this.settings.resource_group, diskName)
       .then(diskResponse => ({
-        volumeId: diskResponse.name,
+        volumeId: this.convertToBoshDiskFormat(diskResponse.name),
         size: diskResponse.diskSizeGB,
         zone: diskResponse.zones[0],
         type: diskResponse.sku ? diskResponse.sku.name : '',

--- a/data-access-layer/iaas/CloudProviderClient.js
+++ b/data-access-layer/iaas/CloudProviderClient.js
@@ -74,7 +74,6 @@ class CloudProviderClient extends BaseCloudClient {
           })
           .promise();
       })
-      .then(diskResponse => diskResponse.Volumes[0])
       .then(volume => {
         const describeReq = {
           VolumeIds: [volume.VolumeId]

--- a/test/test_broker/iaas.AzureClient.spec.js
+++ b/test/test_broker/iaas.AzureClient.spec.js
@@ -124,7 +124,8 @@ describe('iaas', function () {
           }
         });
         return client.getDiskMetadata(diskName).then(res => {
-          expect(res.volumeId).to.equal(diskName);
+          const expectedVolId = client.convertToBoshDiskFormat(diskName);
+          expect(res.volumeId).to.equal(expectedVolId);
           expect(res.zone).to.equal(zone);
           expect(res.size).to.equal('4');
           expect(res.type).to.equal('Premium_LRS');

--- a/test/test_broker/iaas.CloudProviderClient.js
+++ b/test/test_broker/iaas.CloudProviderClient.js
@@ -31,7 +31,9 @@ describe('iaas', function () {
           Value: 'v2'
         }]
       };
-      const waitForResponse = { Volumes: [response] };
+      const waitForResponse = {
+        Volumes: [response]
+      };
       it('should create disk from snapshot for aws', function () {
         const client = new CloudProviderClient({
           name: 'aws',
@@ -59,8 +61,8 @@ describe('iaas', function () {
         });
         const waitForStub = sinon.stub(client.blockstorage, 'waitFor');
         waitForStub.withArgs('volumeAvailable', {
-          VolumeIds: [diskId]
-        })
+            VolumeIds: [diskId]
+          })
           .returns({
             promise: () => Promise.resolve(waitForResponse)
           });
@@ -148,8 +150,8 @@ describe('iaas', function () {
         });
         const waitForStub = sinon.stub(client.blockstorage, 'waitFor');
         waitForStub.withArgs('volumeAvailable', {
-          VolumeIds: [diskId]
-        })
+            VolumeIds: [diskId]
+          })
           .returns({
             promise: () => Promise.reject(new Error('diskwaiterror'))
           });

--- a/test/test_broker/iaas.CloudProviderClient.js
+++ b/test/test_broker/iaas.CloudProviderClient.js
@@ -19,20 +19,19 @@ describe('iaas', function () {
       const volType = 'gp2';
       const zone = 'zone';
       const response = {
-        Volumes: [{
-          VolumeId: diskId,
-          Size: '4',
-          AvailabilityZone: 'zone',
-          VolumeType: 'type',
-          Tags: [{
-            Key: 'k1',
-            Value: 'v1'
-          }, {
-            Key: 'k2',
-            Value: 'v2'
-          }]
+        VolumeId: diskId,
+        Size: '4',
+        AvailabilityZone: 'zone',
+        VolumeType: 'type',
+        Tags: [{
+          Key: 'k1',
+          Value: 'v1'
+        }, {
+          Key: 'k2',
+          Value: 'v2'
         }]
       };
+      const waitForResponse = { Volumes: [response] };
       it('should create disk from snapshot for aws', function () {
         const client = new CloudProviderClient({
           name: 'aws',
@@ -60,10 +59,10 @@ describe('iaas', function () {
         });
         const waitForStub = sinon.stub(client.blockstorage, 'waitFor');
         waitForStub.withArgs('volumeAvailable', {
-            VolumeIds: [diskId]
-          })
+          VolumeIds: [diskId]
+        })
           .returns({
-            promise: () => Promise.resolve(response)
+            promise: () => Promise.resolve(waitForResponse)
           });
         return client
           .createDiskFromSnapshot(snapshotId, zone, {
@@ -149,8 +148,8 @@ describe('iaas', function () {
         });
         const waitForStub = sinon.stub(client.blockstorage, 'waitFor');
         waitForStub.withArgs('volumeAvailable', {
-            VolumeIds: [diskId]
-          })
+          VolumeIds: [diskId]
+        })
           .returns({
             promise: () => Promise.reject(new Error('diskwaiterror'))
           });


### PR DESCRIPTION
- BOSH Instances API returns BOSH Disk metadata for Azure in specialized CPI format.
The CPI format is now expected for disk metadata fetch via the Azure Client itself