### PR TITLE
Fixing get deployment summary API

### DIFF
--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -402,7 +402,10 @@ class ServiceFabrikAdminController extends FabrikBaseController {
           .map(instance => {
             const plan = getPlanByGuid(plans, instance.entity.service_plan_guid);
             return Promise.try(() => DirectorService.createInstance(_.get(instance, 'metadata.guid'), {
-                plan_id: plan.id
+                plan_id: plan.id,
+                context: {
+                  platform: 'cloudfoundry'
+                }
               }))
               .then(service => _
                 .chain(instance)

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -404,7 +404,7 @@ class ServiceFabrikAdminController extends FabrikBaseController {
             return Promise.try(() => DirectorService.createInstance(_.get(instance, 'metadata.guid'), {
                 plan_id: plan.id,
                 context: {
-                  platform: 'cloudfoundry'
+                  platform: CONST.PLATFORM.CF
                 }
               }))
               .then(service => _


### PR DESCRIPTION
passing a default context so that it does not call APIServer multiple times for platform context