### PR TITLE
Don't merge spec.parameters in sfserviceinstance on update call

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -196,7 +196,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             }
           });
         } else {
-          return eventmesh.apiServerClient.patchOSBResource({
+          return eventmesh.apiServerClient.updateOSBResource({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
             resourceId: req.params.instance_id,
@@ -253,7 +253,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
       resourceId: req.params.instance_id
     })
-      .then(() => eventmesh.apiServerClient.patchOSBResource({
+      .then(() => eventmesh.apiServerClient.updateOSBResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
         resourceId: req.params.instance_id,

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -938,35 +938,6 @@ class ApiServerClient {
   }
 
   /**
-   * @description Patches OSB Resource in Apiserver with the opts
-   * Use this method when you want to append something in status.response or spec
-   * @param {string} opts.resourceGroup - Name of resource group ex. backup.servicefabrik.io
-   * @param {string} opts.resourceType - Type of resource ex. defaultbackup
-   * @param {string} opts.resourceId - Unique id of resource ex. backup_guid
-   * @param {string} opts.namespaceId - Unique id of namespace
-   */
-  patchOSBResource(opts) {
-    logger.info('Patching resource options with opts: ', opts);
-    assert.ok(opts.resourceGroup, 'Property \'resourceGroup\' is required to patch options');
-    assert.ok(opts.resourceType, 'Property \'resourceType\' is required to patch options');
-    assert.ok(opts.resourceId, 'Property \'resourceId\' is required to patch options');
-    assert.ok(opts.metadata || opts.spec || opts.status, 'Property \'metadata\' or \'options\' or \'status\' is required to patch resource');
-    const namespaceId = opts.namespaceId ? opts.namespaceId : (this.getNamespaceId(opts.resourceType === CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS ?
-      _.get(opts, 'spec.instance_id') : opts.resourceId
-    ));
-    return this.getResource(_.merge(opts, {
-      namespaceId: namespaceId
-    }))
-      .then(resource => {
-        if (opts.spec && resource.spec) {
-          const spec = _.merge(resource.spec, camelcaseKeys(opts.spec));
-          _.set(opts, 'spec', spec);
-        }
-        return this.updateOSBResource(opts);
-      });
-  }
-
-  /**
    * @description Remove finalizers from finalizer list
    * @param {string} opts.resourceGroup - Name of resource group 
    * @param {string} opts.resourceType - Type of resource 

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -53,7 +53,7 @@ describe('service-broker-api-2.0', function () {
       const dashboard_url_with_template = `${protocol}://${host}/manage/dashboards/director/instances/${instance_id}?planName=v1.0-small&serviceId=${service_id}`;
       const container = backupStore.containerName;
       const deferred = Promise.defer();
-      Promise.onPossiblyUnhandledRejection(() => {});
+      Promise.onPossiblyUnhandledRejection(() => { });
       let getScheduleStub, delayStub;
 
       before(function () {
@@ -602,7 +602,6 @@ describe('service-broker-api-2.0', function () {
           });
           const testPayload = _.cloneDeep(payload1);
           testPayload.spec = camelcaseKeys(payload1.spec);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, testPayload);
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}?accepts_incomplete=true`)
@@ -650,7 +649,6 @@ describe('service-broker-api-2.0', function () {
           });
           const testPayload = _.cloneDeep(payload);
           testPayload.spec = camelcaseKeys(payload.spec);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, testPayload);
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}?accepts_incomplete=true`)
@@ -827,7 +825,6 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           return chai.request(app)
@@ -896,7 +893,6 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           return chai.request(app)
@@ -932,7 +928,6 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           return chai.request(app)

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -220,13 +220,13 @@ describe('eventmesh', () => {
         };
         nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload);
         return apiserver.createResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            options: {
-              opts: 'sample_options'
-            }
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          options: {
+            opts: 'sample_options'
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(201);
             expect(res.body).to.eql({});
@@ -253,16 +253,16 @@ describe('eventmesh', () => {
         };
         nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload);
         return apiserver.createResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            labels: {
-              instance_guid: 'deployment1'
-            },
-            options: {
-              opts: 'sample_options'
-            }
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          labels: {
+            instance_guid: 'deployment1'
+          },
+          options: {
+            opts: 'sample_options'
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(201);
             expect(res.body).to.eql({});
@@ -298,22 +298,22 @@ describe('eventmesh', () => {
         };
         nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload1);
         return apiserver.createResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            labels: {
-              instance_guid: 'deployment1'
-            },
-            options: {
-              opts: 'sample_options'
-            },
-            status: {
-              state: 'create',
-              response: {
-                resp: 'resp'
-              }
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          labels: {
+            instance_guid: 'deployment1'
+          },
+          options: {
+            opts: 'sample_options'
+          },
+          status: {
+            state: 'create',
+            response: {
+              resp: 'resp'
             }
-          })
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(201);
             expect(res.body).to.eql(expectedResponse);
@@ -343,16 +343,16 @@ describe('eventmesh', () => {
         };
         nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, expectedResponse, payload1, 404);
         return apiserver.createResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            labels: {
-              instance_guid: 'deployment1'
-            },
-            options: {
-              opts: 'sample_options'
-            }
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          labels: {
+            instance_guid: 'deployment1'
+          },
+          options: {
+            opts: 'sample_options'
+          }
+        })
           .catch(err => {
             expect(err.status).to.eql(404);
             verify();
@@ -372,13 +372,13 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedResponse, payload);
         return apiserver.updateResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            options: {
-              opts: 'sample_options'
-            }
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          options: {
+            opts: 'sample_options'
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -403,14 +403,14 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedResponse, payload);
         return apiserver.updateResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            metadata: payload.metadata,
-            options: {
-              opts: 'sample_options'
-            }
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          metadata: payload.metadata,
+          options: {
+            opts: 'sample_options'
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -435,16 +435,16 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedResponse, payload);
         return apiserver.updateResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            status: {
-              state: 'create',
-              response: {
-                resp: 'resp'
-              }
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          status: {
+            state: 'create',
+            response: {
+              resp: 'resp'
             }
-          })
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -478,20 +478,20 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedResponse, payload1);
         return apiserver.updateResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            metadata: payload1.metadata,
-            options: {
-              opts: 'sample_options'
-            },
-            status: {
-              state: 'create',
-              response: {
-                resp: 'resp'
-              }
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          metadata: payload1.metadata,
+          options: {
+            opts: 'sample_options'
+          },
+          status: {
+            state: 'create',
+            response: {
+              resp: 'resp'
             }
-          })
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql(expectedResponse);
@@ -512,13 +512,13 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedResponse, payload1, 404);
         return apiserver.updateResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            options: {
-              opts: 'sample_options'
-            }
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          options: {
+            opts: 'sample_options'
+          }
+        })
           .catch(err => {
             expect(err.status).to.eql(404);
             verify();
@@ -547,16 +547,16 @@ describe('eventmesh', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetResponse);
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedResponse, payload);
         return apiserver.patchResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            status: {
-              response: {
-                resp: 'resp1',
-                resp2: 'resp2'
-              }
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          status: {
+            response: {
+              resp: 'resp1',
+              resp2: 'resp2'
             }
-          })
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -584,14 +584,14 @@ describe('eventmesh', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetResponse);
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedResponse, payload);
         return apiserver.patchResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            options: {
-              opt: 'opt1',
-              opt2: 'opt2'
-            }
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          options: {
+            opt: 'opt1',
+            opt2: 'opt2'
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -646,25 +646,25 @@ describe('eventmesh', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetResponse);
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedResponse, payload1);
         return apiserver.patchResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            metadata: {
-              labels: {
-                instance_guid: 'deployment1'
-              }
-            },
-            options: {
-              opt2: 'sample_options'
-            },
-            status: {
-              state: 'in_progress',
-              response: {
-                resp: 'resp1',
-                resp2: 'resp2'
-              }
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          metadata: {
+            labels: {
+              instance_guid: 'deployment1'
             }
-          })
+          },
+          options: {
+            opt2: 'sample_options'
+          },
+          status: {
+            state: 'in_progress',
+            response: {
+              resp: 'resp1',
+              resp2: 'resp2'
+            }
+          }
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -679,10 +679,10 @@ describe('eventmesh', () => {
         const expectedResponse = {};
         nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', undefined, expectedResponse);
         return apiserver.deleteResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -694,11 +694,11 @@ describe('eventmesh', () => {
         nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'namespace', expectedResponse);
         mocks.apiServerEventMesh.nockDeleteNamespace('namespace', {}, 1);
         return apiserver.deleteResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
-            namespaceId: 'namespace'
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
+          namespaceId: 'namespace'
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -708,10 +708,10 @@ describe('eventmesh', () => {
       it('Throws error when delete fails', () => {
         nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', undefined, {}, 404);
         return apiserver.deleteResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+        })
           .catch(err => {
             expect(err.status).to.eql(404);
             verify();
@@ -731,13 +731,13 @@ describe('eventmesh', () => {
         };
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedResponse, payload);
         return apiserver.updateLastOperationValue({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            operationName: CONST.OPERATION_TYPE.BACKUP,
-            operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-            value: 'backup1'
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP,
+          operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+          value: 'backup1'
+        })
           .then(res => {
             expect(res.statusCode).to.eql(200);
             expect(res.body).to.eql({});
@@ -750,10 +750,10 @@ describe('eventmesh', () => {
       it('Gets resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetDeploymentResponse);
         return apiserver.getResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+        })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource);
             verify();
@@ -764,10 +764,10 @@ describe('eventmesh', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
           CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 200);
         return apiserver.getResourceListByState({
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            stateList: [CONST.APISERVER.RESOURCE_STATE.WAITING]
-          })
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          stateList: [CONST.APISERVER.RESOURCE_STATE.WAITING]
+        })
           .then(res => {
             expect(res).to.eql([sampleDeploymentResource]);
             verify();
@@ -778,10 +778,10 @@ describe('eventmesh', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
           CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [], 1, 200);
         return apiserver.getResourceListByState({
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            stateList: [CONST.APISERVER.RESOURCE_STATE.WAITING]
-          })
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          stateList: [CONST.APISERVER.RESOURCE_STATE.WAITING]
+        })
           .then(res => {
             expect(res).to.eql([]);
             verify();
@@ -792,10 +792,10 @@ describe('eventmesh', () => {
         mocks.apiServerEventMesh.nockGetResourceListByState(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
           CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, [CONST.APISERVER.RESOURCE_STATE.WAITING], [expectedGetDeploymentResponse], 1, 404);
         return apiserver.getResourceListByState({
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            stateList: [CONST.APISERVER.RESOURCE_STATE.WAITING]
-          })
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          stateList: [CONST.APISERVER.RESOURCE_STATE.WAITING]
+        })
           .catch(err => {
             expect(err.status).to.eql(404);
             verify();
@@ -808,12 +808,12 @@ describe('eventmesh', () => {
       it('Gets last operation on resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetDeploymentResponse);
         return apiserver.getLastOperationValue({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            operationName: CONST.OPERATION_TYPE.BACKUP,
-            operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP,
+          operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP
+        })
           .then(res => {
             expect(res).to.eql('backup1');
             verify();
@@ -825,12 +825,12 @@ describe('eventmesh', () => {
       it('Gets operation status on resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetDeploymentResponse);
         return apiserver.getResourceStatus({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            operationName: CONST.OPERATION_TYPE.BACKUP,
-            operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP,
+          operationType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP
+        })
           .then(res => {
             expect(res.state).to.eql(expectedGetDeploymentResponse.status.state);
             expect(res.response).to.eql(JSON.parse(expectedGetDeploymentResponse.status.response));
@@ -843,11 +843,11 @@ describe('eventmesh', () => {
       it('Gets options of resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetDeploymentResponse);
         return apiserver.getOptions({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            operationName: CONST.OPERATION_TYPE.BACKUP
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP
+        })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource.spec.options);
             verify();
@@ -859,11 +859,11 @@ describe('eventmesh', () => {
       it('Gets response of resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetDeploymentResponse);
         return apiserver.getResponse({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            operationName: CONST.OPERATION_TYPE.BACKUP
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP
+        })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource.status.response);
             verify();
@@ -875,11 +875,11 @@ describe('eventmesh', () => {
       it('Gets state of resource', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetDeploymentResponse);
         return apiserver.getResourceState({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
-            operationName: CONST.OPERATION_TYPE.BACKUP
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          operationName: CONST.OPERATION_TYPE.BACKUP
+        })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource.status.state);
             verify();
@@ -1051,10 +1051,10 @@ describe('eventmesh', () => {
       it('Gets getPlatformContext', () => {
         nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, 'deployment1', 'default', expectedGetDeploymentResponse);
         return apiserver.getPlatformContext({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
-          })
+          resourceId: 'deployment1',
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR
+        })
           .then(res => {
             expect(res).to.eql(sampleDeploymentResource.spec.options.context);
             verify();
@@ -1134,181 +1134,6 @@ describe('eventmesh', () => {
         return apiserver.getSecret('secret')
           .catch(err => {
             expect(err.status).to.eql(500);
-            verify();
-          });
-      });
-    });
-    describe('patchOSBResource', () => {
-      it('Patches osb resource with spec and status', () => {
-        const expectedGetResponse = {
-          spec: {
-            plan_id: 'plan1',
-            params: {
-              foo: 'bar'
-            },
-            context: {
-              organization_guid: 'org1',
-              space_guid: 'space1'
-            }
-          },
-          status: {
-            state: 'in_queue',
-            description: 'desc'
-          }
-        };
-        const expectedResponse = {};
-        const payload = {
-          spec: {
-            planId: 'plan2',
-            params: {
-              foo: 'bar'
-            },
-            context: {
-              organization_guid: 'org2',
-              space_guid: 'space2'
-            },
-            serviceId: 'service2'
-          },
-          metadata: {
-            labels: {
-              state: 'in_progress'
-            }
-          },
-          status: {
-            state: 'in_progress',
-            description: ''
-          }
-        };
-        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'default', expectedGetResponse);
-        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'default', expectedResponse, payload);
-        return apiserver.patchOSBResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
-            spec: {
-              plan_id: 'plan2',
-              service_id: 'service2',
-              context: {
-                organization_guid: 'org2',
-                space_guid: 'space2'
-              }
-            },
-            status: {
-              state: 'in_progress',
-              description: ''
-            }
-          })
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql({});
-            verify();
-          });
-      });
-
-      it('Patches osb resource in a namespace with spec and status', () => {
-        const expectedGetResponse = {
-          spec: {
-            plan_id: 'plan1',
-            params: {
-              foo: 'bar'
-            },
-            context: {
-              organization_guid: 'org1',
-              space_guid: 'space1'
-            }
-          },
-          status: {
-            state: 'in_queue',
-            description: 'desc'
-          }
-        };
-        const expectedResponse = {};
-        const payload = {
-          spec: {
-            planId: 'plan2',
-            params: {
-              foo: 'bar'
-            },
-            context: {
-              organization_guid: 'org2',
-              space_guid: 'space2'
-            },
-            serviceId: 'service2'
-          },
-          metadata: {
-            labels: {
-              state: 'in_progress'
-            }
-          },
-          status: {
-            state: 'in_progress',
-            description: ''
-          }
-        };
-        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'namespace-id', expectedGetResponse);
-        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'namespace-id', expectedResponse, payload);
-        return apiserver.patchOSBResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
-            namespaceId: 'namespace-id',
-            spec: {
-              plan_id: 'plan2',
-              service_id: 'service2',
-              context: {
-                organization_guid: 'org2',
-                space_guid: 'space2'
-              }
-            },
-            status: {
-              state: 'in_progress',
-              description: ''
-            }
-          })
-          .then(res => {
-            expect(res.statusCode).to.eql(200);
-            expect(res.body).to.eql({});
-            verify();
-          });
-      });
-
-      it('Patches osb resource fails with error', () => {
-        const expectedGetResponse = {
-          spec: {
-            plan_id: 'plan1',
-            params: {
-              foo: 'bar'
-            },
-            context: {
-              organization_guid: 'org1',
-              space_guid: 'space1'
-            }
-          },
-          status: {
-            state: 'in_queue',
-            description: 'desc'
-          }
-        };
-        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'default', expectedGetResponse);
-        return apiserver.patchOSBResource({
-            resourceId: 'deployment1',
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
-            spec: {
-              plan_id: 'plan2',
-              service_id: 'service2',
-              context: {
-                organization_guid: 'org2',
-                space_guid: 'space2'
-              }
-            },
-            status: {
-              state: 'in_progress',
-              description: ''
-            }
-          })
-          .catch(err => {
-            expect(err.status).to.eql(404);
             verify();
           });
       });


### PR DESCRIPTION
Earlier on receiving update call, we were doing deep merge of spec. It was leading to merging of parameters field also.
For example old existing spec was like below:
```javascript
spec: {
  parameters: {
    param1: value1
  }
}
```
Now when user fires update call with -c params as `-c {param2 : value2}`
Ideally old parameters should get overwritten in spec object but with current approach it was resulting in following spec because of deep merging
```javascript
spec: {
  parameters: {
    param1: value1,
    param2: value2,
  }
}
```

With this fix, we will start getting desired result