### PR TITLE
Send instance type EventLog

### DIFF
--- a/jobs/MeterInstanceJob.js
+++ b/jobs/MeterInstanceJob.js
@@ -120,7 +120,13 @@ class MeterInstanceJob extends BaseJob {
   /* jshint ignore:end */
 
   static getInstanceType(event){
-    const enrichedUsageDoc = this.enrichEvent(_.get(event.spec, 'options'));
+    const options = _.get(event.spec, 'options');
+    let enrichedUsageDoc;
+    if ( options.service.plan ) {
+      enrichedUsageDoc = options
+    }else{
+      enrichedUsageDoc = this.enrichEvent(options);
+    }
     const instanceType = enrichedUsageDoc.service.plan.match(/dev/) ? CONST.INSTANCE_TYPE.DOCKER : CONST.INSTANCE_TYPE.DIRECTOR;
     return instanceType
   }
@@ -131,7 +137,7 @@ class MeterInstanceJob extends BaseJob {
       instance_id: _.get(event, 'metadata.labels.instance_guid'),
       event_type: _.get(event, 'metadata.labels.event_type')
     };
-    const instanceType = getInstanceType(event);
+    const instanceType = MeterInstanceJob.getInstanceType(event);
     if (err !== undefined) {
       const now = new Date();
       const secondsSinceEpoch = Math.round(now.getTime() / 1000);

--- a/jobs/MeterInstanceJob.js
+++ b/jobs/MeterInstanceJob.js
@@ -119,16 +119,16 @@ class MeterInstanceJob extends BaseJob {
   }
   /* jshint ignore:end */
 
-  static getInstanceType(event){
+  static getInstanceType(event) {
     const options = _.get(event.spec, 'options');
     let enrichedUsageDoc;
-    if ( options.service.plan ) {
-      enrichedUsageDoc = options
-    }else{
+    if (options.service.plan) {
+      enrichedUsageDoc = options;
+    } else {
       enrichedUsageDoc = this.enrichEvent(options);
     }
     const instanceType = enrichedUsageDoc.service.plan.match(/dev/) ? CONST.INSTANCE_TYPE.DOCKER : CONST.INSTANCE_TYPE.DIRECTOR;
-    return instanceType
+    return instanceType;
   }
 
   static _logMeteringEvent(err, event) {

--- a/jobs/MeterInstanceJob.js
+++ b/jobs/MeterInstanceJob.js
@@ -119,12 +119,19 @@ class MeterInstanceJob extends BaseJob {
   }
   /* jshint ignore:end */
 
+  static getInstanceType(event){
+    const enrichedUsageDoc = this.enrichEvent(_.get(event.spec, 'options'));
+    const instanceType = enrichedUsageDoc.service.plan.match(/dev/) ? CONST.INSTANCE_TYPE.DOCKER : CONST.INSTANCE_TYPE.DIRECTOR;
+    return instanceType
+  }
+
   static _logMeteringEvent(err, event) {
     const eventLogger = EventLogInterceptor.getInstance(config.internal.event_type, 'internal');
     const request = {
       instance_id: _.get(event, 'metadata.labels.instance_guid'),
       event_type: _.get(event, 'metadata.labels.event_type')
     };
+    const instanceType = getInstanceType(event);
     if (err !== undefined) {
       const now = new Date();
       const secondsSinceEpoch = Math.round(now.getTime() / 1000);
@@ -138,7 +145,8 @@ class MeterInstanceJob extends BaseJob {
           statusCode: _.get(err,'status', CONST.HTTP_STATUS_CODE.TIMEOUT)
         };
         const check_res_body = false;
-        return eventLogger.publishAndAuditLogEvent(CONST.URL.METERING_USAGE, CONST.HTTP_METHOD.PUT, request, resp, check_res_body);
+        // if sku contains dev sent instance type as docker
+        return eventLogger.publishAndAuditLogEvent(CONST.URL.METERING_USAGE, CONST.HTTP_METHOD.PUT, request, resp, check_res_body, instanceType);
       }
     } else {
       logger.debug('Publishing log event for success for event:', event);
@@ -146,7 +154,7 @@ class MeterInstanceJob extends BaseJob {
         statusCode: CONST.HTTP_STATUS_CODE.OK
       };
       const check_res_body = false;
-      return eventLogger.publishAndAuditLogEvent(CONST.URL.METERING_USAGE, CONST.HTTP_METHOD.PUT, request, resp, check_res_body);
+      return eventLogger.publishAndAuditLogEvent(CONST.URL.METERING_USAGE, CONST.HTTP_METHOD.PUT, request, resp, check_res_body, instanceType);
     }
   }
 

--- a/jobs/MeterInstanceJob.js
+++ b/jobs/MeterInstanceJob.js
@@ -145,7 +145,6 @@ class MeterInstanceJob extends BaseJob {
           statusCode: _.get(err,'status', CONST.HTTP_STATUS_CODE.TIMEOUT)
         };
         const check_res_body = false;
-        // if sku contains dev sent instance type as docker
         return eventLogger.publishAndAuditLogEvent(CONST.URL.METERING_USAGE, CONST.HTTP_METHOD.PUT, request, resp, check_res_body, instanceType);
       }
     } else {

--- a/test/test_broker/jobs.MeteringInstanceJobs.spec.js
+++ b/test/test_broker/jobs.MeteringInstanceJobs.spec.js
@@ -152,6 +152,23 @@ describe('Jobs', () => {
     });
 
 
+    describe('#getInstanceType', () => {
+      it('should get the instance type as docker when SKU contain dev', () => {
+        options_json.service.service_guid = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
+        options_json.service.plan_guid = '466c5078-df6e-427d-8fb2-c76af50c0f56';
+        const dummy_event = getDummyEvent(options_json);
+        const val = MeterInstanceJob.getInstanceType(dummy_event)
+        expect(val).to.eql(CONST.INSTANCE_TYPE.DOCKER);
+      });
+      it('should get the instance type as director when SKU does not contain dev', () => {
+        options_json.service.service_guid = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
+        options_json.service.plan_guid = 'bc158c9a-7934-401e-94ab-057082a5073f';
+        const dummy_event = getDummyEvent(options_json);
+        const val = MeterInstanceJob.getInstanceType(dummy_event)
+        expect(val).to.eql(CONST.INSTANCE_TYPE.DIRECTOR);
+      });
+    });
+
     describe('#sendEvent', () => {
 
       let publishAndAuditLogEventStub;

--- a/test/test_broker/jobs.MeteringInstanceJobs.spec.js
+++ b/test/test_broker/jobs.MeteringInstanceJobs.spec.js
@@ -163,9 +163,18 @@ describe('Jobs', () => {
       it('should get the instance type as director when SKU does not contain dev', () => {
         options_json.service.service_guid = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
         options_json.service.plan_guid = 'bc158c9a-7934-401e-94ab-057082a5073f';
+        options_json.service.plan = undefined;
         const dummy_event = getDummyEvent(options_json);
         const val = MeterInstanceJob.getInstanceType(dummy_event)
         expect(val).to.eql(CONST.INSTANCE_TYPE.DIRECTOR);
+      });
+      it('should get the instance type as docker when document is already enriched', () => {
+        options_json.service.service_guid = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
+        options_json.service.plan_guid = 'bc158c9a-7934-401e-94ab-057082a5073f';
+        options_json.service.plan = 'dev';
+        const dummy_event = getDummyEvent(options_json);
+        const val = MeterInstanceJob.getInstanceType(dummy_event)
+        expect(val).to.eql(CONST.INSTANCE_TYPE.DOCKER);
       });
     });
 


### PR DESCRIPTION
- The event logs for both docker and director are now sent under 'director' nesting.
this changes conditionally sends docker/director based on the nature of plan SKU