### PR TITLE
[interoperator] Update kubebuilder, Update states

### DIFF
--- a/interoperator/Dockerfile
+++ b/interoperator/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/clou
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest
-WORKDIR /root/
+WORKDIR /
 COPY --from=builder /go/src/github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/manager .
 COPY config/samples/templates/ config/samples/templates/
-ENTRYPOINT ["./manager"]
+ENTRYPOINT ["/manager"]

--- a/interoperator/Gopkg.lock
+++ b/interoperator/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:e4549155be72f065cf860ada7148bbeb0857360e81da2d5e28b799bd8720f1bc"
+  digest = "1:9f3bc9b251182aa0a26ac45e39a226c0f91e8f59dd91d8cab7d56b301684ee6a"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = "T"
-  revision = "0ebda48a7f143b1cce9eb37a8c1106ac762a3430"
-  version = "v0.34.0"
+  revision = "c9474f2f8deb81759839474b6bd1726bbfe1c1c4"
+  version = "v0.36.0"
 
 [[projects]]
   digest = "1:147748cfa709da38076c3df47f6bca6814c8ced6cba510065ec03f2120cc4819"
@@ -26,20 +26,28 @@
   version = "v1.4.2"
 
 [[projects]]
-  digest = "1:d81cc1702059cfcbefb8882b9e876c0e3b6a01f69ba8782aa9db7bffbbb77cf5"
+  digest = "1:855fd08764898bb4199216f9745673f7a78539ed727c7853d7e147a94cee6680"
   name = "github.com/Masterminds/sprig"
   packages = ["."]
   pruneopts = "T"
-  revision = "15f9564e7e9cf0da02a48e0d25f12a7b83559aa6"
-  version = "v2.16.0"
+  revision = "544a9b1d90f323f6509491b389714fbbd126bee3"
+  version = "v2.17.1"
 
 [[projects]]
-  digest = "1:8f5416c7f59da8600725ae1ff00a99af1da8b04c211ae6f3c8f8bcab0164f650"
+  digest = "1:3b10c6fd33854dc41de2cf78b7bae105da94c2789b6fa5b9ac9e593ea43484ac"
   name = "github.com/aokoli/goutils"
   packages = ["."]
   pruneopts = "T"
-  revision = "3391d3790d23d03408670993e957e8f408993c34"
-  version = "v1.0.1"
+  revision = "41ac8693c5c10a92ea1ff5ac3a7f95646f6123b0"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:464aef731a5f82ded547c62e249a2e9ec59fbbc9ddab53cda7b9857852630a61"
+  name = "github.com/appscode/jsonpatch"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "7c0e3b262f30165a8ec3d0b4c6059fd92703bfb2"
+  version = "1.0.0"
 
 [[projects]]
   branch = "master"
@@ -50,6 +58,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:ec66ad050342a3573ed2f5a4337d51b4c6d5d2a717cc6c9ecf86b081235a5759"
+  name = "github.com/cyphar/filepath-securejoin"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "a261ee33d7a517f054effbf451841abaafe3e0fd"
+  version = "v0.2.2"
+
+[[projects]]
   digest = "1:9f42202ac457c462ad8bb9642806d275af9ab4850cf0b1960b9c6f083d4a309a"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -58,15 +74,15 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:0ffd93121f3971aea43f6a26b3eaaa64c8af20fb0ff0731087d8dab7164af5a8"
+  digest = "1:77b39b37b35255582ec2c661b9c49c46356bf9fd5156442b400ef0608c358023"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
     "log",
   ]
   pruneopts = "T"
-  revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
-  version = "v2.8.0"
+  revision = "e37671aced663c8d3a395bd301857e26dcf4340c"
+  version = "v2.8.1"
 
 [[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
@@ -93,12 +109,12 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:3e34b0a53d651b06655475eb488745c912596e08557a33b83d336aab41cb6fe9"
+  digest = "1:74c676217f6583261297ef51c00d945ab470ff5ec5db5a9bf3dcd4cce85ea95f"
   name = "github.com/gobuffalo/envy"
   packages = ["."]
   pruneopts = "T"
-  revision = "801d7253ade1f895f74596b9a96147ed2d3b087e"
-  version = "v1.6.11"
+  revision = "fa0dfdc10b5366ce365b7d9d1755a03e4e797bc5"
+  version = "v1.6.15"
 
 [[projects]]
   digest = "1:0a5d2a670ac050354afcf572e65aceabefdebdbb90973ea729d8640fa211a9e2"
@@ -130,19 +146,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
-  branch = "master"
-  digest = "1:8f3489cb7352125027252a6517757cbd1706523119f1e14e20741ae8d2f70428"
+  digest = "1:fdd1399bcba383bf3cd94862c7280c76b241e33c518bf018fcb2ebbc326961a9"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
   pruneopts = "T"
-  revision = "c65c006176ff7ff98bb916961c7abbc6b0afc0aa"
+  revision = "5b532d6fd5efaf7fa130d4e859a2fde0fc3a9e1b"
 
 [[projects]]
   digest = "1:7912bb30698616cf0c41e5ef6a29a447c9a3e76bfcacbc21420ed3cdf616fd94"
@@ -208,14 +216,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8c0ceab65d43f49dce22aac0e8f670c170fc74dcf2dfba66d3a89516f7ae2c15"
+  digest = "1:6ffd1f94db669e406436cbb6c849c69cb0167e659a0f795ac90845ff0581f72c"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
     "diskcache",
   ]
   pruneopts = "T"
-  revision = "c63ab54fda8f77302f8d414e19933f2b6026a089"
+  revision = "7a902570cb17174de4ac788094f8ebedec136f57"
 
 [[projects]]
   digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
@@ -251,12 +259,12 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:3477d9dd8c135faab978bac762eaeafb31f28d6da97ef500d5c271966f74140a"
+  digest = "1:f53ef9250fa86a357d164aa5188ff02762a6b0ee5129671ad231ed6ba986b4c5"
   name = "github.com/imdario/mergo"
   packages = ["."]
   pruneopts = "T"
-  revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
-  version = "v0.3.6"
+  revision = "7c29201646fa3de8506f701213473dd407f19646"
+  version = "v0.3.7"
 
 [[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
@@ -289,14 +297,6 @@
   pruneopts = "T"
   revision = "24b83195037b3bc61fcda2d28b7b0518bce293b6"
   version = "v1.0.4"
-
-[[projects]]
-  branch = "master"
-  digest = "1:fc2b04b0069d6b10bdef96d278fe20c345794009685ed3c8c7f1a6dc023eefec"
-  name = "github.com/mattbaird/jsonpatch"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
 
 [[projects]]
   digest = "1:a8e3d14801bed585908d130ebfc3b925ba642208e6f30d879437ddfc7bb9b413"
@@ -397,12 +397,12 @@
   version = "v2.0.1"
 
 [[projects]]
-  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "T"
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:3b5729e3fc486abc6fc16ce026331c3d196e788c3b973081ecf5d28ae3e1050d"
@@ -418,15 +418,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:185cf55b1f44a1bf243558901c3f06efa5c64ba62cfdcbb1bf7bbe8c3fb68561"
+  digest = "1:cd67319ee7536399990c4b00fae07c3413035a53193c644549a676091507cadc"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "T"
-  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
 
 [[projects]]
-  branch = "master"
-  digest = "1:af934fb00202ba000f356e210fe42a61527fe9045d29bc5eaa57d0d1b5076963"
+  digest = "1:1688d03416102590c2a93f23d44e4297cb438bff146830aae35e66b33c9af114"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -434,11 +433,12 @@
     "model",
   ]
   pruneopts = "T"
-  revision = "4724e9255275ce38f7179b2478abeae4e28c904f"
+  revision = "cfeb6f9992ffa54aaa4f2170ade4067ee478b250"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:23dfc492513f6cd72a51d20c57a3bebb9b9ac4c81d27a474b1b49e33b79c4894"
+  digest = "1:c15f2711ef0d813a34d687ce5a6ce2ede79c1e9499705b67ebd05ff443e2f813"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -447,10 +447,10 @@
     "xfs",
   ]
   pruneopts = "T"
-  revision = "1dc9a6cbc91aacc3e8b2d63db4d2e957a5394ac4"
+  revision = "488faf799f863e27e50c516468f76ae8f1da20a5"
 
 [[projects]]
-  digest = "1:fac620096bacf6e41b3beb93ff03af9fe545d77421b3e7320f114b2da2e10824"
+  digest = "1:7ed87796a9e0b0310847cde3303fc3de3f0d04a110ca56f85b8674a1f3ba48f4"
   name = "github.com/rogpeppe/go-internal"
   packages = [
     "modfile",
@@ -458,19 +458,19 @@
     "semver",
   ]
   pruneopts = "T"
-  revision = "d87f08a7d80821c797ffc8eb8f4e01675f378736"
-  version = "v1.0.0"
+  revision = "68d1cb014f030acd0f10ac553801e43c0e5da629"
+  version = "v1.1.0"
 
 [[projects]]
-  digest = "1:2b9e473441ec584565880b55467ba1797417f42a60d92af4a761f8485a57e4d0"
+  digest = "1:2c31831b97353515f0bb77a3e7f2df69e50c4173116aad4250e22b1c664a1484"
   name = "github.com/spf13/afero"
   packages = [
     ".",
     "mem",
   ]
   pruneopts = "T"
-  revision = "a5d6946387efe7d64d09dcba68cdd523dc1273a3"
-  version = "v1.2.0"
+  revision = "f4711e4db9e9a1d3887343acb72b2bbfc2f686f5"
+  version = "v1.2.1"
 
 [[projects]]
   digest = "1:8be8b3743fc9795ec21bbd3e0fc28ff6234018e1a269b0a7064184be95ac13e0"
@@ -521,7 +521,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d470cb69884835b1800e93ceceb85afcf981ea647e61d99398a76af7a95bad6a"
+  digest = "1:4db9a8823bf59c4a005542abcbf75f2b3c83810aad1975f6da1e7ca07eb0a8a4"
   name = "golang.org/x/crypto"
   packages = [
     "pbkdf2",
@@ -529,11 +529,11 @@
     "ssh/terminal",
   ]
   pruneopts = "T"
-  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
+  revision = "b8fe1690c61389d7d2a8074a507d1d40c5d30448"
 
 [[projects]]
   branch = "master"
-  digest = "1:31162299b46522ce13b7836d17341c88817e87874c15d9c755e22140feb2718b"
+  digest = "1:a88bdbfd3d7f9750a3b3c6947f2d0f8f1fbbb0b65c38128cbc6548189eaf756b"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -547,11 +547,11 @@
     "idna",
   ]
   pruneopts = "T"
-  revision = "e147a9138326bc0e9d4e179541ffd8af41cff8a9"
+  revision = "65e2d4e15006aab9813ff8769e768bbf4bb667a0"
 
 [[projects]]
   branch = "master"
