### PR TITLE
Adding capabilities to deploy in non default ns

### DIFF
--- a/common/utils/index.js
+++ b/common/utils/index.js
@@ -712,7 +712,8 @@ function getAllServices() {
   const eventmesh = require('../../data-access-layer/eventmesh');
   return eventmesh.apiServerClient.getResources({
     resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
-    resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES
+    resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES,
+    allNamespaces: true
   })
     .then(serviceList => {
       let services = [];
@@ -730,7 +731,8 @@ function getAllPlansForService(serviceId) {
     resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS,
     query: {
       labelSelector: `serviceId=${serviceId}`
-    }
+    },
+    allNamespaces: true
   })
     .then(planList => {
       let plans = [];

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -585,6 +585,7 @@ class ApiServerClient {
    * @param {string} opts.resourceType - Name of operation
    * @param {string} opts.namespaceId - namesapce Id: optional
    * @param {object} opts.query - optional query
+   * @param {boolean} opts.allNamespaces - optional, get  resources across all namespaces
    */
   getResources(opts) {
     logger.debug('Get resources with opts: ', opts);
@@ -596,8 +597,14 @@ class ApiServerClient {
     }
     const namespaceId = opts.namespaceId ? opts.namespaceId : CONST.APISERVER.DEFAULT_NAMESPACE;
     return Promise.try(() => this.init())
-      .then(() => apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
-        .namespaces(namespaceId)[opts.resourceType].get(query))
+      .then(() => {
+        if (!_.get(opts, 'allNamespaces', false)) {
+          return apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION]
+            .namespaces(namespaceId)[opts.resourceType].get(query);
+        } else {
+          return apiserver.apis[opts.resourceGroup][CONST.APISERVER.API_VERSION].namespaces()[opts.resourceType].get(query);
+        }
+      })
       .then(response => _.get(response, 'body.items', []))
       .catch(err => {
         return convertToHttpErrorAndThrow(err);

--- a/interoperator/cmd/manager/main.go
+++ b/interoperator/cmd/manager/main.go
@@ -49,10 +49,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	leaderElectionNamespace := os.Getenv("POD_NAMESPACE")
+	if leaderElectionNamespace == "" {
+		leaderElectionNamespace = "default"
+	}
 	options := manager.Options{
 		LeaderElection:          true,
 		LeaderElectionID:        leaderElectionID,
-		LeaderElectionNamespace: "default",
+		LeaderElectionNamespace: leaderElectionNamespace,
 		//MetricsBindAddress:      metricsAddr,
 	}
 

--- a/interoperator/pkg/internal/resources/resources.go
+++ b/interoperator/pkg/internal/resources/resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/internal/properties"
 
@@ -63,7 +64,11 @@ func (r resourceManager) fetchResources(client kubernetes.Client, instanceID, bi
 	}
 
 	if serviceID != "" && planID != "" {
-		service, plan, err = services.FindServiceInfo(client, serviceID, planID, defaultNamespace)
+		serviceNamespace := os.Getenv("POD_NAMESPACE")
+		if serviceNamespace == "" {
+			serviceNamespace = defaultNamespace
+		}
+		service, plan, err = services.FindServiceInfo(client, serviceID, planID, serviceNamespace)
 		if err != nil {
 			log.Printf("error finding service info with id %s. %v\n", serviceID, err)
 			return nil, nil, nil, nil, err

--- a/test/test_broker/acceptance/service-broker-api.catalog.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.catalog.spec.js
@@ -28,7 +28,7 @@ describe('service-broker-api', function () {
     it('returns 200 Ok; Loads catalog from apiserver', function () {
       const oldServices = config.services;
       config.services = undefined;
-      mocks.apiServerEventMesh.nockGetResources(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, {
+      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, {
         items: [{
           spec: {
             id: 'service1',
@@ -36,7 +36,7 @@ describe('service-broker-api', function () {
           }
         }]
       });
-      mocks.apiServerEventMesh.nockGetResources(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS, {
+      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS, {
         items: [{
           spec: {
             id: 'plan1',

--- a/test/test_broker/mocks/apiServerEventMesh.js
+++ b/test/test_broker/mocks/apiServerEventMesh.js
@@ -22,6 +22,7 @@ exports.nockGetResources = nockGetResources;
 exports.nockCreateNamespace = nockCreateNamespace;
 exports.nockGetSecret = nockGetSecret;
 exports.nockDeleteNamespace = nockDeleteNamespace;
+exports.nockGetResourcesAcrossAllNamespaces = nockGetResourcesAcrossAllNamespaces;
 
 const expectedGetConfigMapResponseEnabled = {
   apiVersion: 'v1',
@@ -163,6 +164,14 @@ function nockGetSecret(secretName, namespaceId, response, times, expectedStatusC
 function nockGetResources(resourceGroup, resourceType, response, query, times, expectedStatusCode) {
   nock(apiServerHost)
     .get(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}`)
+    .query(query)
+    .times(times || 1)
+    .reply(expectedStatusCode || 200, response);
+}
+
+function nockGetResourcesAcrossAllNamespaces(resourceGroup, resourceType, response, query, times, expectedStatusCode) {
+  nock(apiServerHost)
+    .get(`/apis/${resourceGroup}/v1alpha1/namespaces//${resourceType}`)
     .query(query)
     .times(times || 1)
     .reply(expectedStatusCode || 200, response);

--- a/test/test_broker/utils.spec.js
+++ b/test/test_broker/utils.spec.js
@@ -492,7 +492,7 @@ describe('utils', function () {
           }
         }]
       };
-      mocks.apiServerEventMesh.nockGetResources(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, expectedResponse);
+      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, expectedResponse);
       return utils.getAllServices()
         .then(res => {
           expect(res).to.eql([expectedResponse.items[0].spec]);
@@ -500,7 +500,7 @@ describe('utils', function () {
         });
     });
     it('Throws error on getting list of services from apiserver', () => {
-      mocks.apiServerEventMesh.nockGetResources(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, {}, undefined, 1, 500);
+      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, {}, undefined, 1, 500);
       return utils.getAllServices()
         .catch(err => {
           expect(err.status).to.eql(500);
@@ -519,7 +519,7 @@ describe('utils', function () {
           }
         }]
       };
-      mocks.apiServerEventMesh.nockGetResources(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS, expectedResponse, {
+      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS, expectedResponse, {
         labelSelector: `serviceId=service1`
       });
       return utils.getAllPlansForService('service1')
@@ -529,7 +529,7 @@ describe('utils', function () {
         });
     });
     it('Throws error on getting list of plans from apiserver', () => {
-      mocks.apiServerEventMesh.nockGetResources(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS, {}, {
+      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS, {}, {
         labelSelector: `serviceId=service1`
       }, 1, 500);
       return utils.getAllPlansForService('service1')


### PR DESCRIPTION
* Broker gets `sfservices` and `sfplans` from all namespaces.
* Creates interoperator leader election config map in the pod namespace.
* Tries to get `sfplan` and `sfservice` details in interoperator from the pod's namespace.