### PR TITLE
Add configurable indentity_provider

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -380,6 +380,7 @@ defaults: &defaults
     url: https://api.bosh-lite.com
     username: admin
     password: admin
+    identity_provider: uaa
   
   ###################
   # DOCKER SETTINGS #

--- a/data-access-layer/cf/UaaClient.js
+++ b/data-access-layer/cf/UaaClient.js
@@ -109,7 +109,7 @@ class UaaClient extends HttpClient {
   }
 
   accessWithPassword(username, password) {
-    return this.request({
+    const reqBody = {
       method: 'POST',
       url: '/oauth/token',
       auth: {
@@ -120,10 +120,13 @@ class UaaClient extends HttpClient {
         grant_type: 'password',
         client_id: this.clientId,
         username: username,
-        password: password,
-        login_hint: '{"origin":"uaa"}'
+        password: password
       }
-    }, 200).then((res) => {
+    };
+    if (config.cf.identity_provider) {
+      reqBody.form.login_hint = `{"origin":"${config.cf.identity_provider}"}`;
+    }
+    return this.request(reqBody, 200).then((res) => {
       return JSON.parse(res.body);
     });
   }


### PR DESCRIPTION
* If `cf.indentity_provider` is `undefined` then `login_hint` property is not sent in body of `/oauth/token` request