-  digest = "1:320e5ba9ea8000060bec710764b8b26c251ee28f6012422b669cb8cb100c9815"
+  digest = "1:e9502917fb9085710635bdfeeba562925ffc96b68f3c00a6bb5a453dad3923a1"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -561,18 +561,18 @@
     "jwt",
   ]
   pruneopts = "T"
-  revision = "d668ce993890a79bda886613ee587a69dd5da7a6"
+  revision = "99b60b757ec124ebb7d6b7e97f153b19c10ce163"
 
 [[projects]]
   branch = "master"
-  digest = "1:3631df9157a563b9b7efe8bedae459a2d6a8db709826e2c0e26cec4f40d7d7a7"
+  digest = "1:5b2bf4948602d42d5fe80519d28729a50c8d234712e95535cb38c44bf1d1ad14"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "T"
-  revision = "dcdaa6325bcb8d3c07805583fe12153f08a41e2b"
+  revision = "41f3e6584952bb034a481797859f6ab34b6803bd"
 
 [[projects]]
   digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
@@ -619,25 +619,27 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:17cdd942d5006e25ad569c66906afdb409bb009cea6c8c753ac765d0cc2c55b0"
+  digest = "1:6296058e14ab8835e276a405b569f0b6627cfd06ba6acdca263fbeaa81c40311"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "go/gcexportdata",
     "go/internal/cgo",
     "go/internal/gcimporter",
+    "go/internal/packagesdriver",
     "go/packages",
     "go/types/typeutil",
     "imports",
     "internal/fastwalk",
     "internal/gopathwalk",
+    "internal/module",
     "internal/semver",
   ]
   pruneopts = "T"
-  revision = "13ba8ad772dfbf0f451b5dd0679e9c5605afc05d"
+  revision = "44bcb96178d39510d2bb8a61ef1c08b85bb24a45"
 
 [[projects]]
-  digest = "1:fb4ee7f835110d238c58366cfa442da7dfa62cec87d42da2d8049000f4330758"
+  digest = "1:1469235a5a8e192cfe6a99c4804b883a02f0ff96a693cd1660515a3a3b94d5ac"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -652,8 +654,8 @@
     "urlfetch",
   ]
   pruneopts = "T"
-  revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
-  version = "v1.3.0"
+  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:7fc160b460a6fc506b37fcca68332464c3f2cd57b6e3f111f26c5bbfd2d5518e"
@@ -689,7 +691,7 @@
   version = "v2.2.2"
 
 [[projects]]
-  digest = "1:8a1af4b4d5b51e3f8d6ec2a44467e8505e25e29814c2557d1d9717834065c674"
+  digest = "1:a8dd0f5c1137ed558bca1fed6617b019aa645783731d15138abc6f184952fef5"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -698,6 +700,7 @@
     "apps/v1",
     "apps/v1beta1",
     "apps/v1beta2",
+    "auditregistration/v1alpha1",
     "authentication/v1",
     "authentication/v1beta1",
     "authorization/v1",
@@ -726,11 +729,11 @@
     "storage/v1beta1",
   ]
   pruneopts = "T"
-  revision = "b503174bad5991eb66f18247f52e41c3258f6348"
-  version = "kubernetes-1.12.3"
+  revision = "05914d821849570fba9eacfb29466f2d8d3cd229"
+  version = "kubernetes-1.13.1"
 
 [[projects]]
-  digest = "1:3d0ba42a7eaed76c293905ced94201752762c84481f76505ac2079e6f332ae2b"
+  digest = "1:d6b5f1f23ca1b4a68aacbe3167fdd56babaf4b0a72b5d0c166595cee4b71532d"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -740,11 +743,11 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "T"
-  revision = "0cd23ebeb6882bd1cdc2cb15fc7b2d72e8a86a5b"
-  version = "kubernetes-1.12.3"
+  revision = "0fe22c71c47604641d9aa352c785b7912c200562"
+  version = "kubernetes-1.13.1"
 
 [[projects]]
-  digest = "1:bcf693d144a1d98dabdb4ab3bf18fbde8b2f7ee86d2fd8a3f74fb6a035627550"
+  digest = "1:6326c0acd4934569b53d305d4a79a30f7074b3d4fdb3537af06203b68297a22b"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -792,11 +795,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "T"
-  revision = "eddba98df674a16931d2d4ba75edc3a389bf633a"
-  version = "kubernetes-1.12.3"
+  revision = "2b1284ed4c93a43499e781493253e2ac5959c4fd"
+  version = "kubernetes-1.13.1"
 
 [[projects]]
-  digest = "1:5aa94390c366adc57a82b19ad4f99482ab8fbeca0a2ff7b09db12d7baf590e46"
+  digest = "1:0b3ba6818a03b0f0f181ab6b88d9be03789d02ede8929d876f45210471811fdb"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -808,6 +811,7 @@
     "kubernetes/typed/apps/v1",
     "kubernetes/typed/apps/v1beta1",
     "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/auditregistration/v1alpha1",
     "kubernetes/typed/authentication/v1",
     "kubernetes/typed/authentication/v1beta1",
     "kubernetes/typed/authorization/v1",
@@ -868,12 +872,12 @@
     "util/workqueue",
   ]
   pruneopts = "T"
-  revision = "d082d5923d3cc0bfbb066ee5fbdea3d0ca79acf8"
-  version = "kubernetes-1.12.3"
+  revision = "8d9ed539ba3134352c586810e749e58df4e94e4f"
+  version = "kubernetes-1.13.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:b11533d0d337c776e3ee4d59f86ca302a66a777b40a289d97cb59a638179f31e"
+  digest = "1:a53bcf71dd576048b9cdd4cde946c1cdf25e2dc0106763310927941ec31ccd80"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -890,11 +894,11 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "3a2206dd6a78497deceb3ae058417fdeb2036c7e"
+  revision = "52c6f52d780fde3fb538dd327650688a932b6302"
 
 [[projects]]
   branch = "master"
-  digest = "1:c5636f57f83eb7ef2a1c7a2340b7e5750f1c105a1d0cbcfcab429d175c216773"
+  digest = "1:2b9071c93303f1196cfe959c7f7f69ed1e4a5180f240a259536c5886f79f86d4"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -906,10 +910,10 @@
     "types",
   ]
   pruneopts = "T"
-  revision = "fd15ee9cc2f77baa4f31e59e6acbf21146455073"
+  revision = "0689ccc1d7d65d9dd1bedcc3b0b1ed7df91ba266"
 
 [[projects]]
-  digest = "1:30c46ebdbcc5d7bd54c2e7b0e3c65006ebe977a8decd8cceff84076a7ce3b679"
+  digest = "1:772f14170b24f24dc68bfd90defca3077584b658d9ab796350bd66baa75bf509"
   name = "k8s.io/helm"
   packages = [
     "pkg/chartutil",
@@ -922,8 +926,8 @@
     "pkg/version",
   ]
   pruneopts = "T"
-  revision = "d325d2a9c179b33af1a024cdb5a4472b6288016a"
-  version = "v2.12.0"
+  revision = "eecf22f77df5f65c823aacd2dbd30ae6c65f186e"
+  version = "v2.12.3"
 
 [[projects]]
   digest = "1:7a3ef99d492d30157b8e933624a8f0292b4cee5934c23269f7640c8030eb83cd"
@@ -935,14 +939,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:90f16a49f856e6d94089444e487c535f4cd41f59a1e90c51deb9dcf965f3c50b"
+  digest = "1:63f3772acb7c036a16d0ded3c1df71f595020cd0683998fed71faa78a56c6415"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
   pruneopts = "T"
-  revision = "0317810137be915b9cf888946c6e115c1bfac693"
+  revision = "a829e3aed6e2c340adb7b339d221a684e02412f9"
 
 [[projects]]
-  digest = "1:63405fd0a9cf28d074f8ef07f133f818ee633ae874935a1ed52f73c36564dce9"
+  digest = "1:5aa50779f75cc439edd3455a6dee7cf179b52f8dde764a47cc929693485d1afb"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -979,41 +983,51 @@
     "pkg/webhook/internal/cert/generator",
     "pkg/webhook/internal/cert/writer",
     "pkg/webhook/internal/cert/writer/atomic",
+    "pkg/webhook/internal/metrics",
     "pkg/webhook/types",
   ]
   pruneopts = "T"
-  revision = "c63ebda0bf4be5f0a8abd4003e4ea546032545ba"
-  version = "v0.1.8"
+  revision = "12d98582e72927b6cd0123e2b4e819f9341ce62c"
+  version = "v0.1.10"
 
 [[projects]]
-  digest = "1:2518c407c98521579bcff2ca99dca0797cae36120bc47c32c7c929cf6c13a76a"
+  digest = "1:adfc3ea3c2a575c2f6315f17dfcddd6fb49247a1a1b055febc2a44b35e59ca10"
   name = "sigs.k8s.io/controller-tools"
   packages = [
     "cmd/controller-gen",
     "pkg/crd/generator",
     "pkg/crd/util",
-    "pkg/generate/rbac",
-    "pkg/generate/webhook",
-    "pkg/generate/webhook/internal",
     "pkg/internal/codegen",
     "pkg/internal/codegen/parse",
     "pkg/internal/general",
+    "pkg/rbac",
     "pkg/util",
+    "pkg/webhook",
+    "pkg/webhook/internal",
   ]
   pruneopts = "T"
-  revision = "b072ef59824b16023b0e12c94d0040d99059a961"
-  version = "v0.1.7"
+  revision = "fbf141159251d035089e7acdd5a343f8cec91b94"
+  version = "v0.1.9"
 
 [[projects]]
-  digest = "1:fd7fb0f1f6e3259ec03c9730c675f7c97bcbd9d2a1037364734b197eaa76eee7"
+  digest = "1:290b4da306982122bcdff12dbababbb95c6e4a94a2995db88baf235ef2f6e93e"
   name = "sigs.k8s.io/testing_frameworks"
   packages = [
     "integration",
+    "integration/addr",
     "integration/internal",
   ]
   pruneopts = "T"
