### PR TITLE
Allows for clients to customize dashboard URL

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -760,6 +760,7 @@ defaults: &defaults
           update_predecessors:
           - 'bc158c9a-7934-401e-94ab-057082a5073f'
           template: <%= base64_template('templates/blueprint-manifest.yml.ejs') %>
+          dashboard_url_template: <%= new Buffer('http://service-fabrik-broker.bosh-lite.com/manage/dashboards/director/instances/${instance_id}?planName=${plan.name}&serviceId=${plan.service.id}').toString('base64') %>
           releases: *dedicated_releases
           context: &context_plan4
             agent: *agent_blueprint
@@ -833,6 +834,7 @@ defaults: &defaults
           update_predecessors:
           - 'bc158c9a-7934-401e-94ab-057082a5073f'
           template: <%= base64_template('templates/blueprint-manifest.yml.ejs') %>
+          dashboard_url_template: <%= new Buffer('manage/dashboards/director/instances/${instance_id}?planName=${plan.name}&serviceId=${plan.service.id}').toString('base64') %>
           releases: *dedicated_releases
           context: &context_plan7
             agent: *agent_blueprint

--- a/common/constants.js
+++ b/common/constants.js
@@ -475,5 +475,8 @@ module.exports = Object.freeze({
   SYSTEM_ERRORS: ['ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'ESOCKETTIMEDOUT'],
   INTERNAL: 'internal',
   ALL: 'all',
-  DISABLED: 'disabled'
+  DISABLED: 'disabled',
+  REGEX_PATTERN: {
+    URL: /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/
+  }
 });


### PR DESCRIPTION
Currently the dashboard URL sent back by broker as part of create/update requests are all back to its inbuilt dashboard URLs. However there are some usecases where individual services might like to redirect the dashboard requests to their own hosted solution. To address this, we provide a mechanism via Service plan for end users to specify a dashboard_url_template at plan level which will be evaluated with the following context object:
1. Request body as recieved in the PUT/PATCH OSBAPI request
2. [Plan object](https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/master/common/models/Plan.js)

Services are free to use any of the values of the above context when constructing their template URL (refer sample dashboard url template in settings.yml). The template URL must result in an valid absolute URL, else before the request is even processed an error is thrown back to the end user.

Also since the config will be evaluated via lodash at the start of app when setting up config, the url template provided in the config must be base64 encoded in order to avoid false evaluation of the same upfront.