### PR TITLE
Introduction of AliClient

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -67,6 +67,13 @@ const cloudProviders = {
     storageAccessKey: 'xxxxxxxxxxxxxxxxxx',
     container: 'samplecontainer'
   },
+  ali: {
+    keyId: 'key-id',
+    container: 'sample-container',
+    endpoint: 'https://sample-endpoint',
+    region: 'region-name',
+    key: 'secret-key'
+  },
   gcp: {
     projectId: 'my-gcp-dev',
     credentials: {

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -1,0 +1,205 @@
+'use strict';
+const _ = require('lodash');
+const Promise = require('bluebird');
+const Storage = require('ali-oss');
+//const Compute = require('@alicloud/pop-core');
+const logger = require('../../common/logger');
+const errors = require('../../common/errors');
+const utils = require('../../common/utils');
+const uuid = require('uuid');
+//const ComputeClient = require('./ComputeClient');
+const BaseCloudClient = require('./BaseCloudClient');
+const NotFound = errors.NotFound;
+const Unauthorized = errors.Unauthorized;
+const Forbidden = errors.Forbidden;
+
+class AliClient extends BaseCloudClient {
+  constructor(settings) {
+    super(settings);
+    this.constructor.validateParams(_.chain(this.settings).value());
+    this.storage = this.constructor.createStorageClient(_
+      .chain(this.settings)
+      .omit('name')
+      .set('provider', this.provider)
+      .value()
+    );
+  }
+
+  getContainer(container) {
+    if (arguments.length < 1) {
+      container = containerName;
+    }
+    logger.debug("Looking for container " + container);
+    return Promise.try(() => {
+      return this.storage.listBuckets({
+        prefix: container
+      })
+        .then(buckets => {
+          if (buckets.buckets == null) {
+            logger.error("Bucket " + container + " does not exists");
+          } else if (buckets.buckets.length == 1) {
+            return buckets.buckets;
+            logger.info("Bucket " + container + " exists");
+          } else {
+            logger.error("More than 1 Buckets with prefix " + container + " exists");
+          }
+        })
+        .catch(err => {
+          logger.error("Bucket " + container + " does not exists");
+        });
+    });
+  }
+
+
+  list(container, options) {
+    if (arguments.length < 2) {
+      options = container;
+      container = this.containerName;
+    }
+    return storageClient
+      .useBucket(container)
+      .list(options)
+      .then(listOfFiles => {
+        let list = listOfFiles.objects;
+        let isTruncated = listOfFiles.isTruncated;
+        let marker = listOfFiles.nextMarker;
+        const files = [];
+        _.each(list, file => files.push(_
+          .chain(file)
+          .pick('name', 'lastModified')
+          .set('isTruncated', isTruncated)
+          .set('marker', marker)
+          .value()
+        ));
+        return files;
+      });
+  }
+
+  listFilenames(prefix, max_keys) {
+    const options = {
+      prefix: prefix,
+      'max-keys': max_keys
+    };
+
+    let fileList = [];
+    let level = 0;
+
+    function fetchFiles() {
+      level++;
+      logger.debug(`Fetching recursively at level : ${level}`);
+      const promise = new Promise(function (resolve, reject) {
+        Promise.try(() => list(containerName, options))
+          .then(files => {
+            logger.debug('list of files recieved - ', files);
+            if (files && files.length > 0) {
+              fileList = fileList.concat(files);
+              if (files[0].isTruncated === true && level < 10) {
+                options.marker = files[files.length - 1].marker;
+                return fetchFiles()
+                  .then(() => resolve())
+                  .catch(err => reject(err));
+              }
+            }
+            logger.debug('end of recursion');
+            resolve();
+          })
+          .catch(err => reject(err));
+      });
+      return promise;
+    }
+
+    return fetchFiles()
+      .then(() =>
+        _
+          .chain(fileList)
+          .map(file => file)
+          .value());
+  }
+
+  remove(container, file) {
+    if (arguments.length < 2) {
+      file = container;
+      container = containerName;
+    }
+
+    logger.info("Deleting file " + file + " from container " + container);
+    return storageClient
+      .useBucket(container)
+      .delete(file)
+      .then(() => {
+        logger.info("Deleted file " + file + " from container " + container);
+      })
+      .catch(err => {
+        logger.error(err.message);
+      });
+  }
+
+  download(options) {
+    return utils.streamToPromise(this.storage.createReadStream(
+      options.container, options.remote))
+      .catchThrow(BaseCloudClient.providerErrorTypes.NotFound, new NotFound(`Object '${options.remote}' not found`));
+  }
+
+  upload(options, buffer) {
+    return Promise.try(() => {
+      return this.storage
+        .useBucket(options.container)
+        .put(options.remote, buffer)
+        .then(result => {
+          //console.log(result);
+          JSON.parse(buffer);
+        })
+        .catch(err => {
+          logger.error(err)
+        })
+    });
+  }
+
+  uploadJson(container, file, data) {
+    if (arguments.length < 3) {
+      data = file;
+      file = container;
+      container = containerName;
+    }
+
+    logger.info("Uploading file " + file + " to container " + container);
+    return upload({
+      container: container,
+      remote: file
+    }, new Buffer(JSON.stringify(data, null, 2), 'utf8'));
+  }
+
+  downloadJson(container, file) {
+    if (arguments.length < 2) {
+      file = container;
+      container = containerName;
+    }
+    logger.info("Downloading file " + file + " from container " + container);
+    return download({
+      container: container,
+      remote: file
+    })
+      .then((data) => JSON.parse(data));
+  }
+
+  createDiskFromSnapshot(snapshotId, zone, opts = {}) { }
+
+  getDiskMetadata(diskCid, zone) { }
+
+  deleteSnapshot() { }
+
+  getRandomDiskId() { }
+
+  static createComputeClient() { }
+
+  static createStorageClient(options) {
+    return Storage({
+      region: options.region,
+      accessKeyId: options.accessKey,
+      accessKeySecret: options.secretKey,
+      endpoint: options.endpoint
+    });
+  }
+}
+
+module.exports = AliClient;

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -4,10 +4,10 @@ const Promise = require('bluebird');
 const Storage = require('ali-oss');
 // const Compute = require('@alicloud/pop-core');
 const logger = require('../../common/logger');
-const errors = require('../../common/errors');
+// const errors = require('../../common/errors');
 // const utils = require('../../common/utils');
 // const uuid = require('uuid');
-//const ComputeClient = require('./ComputeClient');
+// const ComputeClient = require('./ComputeClient');
 const BaseCloudClient = require('./BaseCloudClient');
 // const NotFound = errors.NotFound;
 // const Unauthorized = errors.Unauthorized;
@@ -35,7 +35,7 @@ class AliClient extends BaseCloudClient {
         prefix: container
       })
         .then(buckets => {
-          if (buckets.buckets == null) {
+          if (buckets.buckets === null) {
             logger.error('Bucket ' + container + ' does not exists');
           } else if (buckets.buckets.length == 1) {
             return buckets.buckets;
@@ -157,8 +157,8 @@ class AliClient extends BaseCloudClient {
           JSON.parse(buffer);
         })
         .catch(err => {
-          logger.error(err)
-        })
+          logger.error(err);
+        });
     });
   }
 
