### PR TITLE
Using dummy context while computing outdated deployments

### DIFF
--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -267,7 +267,7 @@ class ServiceFabrikAdminController extends FabrikBaseController {
       return _
         .chain(deployment)
         .pick('name', 'releases', 'stemcell')
-        .set('diff', utils.unifyDiffResult(deployment))
+        .set('diff', utils.unifyDiffResult(deployment, true))
         .set('instance', _
           .chain(deployment.entity)
           .pick('name', 'last_operation', 'space_guid', 'service_plan_id', 'service_plan_guid', 'dashboard_url')
@@ -280,8 +280,11 @@ class ServiceFabrikAdminController extends FabrikBaseController {
     return this
       .findOutdatedDeployments()
       .then(deployments => {
+        const mappedDeployments = _.map(deployments, mapDeployment);
         const locals = {
-          deployments: _.map(deployments, mapDeployment)
+          deployments: _.filter(mappedDeployments, deployment => {
+            return !_.isEmpty(deployment.diff);
+          })
         };
         res.format({
           html: () => res

--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -346,25 +346,20 @@ class ServiceFabrikAdminController extends FabrikBaseController {
           logger.warn(`Found deployment '${deployment.name}' without service instance`);
           return false;
         }
-        return eventmesh.apiServerClient.getPlatformContext({
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          resourceId: this.getInstanceId(deployment.name)
-        })
-          .then(context => {
-            const opts = {};
-            opts.context = context;
-            return deployment.directorService
-              .diffManifest(deployment.name, opts)
-              .then(result => _
-                .chain(deployment)
-                .assign(_.pick(result, 'diff', 'manifest'))
-                .get('diff')
-                .size()
-                .gt(0)
-                .value()
-              );
-          });
+        const opts = {};
+        opts.context = {
+          platform: 'cloudfoundry'
+        };
+        return deployment.directorService
+          .diffManifest(deployment.name, opts)
+          .then(result => _
+            .chain(deployment)
+            .assign(_.pick(result, 'diff', 'manifest'))
+            .get('diff')
+            .size()
+            .gt(0)
+            .value()
+          );
       })
       .tap(deployments =>
         logger.info('Found outdated deployments', _.map(deployments, 'name'))

--- a/common/constants.js
+++ b/common/constants.js
@@ -18,6 +18,17 @@ module.exports = Object.freeze({
     BOSH_PROCESSING: 'processing',
     BOSH_CANCELLING: 'cancelling'
   },
+  BOSH_DEPLOYMENT_MANIFEST_SECTIONS: [
+    'features',
+    'releases',
+    'stemcells',
+    'update',
+    'instance_groups',
+    'addons',
+    'properties',
+    'variables',
+    'tags'
+  ],
   FABRIK_SCHEDULED_OPERATION: 'scheduled',
   FABRIK_OPERATION_STAGGERED: 'staggered',
   FABRIK_OPERATION_COUNT_EXCEEDED: 'operation count exceeded',

--- a/common/utils/index.js
+++ b/common/utils/index.js
@@ -550,19 +550,31 @@ function hasChangesInForbiddenSections(diff) {
   return false;
 }
 
-function unifyDiffResult(result) {
+function unifyDiffResult(result, ignoreTags) {
   const diff = [];
+  let validDeploymentSection = true;
   _.each(result.diff, _.spread((value, type) => {
-    switch (type) {
-      case 'added':
-        diff.push(`+${value}`);
-        break;
-      case 'removed':
-        diff.push(`-${value}`);
-        break;
-      default:
-        diff.push(` ${value}`);
-        break;
+
+    if(_.includes(value, 'tags:') && ignoreTags) {
+      validDeploymentSection = false;
+    } else if(!validDeploymentSection && _.findIndex(CONST.BOSH_DEPLOYMENT_MANIFEST_SECTIONS, section => {
+      return _.includes(value, section);
+    }) != -1) {
+      validDeploymentSection = true;
+    }
+
+    if(validDeploymentSection) {
+      switch (type) {
+        case 'added':
+          diff.push(`+${value}`);
+          break;
+        case 'removed':
+          diff.push(`-${value}`);
+          break;
+        default:
+          diff.push(` ${value}`);
+          break;
+      }
     }
   }));
   return diff;

--- a/test/test_broker/acceptance/service-fabrik-admin.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.instances.director.spec.js
@@ -94,17 +94,6 @@ describe('service-fabrik-admin', function () {
           mocks.cloudController.getServiceInstances(plan_guid, numberOfDeployments);
           mocks.director.getDeploymentManifest(numberOfDeployments);
           mocks.director.diffDeploymentManifest(numberOfDeployments);
-          _.each(_.range(numberOfDeployments), index => mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, mocks.director.uuidByIndex(index), {
-            spec: {
-              options: JSON.stringify({
-                context: {
-                  platform: CONST.PLATFORM.CF,
-                  space_guid: space_guid,
-                  organization_guid: org_guid
-                }
-              })
-            }
-          }, 1));
           return chai
             .request(apps.internal)
             .get(`${base_url}/deployments/outdated`)

--- a/test/test_broker/utils.spec.js
+++ b/test/test_broker/utils.spec.js
@@ -540,4 +540,132 @@ describe('utils', function () {
     });
   });
 
+  describe('#unifyDiffResult', () => {
+    let sampleDiff = { '0': [ 'stemcells:', 'added' ],
+    '1': [ '- alias: ubuntu-xenial', 'added' ],
+    '2': [ '  name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent', 'added' ],
+    '3': [ '  version: \'170.24\'', 'added' ],
+    '4': [ '', null ],
+    '5': [ 'releases:', null ],
+    '6': [ '- name: blueprint', 'added' ],
+    '7': [ '  version: 1.23.0', 'added' ],
+    '8': [ '- name: service-fabrik', 'added' ],
+    '9': [ '  version: 3.110.0', 'added' ],
+    '10': [ '', null ],
+    '11': [ 'update:', 'added' ],
+    '12': [ '  canaries: 0', 'added' ],
+    '13': [ '  max_in_flight: 50', 'added' ],
+    '14': [ '  canary_watch_time: 1000-100000', 'added' ],
+    '15': [ '  update_watch_time: 1000-100000', 'added' ],
+    '16': [ '  serial: false', 'added' ],
+    '17': [ '', null ],
+    '18': [ 'addons:', 'added' ],
+    '19': [ '- name: iptables-manager', 'added' ],
+    '20': [ '  jobs:', 'added' ],
+    '21': [ '  - name: iptables-manager', 'added' ],
+    '22': [ '    release: service-fabrik', 'added' ],
+    '23': [ '    properties:', 'added' ],
+    '24': 
+     [ '      allow_ips_list: 10.11.13.80',
+       'added' ],
+    '25': 
+     [ '      block_ips_list: 10.11.0.0/18,10.11.64.0/18,10.11.128.0/18',
+       'added' ],
+    '26': [ '', null ],
+    '27': 
+     [ 'name: service-fabrik-0394-34293c64-1c99-4611-9146-fcac7756101d',
+       'added' ],
+    '28': [ '', null ],
+    '29': [ 'tags:', 'added' ],
+    '30': 
+     [ '  organization_guid: 57caa1ea-b47c-408c-8e58-1610b20c9faf',
+       'added' ],
+    '31': [ '  platform: cloudfoundry', 'added' ],
+    '32': 
+     [ '  space_guid: f6be1038-fbba-4ee5-89b1-f801d0eb144d',
+       'added' ],
+    '33': [ '', null ] }
+
+    it('should ignore tags in diff when ignoreTags flag is true', () => {
+      let dummyOutdatedResult = {
+        diff: sampleDiff
+      };
+      let expectedOp = [
+        "+stemcells:",
+        "+- alias: ubuntu-xenial",
+        "+  name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent",
+        "+  version: '170.24'",
+        " ",
+        " releases:",
+        "+- name: blueprint",
+        "+  version: 1.23.0",
+        "+- name: service-fabrik",
+        "+  version: 3.110.0",
+        " ",
+        "+update:",
+        "+  canaries: 0",
+        "+  max_in_flight: 50",
+        "+  canary_watch_time: 1000-100000",
+        "+  update_watch_time: 1000-100000",
+        "+  serial: false",
+        " ",
+        "+addons:",
+        "+- name: iptables-manager",
+        "+  jobs:",
+        "+  - name: iptables-manager",
+        "+    release: service-fabrik",
+        "+    properties:",
+        "+      allow_ips_list: 10.11.13.80",
+        "+      block_ips_list: 10.11.0.0/18,10.11.64.0/18,10.11.128.0/18",
+        " ",
+        "+name: service-fabrik-0394-34293c64-1c99-4611-9146-fcac7756101d",
+        " "
+      ];
+      
+      let actualOp = utils.unifyDiffResult(dummyOutdatedResult, true);
+      expect(actualOp).to.deep.equal(expectedOp);
+    });
+
+    it('should not ignore tags in diff by default', () => {
+      let dummyOutdatedResult = {
+        diff: sampleDiff
+      };
+      let expectedOp = [ "+stemcells:",
+      "+- alias: ubuntu-xenial",
+      "+  name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent",
+      "+  version: '170.24'",
+      " ",
+      " releases:",
+      "+- name: blueprint",
+      "+  version: 1.23.0",
+      "+- name: service-fabrik",
+      "+  version: 3.110.0",
+      " ",
+      "+update:",
+      "+  canaries: 0",
+      "+  max_in_flight: 50",
+      "+  canary_watch_time: 1000-100000",
+      "+  update_watch_time: 1000-100000",
+      "+  serial: false",
+      " ",
+      "+addons:",
+      "+- name: iptables-manager",
+      "+  jobs:",
+      "+  - name: iptables-manager",
+      "+    release: service-fabrik",
+      "+    properties:",
+      "+      allow_ips_list: 10.11.13.80",
+      "+      block_ips_list: 10.11.0.0/18,10.11.64.0/18,10.11.128.0/18",
+      " ",
+      "+name: service-fabrik-0394-34293c64-1c99-4611-9146-fcac7756101d",
+      " ",
+      "+tags:",
+      "+  organization_guid: 57caa1ea-b47c-408c-8e58-1610b20c9faf",
+      "+  platform: cloudfoundry",
+      "+  space_guid: f6be1038-fbba-4ee5-89b1-f801d0eb144d",
+      " "]
+      let actualOp = utils.unifyDiffResult(dummyOutdatedResult);
+      expect(actualOp).to.deep.equal(expectedOp);
+    });
+  });
 });


### PR DESCRIPTION
* This PR removes unnecessary per deployment call to ApiServer for fetching `context` while computing outdated deployments.