### PR TITLE
Make hostname in the docker credentials mandatory

### DIFF
--- a/operators/docker-operator/DockerService.js
+++ b/operators/docker-operator/DockerService.js
@@ -502,7 +502,9 @@ class DockerService extends BaseService {
 
   createCredentials() {
     const networkInfo = this.getNetworkInfo(this.containerInfo);
-    return this.credentials.create(this.getEnvironment(), networkInfo.ip, networkInfo.ports);
+    const creds = this.credentials.create(this.getEnvironment(), networkInfo.ip, networkInfo.ports);
+    assert.ok(creds.hostname, `Attribute 'hostname' is missing in credentials, could be if your container or host is down`);
+    return creds;
   }
 
   ensureContainerIsRunning(removeVolumes) {


### PR DESCRIPTION
During docker bind, sometimes if the docker host is down, bind does not fail but the credential object does not contain host information which makes it unusable. In this fix, we would fail the binding if hostname is missing