### PR TITLE
Adding placeholders for instance sharing related functions in K8sPlatformManager

### DIFF
--- a/platform-managers/K8sPlatformManager.js
+++ b/platform-managers/K8sPlatformManager.js
@@ -10,14 +10,17 @@ class K8sPlatformManager extends BasePlatformManager {
   }
 
   preUnbindOperations(options) {
+    /* jshint unused:false */
     return Promise.resolve();
   }
 
   preBindOperations(options) {
+    /* jshint unused:false */
     return Promise.resolve();
   }
 
   postBindOperations(options) {
+    /* jshint unused:false */
     return Promise.resolve();
   }
 

--- a/platform-managers/K8sPlatformManager.js
+++ b/platform-managers/K8sPlatformManager.js
@@ -1,11 +1,24 @@
 'use strict';
 
 const BasePlatformManager = require('./BasePlatformManager');
+const Promise = require('bluebird');
 
 class K8sPlatformManager extends BasePlatformManager {
   constructor(platform) {
     super(platform);
     this.platform = platform;
+  }
+
+  preUnbindOperations(options) {
+    return Promise.resolve();
+  }
+
+  preBindOperations(options) {
+    return Promise.resolve();
+  }
+
+  postBindOperations(options) {
+    return Promise.resolve();
   }
 
   postInstanceProvisionOperations(options) {

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -1186,7 +1186,7 @@ describe('#DirectorService', function () {
               }, WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION);
             });
         });
-        it('should process the requests originating from k8s platform', function(done) {
+        it('should process the requests originating from k8s platform', function (done) {
           config.mongodb.provision.plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
           deferred.reject(new errors.NotFound('Schedule not found'));
           const WAIT_TIME_FOR_ASYNCH_SCHEDULE_OPERATION = 0;

--- a/test/test_broker/operators.DockerService.spec.js
+++ b/test/test_broker/operators.DockerService.spec.js
@@ -381,6 +381,38 @@ describe('docker-operator', function () {
             mocks.verify();
           });
       });
+      it('returns 201 Created for requests originating from kubernetes platform', function () {
+        mocks.docker.inspectContainer(instance_id);
+        const options = {
+          service_id: service_id,
+          plan_id: plan_id,
+          app_guid: app_guid,
+          bind_resource: {
+            app_guid: app_guid,
+            space_guid: space_guid
+          },
+          context: {
+            platform: 'kubernetes',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          }
+        };
+        return DockerService.createInstance(instance_id, options)
+          .then(service => service.bind(options))
+          .then(res => {
+            expect(res).to.eql({
+              hostname: docker_url.hostname,
+              username: username,
+              password: password,
+              port: undefined,
+              ports: {
+                '12345/tcp': 12345
+              },
+              uri: `http://${username}:${password}@${docker_url.hostname}`
+            });
+            mocks.verify();
+          });
+      });
     });
 
     describe('#unbind', function () {


### PR DESCRIPTION
* This PR addresses NGPBUG-78199.
* With https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/528/ and https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/570, instance sharing feature was introduced for director and docker instances. However, corresponding implementation was not added for requests originating from kubernetes platform, leading to failure in such bind requests.
* This PR provides a temporary fix for this by adding corresponding placeholders in K8sPlatformManager.