-  revision = "5818a3a284a11812aaed11d5ca0bcadec2c50e83"
-  version = "v0.1.0"
+  revision = "d348cb12705b516376e0c323bacca72b00a78425"
+  version = "v0.1.1"
+
+[[projects]]
+  digest = "1:7719608fe0b52a4ece56c2dde37bedd95b938677d1ab0f84b8a7852e4c59f849"
+  name = "sigs.k8s.io/yaml"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
+  version = "v1.1.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/interoperator/Gopkg.toml
+++ b/interoperator/Gopkg.toml
@@ -25,7 +25,7 @@ required = [
   name = "k8s.io/helm"
   version = "2.11.0"
 
-
+  
 # STANZAS BELOW ARE GENERATED AND MAY BE WRITTEN - DO NOT MODIFY BELOW THIS LINE.
 
 [[constraint]]

--- a/interoperator/Makefile
+++ b/interoperator/Makefile
@@ -39,6 +39,9 @@ vet:
 
 # Generate code
 generate:
+ifndef GOPATH
+	$(error GOPATH not defined, please define GOPATH. Run "go help gopath" to learn more about GOPATH)
+endif
 	go generate ./pkg/... ./cmd/...
 
 # Build the docker image

--- a/interoperator/cmd/manager/main.go
+++ b/interoperator/cmd/manager/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"os"
 
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/apis"
@@ -34,6 +35,9 @@ const (
 )
 
 func main() {
+	var metricsAddr string
+	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("entrypoint")
 
@@ -49,6 +53,7 @@ func main() {
 		LeaderElection:          true,
 		LeaderElectionID:        leaderElectionID,
 		LeaderElectionNamespace: "default",
+		//MetricsBindAddress:      metricsAddr,
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components

--- a/interoperator/config/crds/osb_v1alpha1_sfplan.yaml
+++ b/interoperator/config/crds/osb_v1alpha1_sfplan.yaml
@@ -15,8 +15,14 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/config/crds/osb_v1alpha1_sfservice.yaml
+++ b/interoperator/config/crds/osb_v1alpha1_sfservice.yaml
@@ -15,8 +15,14 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/config/crds/osb_v1alpha1_sfservicebinding.yaml
+++ b/interoperator/config/crds/osb_v1alpha1_sfservicebinding.yaml
@@ -15,8 +15,14 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/config/crds/osb_v1alpha1_sfserviceinstance.yaml
+++ b/interoperator/config/crds/osb_v1alpha1_sfserviceinstance.yaml
@@ -15,8 +15,14 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/config/default/kustomization.yaml
+++ b/interoperator/config/default/kustomization.yaml
@@ -21,9 +21,25 @@ resources:
 - ../rbac/rbac_role.yaml
 - ../rbac/rbac_role_binding.yaml
 - ../manager/manager.yaml
+  # Comment the following 3 lines if you want to disable
+  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+  # which protects your /metrics endpoint.
+- ../rbac/auth_proxy_service.yaml
+- ../rbac/auth_proxy_role.yaml
+- ../rbac/auth_proxy_role_binding.yaml
 
 patches:
 - manager_image_patch.yaml
+  # Protect the /metrics endpoint by putting it behind auth.
+  # Only one of manager_auth_proxy_patch.yaml and
+  # manager_prometheus_metrics_patch.yaml should be enabled.
+- manager_auth_proxy_patch.yaml
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, uncomment the following line and
+  # comment manager_auth_proxy_patch.yaml.
+  # Only one of manager_auth_proxy_patch.yaml and
+  # manager_prometheus_metrics_patch.yaml should be enabled.
+#- manager_prometheus_metrics_patch.yaml
 
 vars:
 - name: WEBHOOK_SECRET_NAME

--- a/interoperator/config/default/manager_auth_proxy_patch.yaml
+++ b/interoperator/config/default/manager_auth_proxy_patch.yaml
@@ -1,0 +1,24 @@
+# This patch inject a sidecar container which is a HTTP proxy for the controller manager,
+# it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"

--- a/interoperator/config/default/manager_prometheus_metrics_patch.yaml
+++ b/interoperator/config/default/manager_prometheus_metrics_patch.yaml
@@ -1,0 +1,19 @@
+# This patch enables Prometheus scraping for the manager pod.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      # Expose the prometheus metrics on default port
+      - name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP

--- a/interoperator/config/manager/manager.yaml
+++ b/interoperator/config/manager/manager.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
   name: system
 ---
@@ -42,7 +43,7 @@ spec:
     spec:
       containers:
       - command:
-        - /root/manager
+        - /manager
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/interoperator/config/rbac/auth_proxy_role.yaml
+++ b/interoperator/config/rbac/auth_proxy_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]

--- a/interoperator/config/rbac/auth_proxy_role_binding.yaml
+++ b/interoperator/config/rbac/auth_proxy_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/interoperator/config/rbac/auth_proxy_service.yaml
+++ b/interoperator/config/rbac/auth_proxy_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"

--- a/interoperator/pkg/apis/osb/v1alpha1/sfservicebinding_types.go
+++ b/interoperator/pkg/apis/osb/v1alpha1/sfservicebinding_types.go
@@ -22,7 +22,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("osb-v1alpha1")
+var log = logf.Log.WithName("osb.v1alpha1")
 
 // SFServiceBindingSpec defines the desired state of SFServiceBinding
 type SFServiceBindingSpec struct {

--- a/interoperator/pkg/apis/osb/v1alpha1/sfservicebinding_types.go
+++ b/interoperator/pkg/apis/osb/v1alpha1/sfservicebinding_types.go
@@ -17,11 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"log"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.Log.WithName("osb-v1alpha1")
 
 // SFServiceBindingSpec defines the desired state of SFServiceBinding
 type SFServiceBindingSpec struct {
@@ -79,7 +80,7 @@ func init() {
 // GetState fetches the state of the SFServiceBinding
 func (r *SFServiceBinding) GetState() string {
 	if r == nil || r.Status.State == "" {
-		log.Printf("failed to read state of SFServiceBinding %s", r.GetName())
+		log.Info("failed to read state", "SFServiceBinding", r.GetName())
 		return ""
 	}
 	return r.Status.State

--- a/interoperator/pkg/apis/osb/v1alpha1/sfserviceinstance_types.go
+++ b/interoperator/pkg/apis/osb/v1alpha1/sfserviceinstance_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"fmt"
-	"log"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +34,26 @@ type Source struct {
 
 func (r Source) String() string {
 	return fmt.Sprintf("%s/%s (%s %s)", r.Namespace, r.Name, r.Kind, r.APIVersion)
+}
+
+// GetKind returns the Kind of the resource
+func (r Source) GetKind() string {
+	return r.Kind
+}
+
+// GetAPIVersion returns the APIVersion of the resource
+func (r Source) GetAPIVersion() string {
+	return r.APIVersion
+}
+
+// GetName returns the Name of the resource
+func (r Source) GetName() string {
+	return r.Name
+}
+
+// GetNamespace returns the Namespace of the resource
+func (r Source) GetNamespace() string {
+	return r.Namespace
 }
 
 // SFServiceInstanceSpec defines the desired state of SFServiceInstance
@@ -87,7 +106,7 @@ func init() {
 // GetState fetches the state of the SFServiceInstance
 func (r *SFServiceInstance) GetState() string {
 	if r == nil || r.Status.State == "" {
-		log.Printf("failed to read state of SFServiceInstance %s", r.GetName())
+		log.Info("failed to read state", "SFServiceInstance", r.GetName())
 		return ""
 	}
 	return r.Status.State

--- a/interoperator/pkg/apis/osb/v1alpha1/v1alpha1_suite_test.go
+++ b/interoperator/pkg/apis/osb/v1alpha1/v1alpha1_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"log"
+	stdlog "log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,15 +38,15 @@ func TestMain(m *testing.M) {
 
 	err := SchemeBuilder.AddToScheme(scheme.Scheme)
 	if err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	if cfg, err = t.Start(); err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	if c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme}); err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	code := m.Run()

--- a/interoperator/pkg/controller/controller_test.go
+++ b/interoperator/pkg/controller/controller_test.go
@@ -18,7 +18,7 @@ package controller
 
 import (
 	"fmt"
-	"log"
+	stdlog "log"
 	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -30,12 +30,12 @@ func TestAddToManager(t *testing.T) {
 
 	cfg, err := testEnv.Start()
 	if err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	mgr, err := manager.New(cfg, manager.Options{})
 	if err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 	defer testEnv.Stop()
 

--- a/interoperator/pkg/controller/sfplan/sfplan_controller.go
+++ b/interoperator/pkg/controller/sfplan/sfplan_controller.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("plan-controller")
+var log = logf.Log.WithName("plan.controller")
 
 // Add creates a new SFPlan Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/interoperator/pkg/controller/sfplan/sfplan_controller.go
+++ b/interoperator/pkg/controller/sfplan/sfplan_controller.go
@@ -19,7 +19,6 @@ package sfplan
 import (
 	"context"
 	"fmt"
-	"log"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/apis/osb/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -33,8 +32,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+var log = logf.Log.WithName("plan-controller")
 
 // Add creates a new SFPlan Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -155,7 +157,7 @@ func (r *ReconcileSfPlan) Reconcile(request reconcile.Request) (reconcile.Result
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		log.Printf("Plan %s labels updated\n", instance.GetName())
+		log.Info("Plan labels updated", "plan", instance.GetName())
 	}
 	return reconcile.Result{}, nil
 }

--- a/interoperator/pkg/controller/sfplan/sfplan_controller_suite_test.go
+++ b/interoperator/pkg/controller/sfplan/sfplan_controller_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package sfplan
 
 import (
-	"log"
+	stdlog "log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 
 	var err error
 	if cfg, err = t.Start(); err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	code := m.Run()

--- a/interoperator/pkg/controller/sfservice/sfservice_controller.go
+++ b/interoperator/pkg/controller/sfservice/sfservice_controller.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("plan-controller")
+var log = logf.Log.WithName("service.controller")
 
 // Add creates a new SFService Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/interoperator/pkg/controller/sfservice/sfservice_controller.go
+++ b/interoperator/pkg/controller/sfservice/sfservice_controller.go
@@ -18,7 +18,6 @@ package sfservice
 
 import (
 	"context"
-	"log"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/apis/osb/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -28,8 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+var log = logf.Log.WithName("plan-controller")
 
 // Add creates a new SFService Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -95,7 +97,7 @@ func (r *ReconcileSFService) Reconcile(request reconcile.Request) (reconcile.Res
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		log.Printf("Service %s labels updated\n", instance.GetName())
+		log.Info("Service labels updated", "service", instance.GetName())
 	}
 	return reconcile.Result{}, nil
 }

--- a/interoperator/pkg/controller/sfservice/sfservice_controller_suite_test.go
+++ b/interoperator/pkg/controller/sfservice/sfservice_controller_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package sfservice
 
 import (
-	"log"
+	stdlog "log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 
 	var err error
 	if cfg, err = t.Start(); err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	code := m.Run()

--- a/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller.go
+++ b/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller.go
@@ -19,7 +19,6 @@ package sfservicebinding
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 	"strconv"
 
@@ -39,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -49,6 +49,8 @@ const (
 	lastOperationKey = "interoperator.servicefabrik.io/lastoperation"
 	errorThreshold   = 10
 )
+
+var log = logf.Log.WithName("binding-controller")
 
 // Add creates a new SFServiceBinding Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -111,7 +113,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			OwnerType:    &osbv1alpha1.SFServiceBinding{},
 		})
 		if err != nil {
-			log.Printf("%v", err)
+			log.Error(err, "failed to start watch")
 		}
 	}
 
@@ -148,10 +150,11 @@ func (r *ReconcileSFServiceBinding) Reconcile(request reconcile.Request) (reconc
 		if errors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
+			log.Info("binding deleted", "binding", request.NamespacedName)
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return r.handleError(binding, reconcile.Result{}, err)
+		return r.handleError(binding, reconcile.Result{}, err, "", 0)
 	}
 
 	serviceID := binding.Spec.ServiceID
@@ -164,110 +167,118 @@ func (r *ReconcileSFServiceBinding) Reconcile(request reconcile.Request) (reconc
 	if !ok {
 		lastOperation = "in_queue"
 	}
-	var requeue bool
-	var appliedResources []*unstructured.Unstructured
-	var remainingResource []osbv1alpha1.Source
 
-	if binding.GetDeletionTimestamp().IsZero() {
-		if !containsString(binding.GetFinalizers(), finalizerName) {
-			// The object is not being deleted, so if it does not have our finalizer,
-			// then lets add the finalizer and update the object.
-			binding.SetFinalizers(append(binding.GetFinalizers(), finalizerName))
-			if err := r.Update(context.Background(), binding); err != nil {
-				return r.handleError(binding, reconcile.Result{Requeue: true}, nil)
-			}
-		}
+	if err := r.reconcileFinalizers(binding, 0); err != nil {
+		return r.handleError(binding, reconcile.Result{Requeue: true}, nil, "", 0)
 	}
 
 	targetClient, err := r.clusterFactory.GetCluster(instanceID, bindingID, serviceID, planID)
 	if err != nil {
-		return r.handleError(binding, reconcile.Result{}, err)
+		return r.handleError(binding, reconcile.Result{}, err, "", 0)
 	}
 
 	if state == "delete" && !binding.GetDeletionTimestamp().IsZero() {
 		// The object is being deleted
-		if containsString(binding.GetFinalizers(), finalizerName) {
-			// our finalizer is present, so lets handle our external dependency
-			// Explicitly delete BindSecret
-			secretName := "sf-" + bindingID
-			bindSecret := osbv1alpha1.Source{}
-			bindSecret.Kind = "Secret"
-			bindSecret.APIVersion = "v1"
-			bindSecret.Name = secretName
-			bindSecret.Namespace = binding.GetNamespace()
-			resourceRefs := append(binding.Status.Resources, bindSecret)
-			remainingResource, err = r.resourceManager.DeleteSubResources(targetClient, resourceRefs)
-			if err != nil {
-				log.Printf("Delete sub resources error %s\n", err.Error())
-				requeue = true
-			} else {
-				err = r.setInProgress(request.NamespacedName, state)
-				if err != nil {
-					requeue = true
-				} else {
-					lastOperation = state
-				}
-			}
+		// so lets handle our external dependency
+		// Explicitly delete BindSecret
+		secretName := "sf-" + bindingID
+		bindSecret := osbv1alpha1.Source{}
+		bindSecret.Kind = "Secret"
+		bindSecret.APIVersion = "v1"
+		bindSecret.Name = secretName
+		bindSecret.Namespace = binding.GetNamespace()
+		resourceRefs := append(binding.Status.Resources, bindSecret)
+		remainingResource, err := r.resourceManager.DeleteSubResources(targetClient, resourceRefs)
+		if err != nil {
+			log.Error(err, "Delete sub resources failed")
+			return r.handleError(binding, reconcile.Result{}, err, state, 0)
 		}
+		err = r.setInProgress(request.NamespacedName, state, remainingResource, 0)
+		if err != nil {
+			return r.handleError(binding, reconcile.Result{}, err, state, 0)
+		}
+		lastOperation = state
 	} else if state == "in_queue" || state == "update" {
 		expectedResources, err := r.resourceManager.ComputeExpectedResources(r, instanceID, bindingID, serviceID, planID, osbv1alpha1.BindAction, binding.GetNamespace())
 		if err != nil {
-			return r.handleError(binding, reconcile.Result{}, err)
+			return r.handleError(binding, reconcile.Result{}, err, state, 0)
 		}
 		err = r.resourceManager.SetOwnerReference(binding, expectedResources, r.scheme)
 		if err != nil {
-			return r.handleError(binding, reconcile.Result{}, err)
+			return r.handleError(binding, reconcile.Result{}, err, state, 0)
 		}
 
-		appliedResources, err = r.resourceManager.ReconcileResources(r, targetClient, expectedResources, binding.Status.Resources)
+		resourceRefs, err := r.resourceManager.ReconcileResources(r, targetClient, expectedResources, binding.Status.Resources)
 		if err != nil {
-			log.Printf("Reconcile error %s\n", err.Error())
-			requeue = true
-		} else {
-			err = r.setInProgress(request.NamespacedName, state)
-			if err != nil {
-				requeue = true
-			} else {
-				lastOperation = state
-			}
+			log.Error(err, "ReconcileResources failed")
+			return r.handleError(binding, reconcile.Result{}, err, state, 0)
 		}
+		err = r.setInProgress(request.NamespacedName, state, resourceRefs, 0)
+		if err != nil {
+			return r.handleError(binding, reconcile.Result{}, err, state, 0)
+		}
+		lastOperation = state
 	}
 
 	if lastOperation == "delete" {
-		remainingResource = []osbv1alpha1.Source{}
-		for _, subResource := range binding.Status.Resources {
-			resource := &unstructured.Unstructured{}
-			resource.SetKind(subResource.Kind)
-			resource.SetAPIVersion(subResource.APIVersion)
-			resource.SetName(subResource.Name)
-			resource.SetNamespace(subResource.Namespace)
-			namespacedName := types.NamespacedName{
-				Name:      resource.GetName(),
-				Namespace: resource.GetNamespace(),
-			}
-			err := targetClient.Get(context.TODO(), namespacedName, resource)
-			if !errors.IsNotFound(err) {
-				remainingResource = append(remainingResource, subResource)
-			}
-		}
-		if err := r.updateUnbindStatus(targetClient, binding, remainingResource); err != nil {
-			return r.handleError(binding, reconcile.Result{}, err)
+		if err := r.updateUnbindStatus(targetClient, binding, 0); err != nil {
+			return r.handleError(binding, reconcile.Result{}, err, lastOperation, 0)
 		}
 	} else if lastOperation == "in_queue" || lastOperation == "update" {
-		err = r.updateBindStatus(instanceID, bindingID, serviceID, planID, binding.GetNamespace(), appliedResources)
+		err = r.updateBindStatus(targetClient, binding, 0)
 		if err != nil {
-			return r.handleError(binding, reconcile.Result{}, err)
+			return r.handleError(binding, reconcile.Result{}, err, lastOperation, 0)
 		}
 	}
-	return r.handleError(binding, reconcile.Result{Requeue: requeue}, nil)
+	return r.handleError(binding, reconcile.Result{}, nil, lastOperation, 0)
 }
 
-func (r *ReconcileSFServiceBinding) setInProgress(namespacedName types.NamespacedName, state string) error {
+func (r *ReconcileSFServiceBinding) reconcileFinalizers(object *osbv1alpha1.SFServiceBinding, retryCount int) error {
+	objectID := object.GetName()
+	namespace := object.GetNamespace()
+	// Fetch object again before updating
+	namespacedName := types.NamespacedName{
+		Name:      objectID,
+		Namespace: namespace,
+	}
+	err := r.Get(context.TODO(), namespacedName, object)
+	if err != nil {
+		if retryCount < errorThreshold {
+			log.Info("Retrying", "function", "reconcileFinalizers", "retryCount", retryCount+1, "objectID", objectID)
+			return r.reconcileFinalizers(object, retryCount+1)
+		}
+		log.Error(err, "failed to fetch object", "objectID", objectID)
+		return err
+	}
+	if object.GetDeletionTimestamp().IsZero() {
+		if !containsString(object.GetFinalizers(), finalizerName) {
+			// The object is not being deleted, so if it does not have our finalizer,
+			// then lets add the finalizer and update the object.
+			object.SetFinalizers(append(object.GetFinalizers(), finalizerName))
+			if err := r.Update(context.Background(), object); err != nil {
+				if retryCount < errorThreshold {
+					log.Info("Retrying", "function", "reconcileFinalizers", "retryCount", retryCount+1, "objectID", objectID)
+					return r.reconcileFinalizers(object, retryCount+1)
+				}
+				log.Error(err, "failed to add finalizer", "objectID", objectID)
+				return err
+			}
+			log.Info("added finalizer", "objectID", objectID)
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileSFServiceBinding) setInProgress(namespacedName types.NamespacedName, state string, resources []osbv1alpha1.Source, retryCount int) error {
 	if state == "in_queue" || state == "update" || state == "delete" {
 		binding := &osbv1alpha1.SFServiceBinding{}
 		err := r.Get(context.TODO(), namespacedName, binding)
 		if err != nil {
-			log.Printf("error updating status to in progress. %s\n", err.Error())
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "setInProgress", "retryCount", retryCount+1, "objectID", namespacedName.Name)
+				return r.setInProgress(namespacedName, state, resources, retryCount+1)
+			}
+			log.Error(err, "Updating status to in progress failed")
 			return err
 		}
 		binding.SetState("in progress")
@@ -277,17 +288,22 @@ func (r *ReconcileSFServiceBinding) setInProgress(namespacedName types.Namespace
 		}
 		labels[lastOperationKey] = state
 		binding.SetLabels(labels)
+		binding.Status.Resources = resources
 		err = r.Update(context.Background(), binding)
 		if err != nil {
-			log.Printf("error updating status to in progress. %s\n", err.Error())
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "setInProgress", "retryCount", retryCount+1, "objectID", namespacedName.Name)
+				return r.setInProgress(namespacedName, state, resources, retryCount+1)
+			}
+			log.Error(err, "Updating status to in progress failed")
 			return err
 		}
-		log.Printf("Updated status to in progress for operation %s\n", state)
+		log.Info("Updated status to in progress", "operation", state)
 	}
 	return nil
 }
 
-func (r *ReconcileSFServiceBinding) updateUnbindStatus(targetClient client.Client, binding *osbv1alpha1.SFServiceBinding, remainingResource []osbv1alpha1.Source) error {
+func (r *ReconcileSFServiceBinding) updateUnbindStatus(targetClient client.Client, binding *osbv1alpha1.SFServiceBinding, retryCount int) error {
 	serviceID := binding.Spec.ServiceID
 	planID := binding.Spec.PlanID
 	instanceID := binding.Spec.InstanceID
@@ -295,18 +311,18 @@ func (r *ReconcileSFServiceBinding) updateUnbindStatus(targetClient client.Clien
 	namespace := binding.GetNamespace()
 	computedStatus, err := r.resourceManager.ComputeStatus(r, targetClient, instanceID, bindingID, serviceID, planID, osbv1alpha1.BindAction, namespace)
 	if err != nil {
-		log.Printf("error computing status. %v\n", err)
+		log.Error(err, "ComputeStatus failed for unbind")
 		return err
 	}
 
-	bindingObj := &osbv1alpha1.SFServiceBinding{}
+	// Fetch object again before updating status
 	namespacedName := types.NamespacedName{
 		Name:      bindingID,
 		Namespace: namespace,
 	}
-	err = r.Get(context.TODO(), namespacedName, bindingObj)
+	err = r.Get(context.TODO(), namespacedName, binding)
 	if err != nil {
-		log.Printf("error fetching binding. %v\n", err.Error())
+		log.Error(err, "Failed to get binding")
 		return err
 	}
 
@@ -314,118 +330,126 @@ func (r *ReconcileSFServiceBinding) updateUnbindStatus(targetClient client.Clien
 	updatedStatus := binding.Status.DeepCopy()
 	updatedStatus.State = computedStatus.Unbind.State
 	updatedStatus.Error = computedStatus.Unbind.Error
+
+	remainingResource := []osbv1alpha1.Source{}
+	for _, subResource := range binding.Status.Resources {
+		resource := &unstructured.Unstructured{}
+		resource.SetKind(subResource.Kind)
+		resource.SetAPIVersion(subResource.APIVersion)
+		resource.SetName(subResource.Name)
+		resource.SetNamespace(subResource.Namespace)
+		namespacedName := types.NamespacedName{
+			Name:      resource.GetName(),
+			Namespace: resource.GetNamespace(),
+		}
+		err := targetClient.Get(context.TODO(), namespacedName, resource)
+		if !errors.IsNotFound(err) {
+			remainingResource = append(remainingResource, subResource)
+		}
+	}
 	updatedStatus.Resources = remainingResource
 	if !reflect.DeepEqual(&binding.Status, updatedStatus) {
 		updatedStatus.DeepCopyInto(&binding.Status)
 		updateRequired = true
 	}
 
-	if binding.Status.State == "succeeded" || len(remainingResource) == 0 {
+	if binding.GetState() == "succeeded" || len(remainingResource) == 0 {
 		// remove our finalizer from the list and update it.
-		log.Printf("binding %s removing finalizer\n", bindingID)
+		log.Info("Removing finalizer", "binding", bindingID)
 		binding.SetFinalizers(removeString(binding.GetFinalizers(), finalizerName))
+		binding.SetState("succeeded")
 		updateRequired = true
 	}
 
 	if updateRequired {
 		if err := r.Update(context.Background(), binding); err != nil {
-			log.Printf("error updating unbind status %s. %s.\n", bindingID, err.Error())
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "updateUnbindStatus", "retryCount", retryCount+1, "bindingID", bindingID)
+				return r.updateUnbindStatus(targetClient, binding, retryCount+1)
+			}
+			log.Error(err, "failed to update unbind status", "binding", bindingID)
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *ReconcileSFServiceBinding) updateBindStatus(instanceID, bindingID, serviceID, planID, namespace string, appliedResources []*unstructured.Unstructured) error {
-	targetClient, err := r.clusterFactory.GetCluster(instanceID, bindingID, serviceID, planID)
-	if err != nil {
-		return err
-	}
-
-	resourceRefs := make([]osbv1alpha1.Source, 0, len(appliedResources))
-	for _, appliedResource := range appliedResources {
-		resource := osbv1alpha1.Source{}
-		resource.Kind = appliedResource.GetKind()
-		resource.APIVersion = appliedResource.GetAPIVersion()
-		resource.Name = appliedResource.GetName()
-		resource.Namespace = appliedResource.GetNamespace()
-		resourceRefs = append(resourceRefs, resource)
-	}
-
+func (r *ReconcileSFServiceBinding) updateBindStatus(targetClient client.Client, binding *osbv1alpha1.SFServiceBinding, retryCount int) error {
+	serviceID := binding.Spec.ServiceID
+	planID := binding.Spec.PlanID
+	instanceID := binding.Spec.InstanceID
+	bindingID := binding.GetName()
+	namespace := binding.GetNamespace()
 	computedStatus, err := r.resourceManager.ComputeStatus(r, targetClient, instanceID, bindingID, serviceID, planID, osbv1alpha1.BindAction, namespace)
 	if err != nil {
-		log.Printf("error computing status. %v\n", err)
+		log.Error(err, "Compute status failed for bind", "binding", bindingID)
 		return err
 	}
 
 	// Fetch object again before updating status
-	bindingObj := &osbv1alpha1.SFServiceBinding{}
 	namespacedName := types.NamespacedName{
 		Name:      bindingID,
 		Namespace: namespace,
 	}
-	err = r.Get(context.TODO(), namespacedName, bindingObj)
+	err = r.Get(context.TODO(), namespacedName, binding)
 	if err != nil {
-		log.Printf("error fetching binding. %v\n", err)
+		log.Error(err, "failed to fetch binding", "binding", bindingID)
 		return err
 	}
-	if bindingObj.Status.State != "succeeded" && bindingObj.Status.State != "failed" {
-		updatedStatus := bindingObj.Status.DeepCopy()
-		bindingStatus := computedStatus.Bind
-		if bindingStatus.State == "succeeded" {
-			secretName := "sf-" + bindingID
 
-			data := make(map[string]string)
-			data["response"] = bindingStatus.Response
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: namespace,
-				},
-				StringData: data,
-			}
+	updatedStatus := binding.Status.DeepCopy()
+	updatedStatus.State = computedStatus.Bind.State
+	updatedStatus.Error = computedStatus.Bind.Error
 
-			if err := controllerutil.SetControllerReference(bindingObj, secret, r.scheme); err != nil {
-				log.Printf("error setting owner reference for secret. %v\n", err)
-				return err
-			}
-			secretNamespacedName := types.NamespacedName{
+	computedBindingStatus := computedStatus.Bind
+
+	// Create secret if not exist
+	if computedBindingStatus.State == "succeeded" {
+		secretName := "sf-" + bindingID
+
+		data := make(map[string]string)
+		data["response"] = computedBindingStatus.Response
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
 				Namespace: namespace,
-			}
-			foundSecret := &corev1.Secret{}
-			err = r.Get(context.TODO(), secretNamespacedName, foundSecret)
-			if err != nil && errors.IsNotFound(err) {
-				err = r.Create(context.TODO(), secret)
-				if err != nil {
-					log.Printf("error creating secret. %v\n", err)
-					return err
-				}
-			} else if err != nil {
-				return err
-			} else {
-				err = r.Update(context.TODO(), secret)
-				if err != nil {
-					log.Printf("error updating secret. %v\n", err)
-					return err
-				}
-			}
-			updatedStatus.Response.SecretRef = secretName
-		} else if bindingStatus.State == "failed" {
-			updatedStatus.Error = bindingStatus.Error
+			},
+			StringData: data,
 		}
-		updatedStatus.State = bindingStatus.State
-		if appliedResources != nil {
-			updatedStatus.Resources = resourceRefs
+
+		if err := controllerutil.SetControllerReference(binding, secret, r.scheme); err != nil {
+			log.Error(err, "failed to set owner reference for secret")
+			return err
 		}
-		if !reflect.DeepEqual(&bindingObj.Status, updatedStatus) {
-			updatedStatus.DeepCopyInto(&bindingObj.Status)
-			log.Printf("Updating bind status from template for %s\n", namespacedName)
-			err = r.Update(context.Background(), bindingObj)
+		secretNamespacedName := types.NamespacedName{
+			Name:      secretName,
+			Namespace: namespace,
+		}
+		foundSecret := &corev1.Secret{}
+		err = r.Get(context.TODO(), secretNamespacedName, foundSecret)
+		if err != nil && errors.IsNotFound(err) {
+			err = r.Create(context.TODO(), secret)
 			if err != nil {
-				log.Printf("error updating status. %v\n", err)
+				log.Error(err, "failed to create secret")
 				return err
 			}
+		} else if err != nil {
+			return err
+		}
+		updatedStatus.Response.SecretRef = secretName
+	}
+
+	if !reflect.DeepEqual(&binding.Status, updatedStatus) {
+		updatedStatus.DeepCopyInto(&binding.Status)
+		log.Info("Updating bind status from template", "binding", namespacedName)
+		err = r.Update(context.Background(), binding)
+		if err != nil {
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "updateBindStatus", "retryCount", retryCount+1, "bindingID", bindingID)
+				return r.updateBindStatus(targetClient, binding, retryCount+1)
+			}
+			log.Error(err, "failed to update status")
+			return err
 		}
 	}
 	return nil
@@ -453,10 +477,29 @@ func removeString(slice []string, s string) (result []string) {
 	return
 }
 
-func (r *ReconcileSFServiceBinding) handleError(object *osbv1alpha1.SFServiceBinding, result reconcile.Result, inputErr error) (reconcile.Result, error) {
+func (r *ReconcileSFServiceBinding) handleError(object *osbv1alpha1.SFServiceBinding, result reconcile.Result, inputErr error, lastOperation string, retryCount int) (reconcile.Result, error) {
+	objectID := object.GetName()
+	namespace := object.GetNamespace()
+	// Fetch object again before updating
+	namespacedName := types.NamespacedName{
+		Name:      objectID,
+		Namespace: namespace,
+	}
+	err := r.Get(context.TODO(), namespacedName, object)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return result, inputErr
+		}
+		if retryCount < errorThreshold {
+			log.Info("Retrying", "function", "handleError", "retryCount", retryCount+1, "lastOperation", lastOperation, "err", inputErr, "objectID", objectID)
+			return r.handleError(object, result, inputErr, lastOperation, retryCount+1)
+		}
+		log.Error(err, "failed to fetch object", "objectID", objectID)
+		return result, nil
+	}
+
 	labels := object.GetLabels()
 	var count int64
-	id := object.GetName()
 
 	if labels == nil {
 		labels = make(map[string]string)
@@ -485,37 +528,33 @@ func (r *ReconcileSFServiceBinding) handleError(object *osbv1alpha1.SFServiceBin
 	}
 
 	if count > errorThreshold {
-		log.Printf("Retry threshold reached for %s. Ignoring %v\n", id, inputErr)
+		log.Error(inputErr, "Retry threshold reached. Ignoring error", "objectID", objectID)
 		object.Status.State = "failed"
-		object.Status.Error = fmt.Sprintf("Retry threshold reached for %s.\n%s", id, inputErr.Error())
+		object.Status.Error = fmt.Sprintf("Retry threshold reached for %s.\n%s", objectID, inputErr.Error())
+		if lastOperation != "" {
+			labels[lastOperationKey] = lastOperation
+			object.SetLabels(labels)
+		}
 		err := r.Update(context.TODO(), object)
 		if err != nil {
-			log.Printf("Error setting state to failed for %s\n", id)
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "handleError", "retryCount", retryCount+1, "lastOperation", lastOperation, "err", inputErr, "objectID", objectID)
+				return r.handleError(object, result, inputErr, lastOperation, retryCount+1)
+			}
+			log.Error(err, "Failed to set state to failed", "objectID", objectID)
 		}
 		return result, nil
 	}
 
 	labels[errorCountKey] = strconv.FormatInt(count, 10)
 	object.SetLabels(labels)
-	err := r.Update(context.TODO(), object)
+	err = r.Update(context.TODO(), object)
 	if err != nil {
-		if errors.IsConflict(err) {
-			err := r.Get(context.TODO(), types.NamespacedName{
-				Name:      object.GetName(),
-				Namespace: object.GetNamespace(),
-			}, object)
-			if err != nil {
-				return result, inputErr
-			}
-			labels = object.GetLabels()
-			if labels == nil {
-				labels = make(map[string]string)
-			}
-			labels[errorCountKey] = strconv.FormatInt(count, 10)
-			object.SetLabels(labels)
-			return r.handleError(object, result, inputErr)
+		if retryCount < errorThreshold {
+			log.Info("Retrying", "function", "handleError", "retryCount", retryCount+1, "lastOperation", lastOperation, "err", inputErr, "objectID", objectID)
+			return r.handleError(object, result, inputErr, lastOperation, retryCount+1)
 		}
-		log.Printf("Error Updating error count label to %d for binding %s\n", count, id)
+		log.Error(err, "Failed to update error count label", "objectID", objectID, "count", count)
 	}
 	return result, inputErr
 }

--- a/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller.go
+++ b/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller.go
@@ -48,9 +48,10 @@ const (
 	errorCountKey    = "interoperator.servicefabrik.io/error"
 	lastOperationKey = "interoperator.servicefabrik.io/lastoperation"
 	errorThreshold   = 10
+	workerCount      = 20
 )
 
-var log = logf.Log.WithName("binding-controller")
+var log = logf.Log.WithName("binding.controller")
 
 // Add creates a new SFServiceBinding Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -72,7 +73,7 @@ func newReconciler(mgr manager.Manager, resourceManager resources.ResourceManage
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("sfservicebinding-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("sfservicebinding-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: workerCount})
 	if err != nil {
 		return err
 	}

--- a/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller_suite_test.go
+++ b/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package sfservicebinding
 
 import (
-	"log"
+	stdlog "log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 
 	var err error
 	if cfg, err = t.Start(); err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	code := m.Run()
@@ -66,10 +66,10 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}, *sync.WaitGroup) {
 	stop := make(chan struct{})
 	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
+		defer wg.Done()
 		g.Expect(mgr.Start(stop)).NotTo(gomega.HaveOccurred())
-		wg.Done()
 	}()
 	return stop, wg
 }

--- a/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller_test.go
+++ b/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var templateSpec = []osbv1alpha1.TemplateSpec{
@@ -165,8 +166,9 @@ func TestReconcile(t *testing.T) {
 	defer ctrl.Finish()
 
 	var expectedResources = []*unstructured.Unstructured{nil}
-	var appliedResources = []*unstructured.Unstructured{
-		&unstructured.Unstructured{},
+
+	var appliedResources = []osbv1alpha1.Source{
+		osbv1alpha1.Source{},
 	}
 	err1 := fmt.Errorf("Some error")
 
@@ -200,6 +202,8 @@ func TestReconcile(t *testing.T) {
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	logf.SetLogger(logf.ZapLogger(true))
 
 	defer func() {
 		close(stopMgr)

--- a/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller.go
+++ b/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller.go
@@ -47,9 +47,10 @@ const (
 	errorCountKey    = "interoperator.servicefabrik.io/error"
 	lastOperationKey = "interoperator.servicefabrik.io/lastoperation"
 	errorThreshold   = 10
+	workerCount      = 10
 )
 
-var log = logf.Log.WithName("instance-controller")
+var log = logf.Log.WithName("instance.controller")
 
 // Add creates a new SFServiceInstance Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -71,7 +72,7 @@ func newReconciler(mgr manager.Manager, resourceManager resources.ResourceManage
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("sfserviceinstance-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("sfserviceinstance-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: workerCount})
 	if err != nil {
 		return err
 	}

--- a/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller.go
+++ b/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller.go
@@ -19,7 +19,6 @@ package sfserviceinstance
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 	"strconv"
 
@@ -38,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -49,7 +49,9 @@ const (
 	errorThreshold   = 10
 )
 
-// Add creates a new ServiceInstance Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+var log = logf.Log.WithName("instance-controller")
+
+// Add creates a new SFServiceInstance Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
 	clusterFactory, _ := clusterFactory.New(mgr)
@@ -58,7 +60,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, resourceManager resources.ResourceManager, clusterFactory clusterFactory.ClusterFactory) reconcile.Reconciler {
-	return &ReconcileServiceInstance{
+	return &ReconcileSFServiceInstance{
 		Client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
 		clusterFactory:  clusterFactory,
@@ -69,12 +71,12 @@ func newReconciler(mgr manager.Manager, resourceManager resources.ResourceManage
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("serviceinstance-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("sfserviceinstance-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
 	}
 
-	// Watch for changes to ServiceInstance
+	// Watch for changes to SFServiceInstance
 	err = c.Watch(&source.Kind{Type: &osbv1alpha1.SFServiceInstance{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
@@ -116,25 +118,25 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			OwnerType:    &osbv1alpha1.SFServiceInstance{},
 		})
 		if err != nil {
-			log.Printf("%v", err)
+			log.Error(err, "failed to start watch")
 		}
 	}
 
 	return nil
 }
 
-var _ reconcile.Reconciler = &ReconcileServiceInstance{}
+var _ reconcile.Reconciler = &ReconcileSFServiceInstance{}
 
-// ReconcileServiceInstance reconciles a ServiceInstance object
-type ReconcileServiceInstance struct {
+// ReconcileSFServiceInstance reconciles a SFServiceInstance object
+type ReconcileSFServiceInstance struct {
 	client.Client
 	scheme          *runtime.Scheme
 	clusterFactory  clusterFactory.ClusterFactory
 	resourceManager resources.ResourceManager
 }
 
-// Reconcile reads that state of the cluster for a ServiceInstance object and makes changes based on the state read
-// and what is in the ServiceInstance.Spec
+// Reconcile reads that state of the cluster for a SFServiceInstance object and makes changes based on the state read
+// and what is in the SFServiceInstance.Spec
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=kubedb.com,resources=Postgres,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubernetes.sapcloud.io,resources=postgresql,verbs=get;list;watch;create;update;patch;delete
@@ -146,7 +148,7 @@ type ReconcileServiceInstance struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=interoperator.servicefabrik.io,resources=sfserviceinstances,verbs=get;list;watch;create;update;patch;delete
 // TODO dynamically setup rbac rules and watches
-func (r *ReconcileServiceInstance) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileSFServiceInstance) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the ServiceInstance instance
 	instance := &osbv1alpha1.SFServiceInstance{}
 	err := r.Get(context.TODO(), request.NamespacedName, instance)
@@ -154,11 +156,11 @@ func (r *ReconcileServiceInstance) Reconcile(request reconcile.Request) (reconci
 		if errors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
-			log.Printf("instance %s deleted\n", request.NamespacedName)
+			log.Info("instance deleted", "binding", request.NamespacedName)
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return r.handleError(instance, reconcile.Result{}, err)
+		return r.handleError(instance, reconcile.Result{}, err, "", 0)
 	}
 
 	serviceID := instance.Spec.ServiceID
@@ -171,103 +173,111 @@ func (r *ReconcileServiceInstance) Reconcile(request reconcile.Request) (reconci
 	if !ok {
 		lastOperation = "in_queue"
 	}
-	var requeue bool
-	var appliedResources []*unstructured.Unstructured
-	var remainingResource []osbv1alpha1.Source
 
-	if instance.GetDeletionTimestamp().IsZero() {
-		if !containsString(instance.GetFinalizers(), finalizerName) {
-			// The object is not being deleted, so if it does not have our finalizer,
-			// then lets add the finalizer and update the object.
-			instance.SetFinalizers(append(instance.GetFinalizers(), finalizerName))
-			if err := r.Update(context.Background(), instance); err != nil {
-				return r.handleError(instance, reconcile.Result{Requeue: true}, nil)
-			}
-		}
+	if err := r.reconcileFinalizers(instance, 0); err != nil {
+		return r.handleError(instance, reconcile.Result{Requeue: true}, nil, "", 0)
 	}
 
 	targetClient, err := r.clusterFactory.GetCluster(instanceID, bindingID, serviceID, planID)
 	if err != nil {
-		return r.handleError(instance, reconcile.Result{}, err)
+		return r.handleError(instance, reconcile.Result{}, err, "", 0)
 	}
 
 	if state == "delete" && !instance.GetDeletionTimestamp().IsZero() {
 		// The object is being deleted
-		if containsString(instance.GetFinalizers(), finalizerName) {
-			// our finalizer is present, so lets handle our external dependency
-			remainingResource, err = r.resourceManager.DeleteSubResources(targetClient, instance.Status.Resources)
-			if err != nil {
-				log.Printf("Delete sub resources error %s\n", err.Error())
-				requeue = true
-			} else {
-				err = r.setInProgress(request.NamespacedName, state)
-				if err != nil {
-					requeue = true
-				} else {
-					lastOperation = state
-				}
-			}
+		// so lets handle our external dependency
+		remainingResource, err := r.resourceManager.DeleteSubResources(targetClient, instance.Status.Resources)
+		if err != nil {
+			log.Error(err, "Delete sub resources failed")
+			return r.handleError(instance, reconcile.Result{}, err, state, 0)
 		}
+		err = r.setInProgress(request.NamespacedName, state, remainingResource, 0)
+		if err != nil {
+			return r.handleError(instance, reconcile.Result{}, err, state, 0)
+		}
+		lastOperation = state
 	} else if state == "in_queue" || state == "update" {
 		expectedResources, err := r.resourceManager.ComputeExpectedResources(r, instanceID, bindingID, serviceID, planID, osbv1alpha1.ProvisionAction, instance.GetNamespace())
 		if err != nil {
-			return r.handleError(instance, reconcile.Result{}, err)
+			return r.handleError(instance, reconcile.Result{}, err, state, 0)
 		}
 
 		err = r.resourceManager.SetOwnerReference(instance, expectedResources, r.scheme)
 		if err != nil {
-			return r.handleError(instance, reconcile.Result{}, err)
+			return r.handleError(instance, reconcile.Result{}, err, state, 0)
 		}
 
-		appliedResources, err = r.resourceManager.ReconcileResources(r, targetClient, expectedResources, instance.Status.Resources)
+		resourceRefs, err := r.resourceManager.ReconcileResources(r, targetClient, expectedResources, instance.Status.Resources)
 		if err != nil {
-			log.Printf("Reconcile error %s\n", err.Error())
-			requeue = true
-		} else {
-			err = r.setInProgress(request.NamespacedName, state)
-			if err != nil {
-				requeue = true
-			} else {
-				lastOperation = state
-			}
+			log.Error(err, "ReconcileResources failed")
+			return r.handleError(instance, reconcile.Result{}, err, state, 0)
 		}
+		err = r.setInProgress(request.NamespacedName, state, resourceRefs, 0)
+		if err != nil {
+			return r.handleError(instance, reconcile.Result{}, err, state, 0)
+		}
+		lastOperation = state
 	}
 
 	if lastOperation == "delete" {
-		remainingResource = []osbv1alpha1.Source{}
-		for _, subResource := range instance.Status.Resources {
-			resource := &unstructured.Unstructured{}
-			resource.SetKind(subResource.Kind)
-			resource.SetAPIVersion(subResource.APIVersion)
-			resource.SetName(subResource.Name)
-			resource.SetNamespace(subResource.Namespace)
-			namespacedName := types.NamespacedName{
-				Name:      resource.GetName(),
-				Namespace: resource.GetNamespace(),
-			}
-			err := targetClient.Get(context.TODO(), namespacedName, resource)
-			if !errors.IsNotFound(err) {
-				remainingResource = append(remainingResource, subResource)
-			}
-		}
-		if err := r.updateDeprovisionStatus(targetClient, instance, remainingResource); err != nil {
-			return r.handleError(instance, reconcile.Result{}, err)
+		if err := r.updateDeprovisionStatus(targetClient, instance, 0); err != nil {
+			return r.handleError(instance, reconcile.Result{}, err, lastOperation, 0)
 		}
 	} else if lastOperation == "in_queue" || lastOperation == "update" {
-		err = r.updateStatus(instanceID, bindingID, serviceID, planID, instance.GetNamespace(), appliedResources)
+		err = r.updateStatus(targetClient, instance, 0)
 		if err != nil {
-			return r.handleError(instance, reconcile.Result{}, err)
+			return r.handleError(instance, reconcile.Result{}, err, lastOperation, 0)
 		}
 	}
-	return r.handleError(instance, reconcile.Result{Requeue: requeue}, nil)
+	return r.handleError(instance, reconcile.Result{}, nil, lastOperation, 0)
 }
 
-func (r *ReconcileServiceInstance) setInProgress(namespacedName types.NamespacedName, state string) error {
+func (r *ReconcileSFServiceInstance) reconcileFinalizers(object *osbv1alpha1.SFServiceInstance, retryCount int) error {
+	objectID := object.GetName()
+	namespace := object.GetNamespace()
+	// Fetch object again before updating
+	namespacedName := types.NamespacedName{
+		Name:      objectID,
+		Namespace: namespace,
+	}
+	err := r.Get(context.TODO(), namespacedName, object)
+	if err != nil {
+		if retryCount < errorThreshold {
+			log.Info("Retrying", "function", "reconcileFinalizers", "retryCount", retryCount+1, "objectID", objectID)
+			return r.reconcileFinalizers(object, retryCount+1)
+		}
+		log.Error(err, "failed to fetch object", "objectID", objectID)
+		return err
+	}
+	if object.GetDeletionTimestamp().IsZero() {
+		if !containsString(object.GetFinalizers(), finalizerName) {
+			// The object is not being deleted, so if it does not have our finalizer,
+			// then lets add the finalizer and update the object.
+			object.SetFinalizers(append(object.GetFinalizers(), finalizerName))
+			if err := r.Update(context.Background(), object); err != nil {
+				if retryCount < errorThreshold {
+					log.Info("Retrying", "function", "reconcileFinalizers", "retryCount", retryCount+1, "objectID", objectID)
+					return r.reconcileFinalizers(object, retryCount+1)
+				}
+				log.Error(err, "failed to add finalizer", "objectID", objectID)
+				return err
+			}
+			log.Info("added finalizer", "objectID", objectID)
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileSFServiceInstance) setInProgress(namespacedName types.NamespacedName, state string, resources []osbv1alpha1.Source, retryCount int) error {
 	if state == "in_queue" || state == "update" || state == "delete" {
 		instance := &osbv1alpha1.SFServiceInstance{}
 		err := r.Get(context.TODO(), namespacedName, instance)
 		if err != nil {
-			log.Printf("error updating status to in progress. %s\n", err.Error())
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "setInProgress", "retryCount", retryCount+1, "objectID", namespacedName.Name)
+				return r.setInProgress(namespacedName, state, resources, retryCount+1)
+			}
+			log.Error(err, "Updating status to in progress failed")
 			return err
 		}
 		instance.SetState("in progress")
@@ -277,17 +287,22 @@ func (r *ReconcileServiceInstance) setInProgress(namespacedName types.Namespaced
 		}
 		labels[lastOperationKey] = state
 		instance.SetLabels(labels)
+		instance.Status.Resources = resources
 		err = r.Update(context.Background(), instance)
 		if err != nil {
-			log.Printf("error updating status to in progress. %s\n", err.Error())
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "setInProgress", "retryCount", retryCount+1, "objectID", namespacedName.Name)
+				return r.setInProgress(namespacedName, state, resources, retryCount+1)
+			}
+			log.Error(err, "Updating status to in progress failed")
 			return err
 		}
-		log.Printf("Updated status to in progress for operation %s\n", state)
+		log.Info("Updated status to in progress", "operation", state)
 	}
 	return nil
 }
 
-func (r *ReconcileServiceInstance) updateDeprovisionStatus(targetClient client.Client, instance *osbv1alpha1.SFServiceInstance, remainingResource []osbv1alpha1.Source) error {
+func (r *ReconcileSFServiceInstance) updateDeprovisionStatus(targetClient client.Client, instance *osbv1alpha1.SFServiceInstance, retryCount int) error {
 	serviceID := instance.Spec.ServiceID
 	planID := instance.Spec.PlanID
 	instanceID := instance.GetName()
@@ -295,19 +310,18 @@ func (r *ReconcileServiceInstance) updateDeprovisionStatus(targetClient client.C
 	namespace := instance.GetNamespace()
 	computedStatus, err := r.resourceManager.ComputeStatus(r, targetClient, instanceID, bindingID, serviceID, planID, osbv1alpha1.ProvisionAction, namespace)
 	if err != nil {
-		log.Printf("error computing status. %v\n", err)
+		log.Error(err, "ComputeStatus failed for deprovision")
 		return err
 	}
 
 	// Fetch object again before updating status
-	instanceObj := &osbv1alpha1.SFServiceInstance{}
 	namespacedName := types.NamespacedName{
 		Name:      instanceID,
 		Namespace: namespace,
 	}
-	err = r.Get(context.TODO(), namespacedName, instanceObj)
+	err = r.Get(context.TODO(), namespacedName, instance)
 	if err != nil {
-		log.Printf("error fetching instance. %v\n", err.Error())
+		log.Error(err, "Failed to get instance")
 		return err
 	}
 
@@ -316,79 +330,91 @@ func (r *ReconcileServiceInstance) updateDeprovisionStatus(targetClient client.C
 	updatedStatus.State = computedStatus.Deprovision.State
 	updatedStatus.Error = computedStatus.Deprovision.Error
 	updatedStatus.Description = computedStatus.Deprovision.Response
+
+	remainingResource := []osbv1alpha1.Source{}
+	for _, subResource := range instance.Status.Resources {
+		resource := &unstructured.Unstructured{}
+		resource.SetKind(subResource.Kind)
+		resource.SetAPIVersion(subResource.APIVersion)
+		resource.SetName(subResource.Name)
+		resource.SetNamespace(subResource.Namespace)
+		namespacedName := types.NamespacedName{
+			Name:      resource.GetName(),
+			Namespace: resource.GetNamespace(),
+		}
+		err := targetClient.Get(context.TODO(), namespacedName, resource)
+		if !errors.IsNotFound(err) {
+			remainingResource = append(remainingResource, subResource)
+		}
+	}
 	updatedStatus.Resources = remainingResource
 	if !reflect.DeepEqual(&instance.Status, updatedStatus) {
 		updatedStatus.DeepCopyInto(&instance.Status)
 		updateRequired = true
 	}
 
-	if instance.Status.State == "succeeded" || len(remainingResource) == 0 {
+	if instance.GetState() == "succeeded" || len(remainingResource) == 0 {
 		// remove our finalizer from the list and update it.
-		log.Printf("instance %s removing finalizer\n", instanceID)
+		log.Info("Removing finalizer", "instance", instanceID)
 		instance.SetFinalizers(removeString(instance.GetFinalizers(), finalizerName))
+		instance.SetState("succeeded")
 		updateRequired = true
 	}
 
 	if updateRequired {
 		if err := r.Update(context.Background(), instance); err != nil {
-			log.Printf("error updating deprovision status instance %s. %s.\n", instanceID, err.Error())
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "updateDeprovisionStatus", "retryCount", retryCount+1, "instanceID", instanceID)
+				return r.updateDeprovisionStatus(targetClient, instance, retryCount+1)
+			}
+			log.Error(err, "failed to update deprovision status", "instance", instanceID)
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *ReconcileServiceInstance) updateStatus(instanceID, bindingID, serviceID, planID, namespace string, appliedResources []*unstructured.Unstructured) error {
-	targetClient, err := r.clusterFactory.GetCluster(instanceID, bindingID, serviceID, planID)
-	if err != nil {
-		return err
-	}
-
-	resourceRefs := make([]osbv1alpha1.Source, 0, len(appliedResources))
-	for _, appliedResource := range appliedResources {
-		resource := osbv1alpha1.Source{}
-		resource.Kind = appliedResource.GetKind()
-		resource.APIVersion = appliedResource.GetAPIVersion()
-		resource.Name = appliedResource.GetName()
-		resource.Namespace = appliedResource.GetNamespace()
-		resourceRefs = append(resourceRefs, resource)
-	}
-
+func (r *ReconcileSFServiceInstance) updateStatus(targetClient client.Client, instance *osbv1alpha1.SFServiceInstance, retryCount int) error {
+	serviceID := instance.Spec.ServiceID
+	planID := instance.Spec.PlanID
+	instanceID := instance.GetName()
+	bindingID := ""
+	namespace := instance.GetNamespace()
 	computedStatus, err := r.resourceManager.ComputeStatus(r, targetClient, instanceID, bindingID, serviceID, planID, osbv1alpha1.ProvisionAction, namespace)
 	if err != nil {
-		log.Printf("error computing status. %v\n", err)
+		log.Error(err, "Compute status failed", "instance", instanceID)
 		return err
 	}
 
 	// Fetch object again before updating status
-	instanceObj := &osbv1alpha1.SFServiceInstance{}
 	namespacedName := types.NamespacedName{
 		Name:      instanceID,
 		Namespace: namespace,
 	}
-	err = r.Get(context.TODO(), namespacedName, instanceObj)
+	err = r.Get(context.TODO(), namespacedName, instance)
 	if err != nil {
-		log.Printf("error fetching instance. %v\n", err)
+		log.Error(err, "failed to fetch instance", "instance", instanceID)
 		return err
 	}
-	updatedStatus := instanceObj.Status.DeepCopy()
+	updatedStatus := instance.Status.DeepCopy()
 	updatedStatus.State = computedStatus.Provision.State
 	updatedStatus.Error = computedStatus.Provision.Error
 	updatedStatus.Description = computedStatus.Provision.Response
 	updatedStatus.DashboardURL = computedStatus.Provision.DashboardURL
-	if appliedResources != nil {
-		updatedStatus.Resources = resourceRefs
-	}
-	if !reflect.DeepEqual(&instanceObj.Status, updatedStatus) {
-		updatedStatus.DeepCopyInto(&instanceObj.Status)
-		log.Printf("Updating provision status from template for %s\n", namespacedName)
-		err = r.Update(context.Background(), instanceObj)
+
+	if !reflect.DeepEqual(&instance.Status, updatedStatus) {
+		updatedStatus.DeepCopyInto(&instance.Status)
+		log.Info("Updating provision status from template", "instance", namespacedName)
+		err = r.Update(context.Background(), instance)
 		if err != nil {
-			log.Printf("error updating status. %v\n", err)
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "updateStatus", "retryCount", retryCount+1, "instanceID", instanceID)
+				return r.updateStatus(targetClient, instance, retryCount+1)
+			}
+			log.Error(err, "failed to update status")
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -414,10 +440,29 @@ func removeString(slice []string, s string) (result []string) {
 	return
 }
 
-func (r *ReconcileServiceInstance) handleError(object *osbv1alpha1.SFServiceInstance, result reconcile.Result, inputErr error) (reconcile.Result, error) {
+func (r *ReconcileSFServiceInstance) handleError(object *osbv1alpha1.SFServiceInstance, result reconcile.Result, inputErr error, lastOperation string, retryCount int) (reconcile.Result, error) {
+	objectID := object.GetName()
+	namespace := object.GetNamespace()
+	// Fetch object again before updating
+	namespacedName := types.NamespacedName{
+		Name:      objectID,
+		Namespace: namespace,
+	}
+	err := r.Get(context.TODO(), namespacedName, object)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return result, inputErr
+		}
+		if retryCount < errorThreshold {
+			log.Info("Retrying", "function", "handleError", "retryCount", retryCount+1, "lastOperation", lastOperation, "err", inputErr, "objectID", objectID)
+			return r.handleError(object, result, inputErr, lastOperation, retryCount+1)
+		}
+		log.Error(err, "failed to fetch object", "objectID", objectID)
+		return result, nil
+	}
+
 	labels := object.GetLabels()
 	var count int64
-	id := object.GetName()
 
 	if labels == nil {
 		labels = make(map[string]string)
@@ -446,38 +491,34 @@ func (r *ReconcileServiceInstance) handleError(object *osbv1alpha1.SFServiceInst
 	}
 
 	if count > errorThreshold {
-		log.Printf("Retry threshold reached for %s. Ignoring %v\n", id, inputErr)
+		log.Error(inputErr, "Retry threshold reached. Ignoring error", "objectID", objectID)
 		object.Status.State = "failed"
-		object.Status.Error = fmt.Sprintf("Retry threshold reached for %s.\n%s", id, inputErr.Error())
+		object.Status.Error = fmt.Sprintf("Retry threshold reached for %s.\n%s", objectID, inputErr.Error())
 		object.Status.Description = "Service Broker Error, status code: ETIMEDOUT, error code: 10008"
+		if lastOperation != "" {
+			labels[lastOperationKey] = lastOperation
+			object.SetLabels(labels)
+		}
 		err := r.Update(context.TODO(), object)
 		if err != nil {
-			log.Printf("Error setting state to failed for %s\n", id)
+			if retryCount < errorThreshold {
+				log.Info("Retrying", "function", "handleError", "retryCount", retryCount+1, "lastOperation", lastOperation, "err", inputErr, "objectID", objectID)
+				return r.handleError(object, result, inputErr, lastOperation, retryCount+1)
+			}
+			log.Error(err, "Failed to set state to failed", "objectID", objectID)
 		}
 		return result, nil
 	}
 
 	labels[errorCountKey] = strconv.FormatInt(count, 10)
 	object.SetLabels(labels)
-	err := r.Update(context.TODO(), object)
+	err = r.Update(context.TODO(), object)
 	if err != nil {
-		if errors.IsConflict(err) {
-			err := r.Get(context.TODO(), types.NamespacedName{
-				Name:      object.GetName(),
-				Namespace: object.GetNamespace(),
-			}, object)
-			if err != nil {
-				return result, inputErr
-			}
-			labels = object.GetLabels()
-			if labels == nil {
-				labels = make(map[string]string)
-			}
-			labels[errorCountKey] = strconv.FormatInt(count, 10)
-			object.SetLabels(labels)
-			return r.handleError(object, result, inputErr)
+		if retryCount < errorThreshold {
+			log.Info("Retrying", "function", "handleError", "retryCount", retryCount+1, "lastOperation", lastOperation, "err", inputErr, "objectID", objectID)
+			return r.handleError(object, result, inputErr, lastOperation, retryCount+1)
 		}
-		log.Printf("Error Updating error count label to %d for instance %s\n", count, id)
+		log.Error(err, "Failed to update error count label", "objectID", objectID, "count", count)
 	}
 	return result, inputErr
 }

--- a/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller_suite_test.go
+++ b/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package sfserviceinstance
 
 import (
-	"log"
+	stdlog "log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 
 	var err error
 	if cfg, err = t.Start(); err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	code := m.Run()
@@ -66,10 +66,10 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}, *sync.WaitGroup) {
 	stop := make(chan struct{})
 	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
+		defer wg.Done()
 		g.Expect(mgr.Start(stop)).NotTo(gomega.HaveOccurred())
-		wg.Done()
 	}()
 	return stop, wg
 }

--- a/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller_test.go
+++ b/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var c client.Client
@@ -149,8 +150,8 @@ func TestReconcile(t *testing.T) {
 	defer ctrl.Finish()
 
 	var expectedResources = []*unstructured.Unstructured{nil}
-	var appliedResources = []*unstructured.Unstructured{
-		&unstructured.Unstructured{},
+	var appliedResources = []osbv1alpha1.Source{
+		osbv1alpha1.Source{},
 	}
 	err1 := fmt.Errorf("Some error")
 
@@ -183,6 +184,8 @@ func TestReconcile(t *testing.T) {
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	logf.SetLogger(logf.ZapLogger(true))
 
 	defer func() {
 		close(stopMgr)

--- a/interoperator/pkg/internal/cluster/factory/factory.go
+++ b/interoperator/pkg/internal/cluster/factory/factory.go
@@ -10,7 +10,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("cluster-factory")
+var log = logf.Log.WithName("cluster.factory")
 
 // ClusterFactory sets up k8s clusters and gets client for them
 //go:generate mockgen -source factory.go -destination ./mock_factory/mock_factory.go

--- a/interoperator/pkg/internal/cluster/factory/factory.go
+++ b/interoperator/pkg/internal/cluster/factory/factory.go
@@ -2,13 +2,15 @@ package factory
 
 import (
 	"fmt"
-	"log"
 
 	"k8s.io/client-go/rest"
 	kubernetes "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.Log.WithName("cluster-factory")
 
 // ClusterFactory sets up k8s clusters and gets client for them
 //go:generate mockgen -source factory.go -destination ./mock_factory/mock_factory.go
@@ -40,7 +42,7 @@ func (f *clusterFactory) GetCluster(instanceID, bindingID, serviceID, planID str
 	if cfg == nil {
 		cfg, err = config.GetConfig()
 		if err != nil {
-			log.Printf("unable to get client config %v", err)
+			log.Error(err, "unable to get client config")
 			return nil, err
 		}
 	}
@@ -51,7 +53,7 @@ func (f *clusterFactory) GetCluster(instanceID, bindingID, serviceID, planID str
 	}
 	client, err := kubernetes.New(cfg, options)
 	if err != nil {
-		log.Printf("unable create kubernetes client %v", err)
+		log.Error(err, "unable create kubernetes client")
 		return nil, err
 	}
 	return client, nil

--- a/interoperator/pkg/internal/cluster/factory/factory_suite_test.go
+++ b/interoperator/pkg/internal/cluster/factory/factory_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package factory
 
 import (
-	"log"
+	stdlog "log"
 	"os"
 	"testing"
 
@@ -36,15 +36,15 @@ func TestMain(m *testing.M) {
 	var err error
 	t := &envtest.Environment{}
 	if cfg, err = t.Start(); err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	if c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme}); err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	if mgr, err = manager.New(cfg, manager.Options{}); err != nil {
-		log.Fatal(err)
+		stdlog.Fatal(err)
 	}
 
 	code := m.Run()

--- a/interoperator/pkg/internal/resources/mock_resources/mock_resources.go
+++ b/interoperator/pkg/internal/resources/mock_resources/mock_resources.go
@@ -68,10 +68,10 @@ func (mr *MockResourceManagerMockRecorder) SetOwnerReference(owner, resources, s
 }
 
 // ReconcileResources mocks base method
-func (m *MockResourceManager) ReconcileResources(sourceClient, targetClient client.Client, expectedResources []*unstructured.Unstructured, lastResources []v1alpha1.Source) ([]*unstructured.Unstructured, error) {
+func (m *MockResourceManager) ReconcileResources(sourceClient, targetClient client.Client, expectedResources []*unstructured.Unstructured, lastResources []v1alpha1.Source) ([]v1alpha1.Source, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReconcileResources", sourceClient, targetClient, expectedResources, lastResources)
-	ret0, _ := ret[0].([]*unstructured.Unstructured)
+	ret0, _ := ret[0].([]v1alpha1.Source)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/interoperator/pkg/internal/resources/resources_test.go
+++ b/interoperator/pkg/internal/resources/resources_test.go
@@ -1393,7 +1393,7 @@ func Test_resourceManager_deleteSubResource(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Use kubebuilder version v1.0.8
- Adds monitoring to interoperator
- Use logger from controller runtime
  Only changed in instance and binding controller
- Set in progress also updates resources field in status
- Fail reconcile if set in progress fails
- Refetch intance/binding before updating status
- Removed updating bind secret if already exist
  Done to make it less complex