@@ -186,7 +186,7 @@ class AliClient extends BaseCloudClient {
       container: container,
       remote: file
     })
-      .then((data) => JSON.parse(data));
+      .then(data => JSON.parse(data));
   }
 
   createDiskFromSnapshot(snapshotId, zone, opts = {}) { }

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -5,18 +5,18 @@ const Storage = require('ali-oss');
 // const Compute = require('@alicloud/pop-core');
 const logger = require('../../common/logger');
 const errors = require('../../common/errors');
-const utils = require('../../common/utils');
-const uuid = require('uuid');
+// const utils = require('../../common/utils');
+// const uuid = require('uuid');
 //const ComputeClient = require('./ComputeClient');
 const BaseCloudClient = require('./BaseCloudClient');
-const NotFound = errors.NotFound;
-const Unauthorized = errors.Unauthorized;
-const Forbidden = errors.Forbidden;
+// const NotFound = errors.NotFound;
+// const Unauthorized = errors.Unauthorized;
+// const Forbidden = errors.Forbidden;
 
 class AliClient extends BaseCloudClient {
   constructor(settings) {
     super(settings);
-    //this.constructor.validateParams(_.chain(this.settings).value());
+    // this.constructor.validateParams(_.chain(this.settings).value());
     this.storage = this.constructor.createStorageClient(_
       .chain(this.settings)
       .omit('name')
@@ -29,23 +29,23 @@ class AliClient extends BaseCloudClient {
     if (arguments.length < 1) {
       container = this.containerName;
     }
-    logger.debug("Looking for container " + container);
+    logger.debug('Looking for container ' + container);
     return Promise.try(() => {
       return this.storage.listBuckets({
         prefix: container
       })
         .then(buckets => {
           if (buckets.buckets == null) {
-            logger.error("Bucket " + container + " does not exists");
+            logger.error('Bucket ' + container + ' does not exists');
           } else if (buckets.buckets.length == 1) {
             return buckets.buckets;
-            logger.info("Bucket " + container + " exists");
+            logger.info('Bucket ' + container + ' exists');
           } else {
-            logger.error("More than 1 Buckets with prefix " + container + " exists");
+            logger.error('More than 1 Buckets with prefix ' + container + ' exists');
           }
         })
         .catch(err => {
-          logger.error("Bucket " + container + " does not exists");
+          logger.error('Bucket ' + container + ' does not exists');
         });
     });
   }
@@ -122,12 +122,12 @@ class AliClient extends BaseCloudClient {
       container = this.containerName;
     }
 
-    logger.info("Deleting file " + file + " from container " + container);
+    logger.info('Deleting file ' + file + ' from container ' + container);
     return this.storage
       .useBucket(container)
       .delete(file)
       .then(() => {
-        logger.info("Deleted file " + file + " from container " + container);
+        logger.info('Deleted file ' + file + ' from container ' + container);
       })
       .catch(err => {
         logger.error(err.message);
@@ -143,8 +143,8 @@ class AliClient extends BaseCloudClient {
           return result.content;
         })
         .catch(err => {
-          console.error(err)
-        })
+          console.error(err);
+        });
     });
   }
 
@@ -153,8 +153,7 @@ class AliClient extends BaseCloudClient {
       return this.storage
         .useBucket(options.container)
         .put(options.remote, buffer)
-        .then(result => {
-          //console.log(result);
+        .then(() => {
           JSON.parse(buffer);
         })
         .catch(err => {
@@ -170,7 +169,7 @@ class AliClient extends BaseCloudClient {
       container = this.containerName;
     }
 
-    logger.info("Uploading file " + file + " to container " + container);
+    logger.info('Uploading file ' + file + ' to container ' + container);
     return this.upload({
       container: container,
       remote: file
@@ -182,7 +181,7 @@ class AliClient extends BaseCloudClient {
       file = container;
       container = this.containerName;
     }
-    logger.info("Downloading file " + file + " from container " + container);
+    logger.info('Downloading file ' + file + ' from container ' + container);
     return this.download({
       container: container,
       remote: file

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -16,7 +16,7 @@ const Forbidden = errors.Forbidden;
 class AliClient extends BaseCloudClient {
   constructor(settings) {
     super(settings);
-    this.constructor.validateParams(_.chain(this.settings).value());
+    //this.constructor.validateParams(_.chain(this.settings).value());
     this.storage = this.constructor.createStorageClient(_
       .chain(this.settings)
       .omit('name')
@@ -195,8 +195,8 @@ class AliClient extends BaseCloudClient {
   static createStorageClient(options) {
     return Storage({
       region: options.region,
-      accessKeyId: options.accessKey,
-      accessKeySecret: options.secretKey,
+      accessKeyId: options.keyId,
+      accessKeySecret: options.key,
       endpoint: options.endpoint
     });
   }

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -2,21 +2,12 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const Storage = require('ali-oss');
-// const Compute = require('@alicloud/pop-core');
 const logger = require('../../common/logger');
-// const errors = require('../../common/errors');
-// const utils = require('../../common/utils');
-// const uuid = require('uuid');
-// const ComputeClient = require('./ComputeClient');
 const BaseCloudClient = require('./BaseCloudClient');
-// const NotFound = errors.NotFound;
-// const Unauthorized = errors.Unauthorized;
-// const Forbidden = errors.Forbidden;
 
 class AliClient extends BaseCloudClient {
   constructor(settings) {
     super(settings);
-    // this.constructor.validateParams(_.chain(this.settings).value());
     this.storage = this.constructor.createStorageClient(_
       .chain(this.settings)
       .omit('name')

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -144,9 +144,7 @@ class AliClient extends BaseCloudClient {
       return this.storage
         .useBucket(options.container)
         .put(options.remote, buffer)
-        .then(() => {
-          JSON.parse(buffer);
-        })
+        .then(() => JSON.parse(buffer))
         .catch(err => {
           logger.error(err);
         });

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -39,9 +39,6 @@ class AliClient extends BaseCloudClient {
             throw new Error(`More than 1 Buckets with prefix ${container} exists`);
           }
         })
-        .catch(err => {
-          logger.error('Bucket ' + container + ' does not exists');
-        });
     });
   }
 

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -27,7 +27,7 @@ class AliClient extends BaseCloudClient {
 
   getContainer(container) {
     if (arguments.length < 1) {
-      container = containerName;
+      container = this.containerName;
     }
     logger.debug("Looking for container " + container);
     return Promise.try(() => {
@@ -88,7 +88,7 @@ class AliClient extends BaseCloudClient {
       level++;
       logger.debug(`Fetching recursively at level : ${level}`);
       const promise = new Promise(function (resolve, reject) {
-        Promise.try(() => list(containerName, options))
+        Promise.try(() => list(this.containerName, options))
           .then(files => {
             logger.debug('list of files recieved - ', files);
             if (files && files.length > 0) {
@@ -119,7 +119,7 @@ class AliClient extends BaseCloudClient {
   remove(container, file) {
     if (arguments.length < 2) {
       file = container;
-      container = containerName;
+      container = this.containerName;
     }
 
     logger.info("Deleting file " + file + " from container " + container);
@@ -159,11 +159,11 @@ class AliClient extends BaseCloudClient {
     if (arguments.length < 3) {
       data = file;
       file = container;
-      container = containerName;
+      container = this.containerName;
     }
 
     logger.info("Uploading file " + file + " to container " + container);
-    return upload({
+    return this.upload({
       container: container,
       remote: file
     }, new Buffer(JSON.stringify(data, null, 2), 'utf8'));
@@ -172,7 +172,7 @@ class AliClient extends BaseCloudClient {
   downloadJson(container, file) {
     if (arguments.length < 2) {
       file = container;
-      container = containerName;
+      container = this.containerName;
     }
     logger.info("Downloading file " + file + " from container " + container);
     return download({

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -56,7 +56,7 @@ class AliClient extends BaseCloudClient {
       options = container;
       container = this.containerName;
     }
-    return storageClient
+    return this.storage
       .useBucket(container)
       .list(options)
       .then(listOfFiles => {
@@ -123,7 +123,7 @@ class AliClient extends BaseCloudClient {
     }
 
     logger.info("Deleting file " + file + " from container " + container);
-    return storageClient
+    return this.storage
       .useBucket(container)
       .delete(file)
       .then(() => {

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -38,7 +38,7 @@ class AliClient extends BaseCloudClient {
             logger.error('More than 1 Buckets with prefix ' + container + ' exists');
             throw new Error(`More than 1 Buckets with prefix ${container} exists`);
           }
-        })
+        });
     });
   }
 

--- a/data-access-layer/iaas/index.js
+++ b/data-access-layer/iaas/index.js
@@ -4,6 +4,7 @@ const config = require('../../common/config');
 const CloudProviderClient = require('./CloudProviderClient');
 const AzureClient = require('./AzureClient');
 const GcpClient = require('./GcpClient');
+const AliClient = require('./AliClient');
 const BackupStore = require('./BackupStore');
 const BackupStoreForServiceInstance = require('./BackupStoreForServiceInstance');
 const BackupStoreForOob = require('./BackupStoreForOob');
@@ -19,6 +20,8 @@ const getCloudClient = function (settings) {
     case 'openstack':
     case 'os':
       return new CloudProviderClient(settings);
+    case 'ali':
+      return new AliClient(settings);
     default:
       return new BaseCloudClient(settings);
   }
@@ -28,6 +31,7 @@ const cloudProvider = getCloudClient(config.backup.provider);
 exports.CloudProviderClient = CloudProviderClient;
 exports.AzureClient = AzureClient;
 exports.GcpClient = GcpClient;
+exports.AliClient = AliClient;
 exports.BackupStore = BackupStore;
 exports.BaseCloudClient = BaseCloudClient;
 exports.cloudProvider = cloudProvider;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@google-cloud/compute": "0.9.1",
     "@google-cloud/storage": "1.6.0",
     "agenda": "0.10.0",
-    "ali-oss": "5.3.0",
+    "ali-oss": "6.0.1",
     "@alicloud/pop-core": "1.7.1",
     "aws-sdk": "2.35.0",
     "azure-arm-compute": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "@google-cloud/compute": "0.9.1",
     "@google-cloud/storage": "1.6.0",
     "agenda": "0.10.0",
+    "ali-oss": "5.3.0",
+    "@alicloud/pop-core": "1.7.1",
     "aws-sdk": "2.35.0",
     "azure-arm-compute": "4.0.0",
     "azure-storage": "2.8.3",

--- a/test/test_broker/iaas.AliClient.spec.js
+++ b/test/test_broker/iaas.AliClient.spec.js
@@ -1,0 +1,148 @@
+'use strict';
+const _ = require('lodash');
+const Promise = require('bluebird');
+const logger = require('../../common/logger');
+// const errors = require('../../common/errors');
+// const utils = require('../../common/utils');
+const AliClient = require('../../data-access-layer/iaas').AliClient;
+const AliStorage = require('ali-oss');
+// const NotFound = errors.NotFound;
+// const Forbidden = errors.Forbidden;
+// const UnprocessableEntity = errors.UnprocessableEntity;
+
+const CONNECTION_WAIT_SIMULATED_DELAY = 5;
+const config = {
+  backup: {
+    retention_period_in_days: 14,
+    max_num_on_demand_backup: 2,
+    status_check_every: 120000, // (ms) Check the status of backup once every 2 mins
+    backup_restore_status_poller_timeout: 86400000, // (ms) Deployment backup/restore must finish within this timeout time (24 hrs)
+    backup_restore_status_check_every: 120000, // (ms) Check the status of deployment backup/restore once every 2 mins
+    abort_time_out: 300000, //(ms) Timeout time for abort of backup to complete
+    provider: {
+      keyId: 'key-id',
+      container: 'sample-container',
+      endpoint: 'https://sample-endpoint',
+      name: 'ali',
+      region: 'region-name',
+      key: 'secret-key'
+    }
+  }
+};
+const settings = config.backup.provider;
+const bucketMetadataResponse = {
+  buckets: [{
+    name: 'sample-container',
+    id: 'sample-container',
+    timeCreated: '2017-12-24T10:23:50.348Z',
+    updated: '2017-12-24T10:23:50.348Z',
+    location: 'region-name',
+  }]
+};
+const listFilesResponse = {
+  objects:
+    [{
+      name: 'blob1.txt',
+      lastModified: '2018-03-08T14:15:49.655Z'
+    },
+    {
+      name: 'blob2.txt',
+      lastModified: '2018-03-08T14:15:49.655Z'
+    }]
+};
+const deleteFileSuccessResponse = {
+  undefined
+};
+
+const validBlobName = 'blob1.txt';
+const bucketStub = function () {
+  return Promise.resolve(bucketMetadataResponse);
+};
+const listFilesStub = {
+  list: () => {
+    return Promise.resolve(listFilesResponse);
+  },
+  delete: (file) => {
+    if (file === validBlobName) {
+      return Promise.resolve(deleteFileSuccessResponse);
+    }
+  }
+};
+describe('iaas', function () {
+  describe('AliClient', function () {
+    describe('#AliStorage', function () {
+      it('should form an object with correct credentials', function () {
+        const responseAliStorageObject = AliClient.createStorageClient(settings);
+
+        expect(responseAliStorageObject.options.accessKeyId).to.equal(settings.keyId);
+        expect(responseAliStorageObject.options.accessKeySecret).to.equal(settings.key);
+        expect(responseAliStorageObject.options.region).to.equal(settings.region);
+        expect(responseAliStorageObject.options.endpoint.href).to.equal(settings.endpoint + '/');
+        expect(responseAliStorageObject.options.endpoint.hostname).to.equal(_.split(settings.endpoint, '//')[1]);
+        expect(responseAliStorageObject.options.endpoint.protocol).to.equal(_.split(settings.endpoint, '//')[0]);
+      });
+    });
+
+    describe('#BucketOperations', function () {
+      let sandbox, client;
+      before(function () {
+        sandbox = sinon.createSandbox();
+        client = new AliClient(settings);
+        sandbox.stub(AliStorage.prototype, 'listBuckets').withArgs({ prefix: settings.container }).callsFake(bucketStub);
+        sandbox.stub(AliStorage.prototype, 'useBucket').withArgs(settings.container).returns(listFilesStub);
+      });
+      after(function () {
+        sandbox.restore();
+      });
+
+      it('container properties should be retrived successfully', function () {
+        return client.getContainer()
+          .then(result => {
+            expect(result[0].name).to.equal(settings.container);
+            expect(result[0].id).to.equal(settings.container);
+            expect(result[0].location).to.equal(settings.region);
+          })
+          .catch(err => {
+            logger.error(err);
+            console.log(err);
+            throw new Error('expected container properties to be retrived successfully');
+          });
+      });
+      it('list of files/blobs should be returned', function () {
+        const options = {
+          prefix: 'blob'
+        };
+        const expectedResponses = [{
+          name: 'blob1.txt',
+          lastModified: '2018-03-08T14:15:49.655Z'
+        },
+        {
+          name: 'blob2.txt',
+          lastModified: '2018-03-08T14:15:49.655Z'
+        }
+        ];
+        return client.list(options)
+          .then(results => {
+            expect(results).to.be.an('array');
+            expect(results).to.have.lengthOf(2);
+            expect(results[0].name).to.equal(expectedResponses[0].name);
+            expect(results[0].lastModified).to.equal(expectedResponses[0].lastModified);
+            expect(results[1].name).to.equal(expectedResponses[1].name);
+            expect(results[1].lastModified).to.equal(expectedResponses[1].lastModified);
+          })
+          .catch(err => {
+            logger.error(err);
+            throw new Error('expected list of files/blobs to be returned successfully');
+          });
+      });
+      it('file/blob deletion should be successful', function () {
+        return client.remove(validBlobName)
+          .then(result => expect(result).to.be.undefined)
+          .catch(err => {
+            logger.error(err);
+            throw new Error('expected file/blob deletion to be successful');
+          });
+      });
+    });
+  });
+});

--- a/test/test_broker/iaas.AliClient.spec.js
+++ b/test/test_broker/iaas.AliClient.spec.js
@@ -55,12 +55,19 @@ const deleteFileSuccessResponse = {
 };
 
 const validBlobName = 'blob1.txt';
+const jsonContent = {
+  content: '{"data": "This is a sample content"}'
+};
+
 const bucketStub = function () {
   return Promise.resolve(bucketMetadataResponse);
 };
 const listFilesStub = {
   list: () => {
     return Promise.resolve(listFilesResponse);
+  },
+  get: () => {
+    return Promise.resolve(jsonContent);
   },
   delete: (file) => {
     if (file === validBlobName) {
@@ -141,6 +148,13 @@ describe('iaas', function () {
           .catch(err => {
             logger.error(err);
             throw new Error('expected file/blob deletion to be successful');
+          });
+      });
+      it('file/blob download should be successful', function () {
+        return client.downloadJson(validBlobName)
+          .then(response => expect(response).to.eql(JSON.parse(jsonContent.content)))
+          .catch(() => {
+            throw new Error('expected download to be successful');
           });
       });
     });

--- a/test/test_broker/iaas.AliClient.spec.js
+++ b/test/test_broker/iaas.AliClient.spec.js
@@ -170,6 +170,7 @@ describe('iaas', function () {
         return client.getContainer()
           .then(() => {
             logger.error('The get container call should fail');
+            throw new Error('The get container call should fails');
           })
           .catch(err => {
             expect(err).to.be.an.instanceof(NotFound);
@@ -183,6 +184,7 @@ describe('iaas', function () {
         return client.getContainer()
           .then(() => {
             logger.error('The get container call should fails');
+            throw new Error('The get container call should fails');
           })
           .catch(err => {
             expect(err.message).to.equal(`More than 1 Buckets with prefix ${settings.container} exists`);

--- a/test/test_broker/iaas.AliClient.spec.js
+++ b/test/test_broker/iaas.AliClient.spec.js
@@ -109,7 +109,6 @@ describe('iaas', function () {
     describe('#AliStorage', function () {
       it('should form an object with correct credentials', function () {
         const responseAliStorageObject = AliClient.createStorageClient(settings);
-
         expect(responseAliStorageObject.options.accessKeyId).to.equal(settings.keyId);
         expect(responseAliStorageObject.options.accessKeySecret).to.equal(settings.key);
         expect(responseAliStorageObject.options.region).to.equal(settings.region);

--- a/test/test_broker/iaas.AliClient.spec.js
+++ b/test/test_broker/iaas.AliClient.spec.js
@@ -69,6 +69,9 @@ const listFilesStub = {
   get: () => {
     return Promise.resolve(jsonContent);
   },
+  put: () => {
+    return Promise.resolve(jsonContent);
+  },
   delete: (file) => {
     if (file === validBlobName) {
       return Promise.resolve(deleteFileSuccessResponse);
@@ -156,6 +159,10 @@ describe('iaas', function () {
           .catch(() => {
             throw new Error('expected download to be successful');
           });
+      });
+      it('file/blob upload should be successful', function () {
+        return client.uploadJson(validBlobName, jsonContent)
+          .then(response => expect(response.content).to.eql(jsonContent.content));
       });
     });
   });


### PR DESCRIPTION
This PR introduces the `AliClient` to the backup-restore library.
This client will be needed to support any backup/restore operations in an `Ali` IaaS.

This will enable taking backups and storing in Object Storage and downloading these objects from ObjectStorage during restore. For now, the client performs only these functions.

This being an iterative change, the snapshot based functions will be introduced later.