### PR TITLE
Choose options if appliedOptions is empty

### DIFF
--- a/webhooks/pkg/webhooks/manager/event.go
+++ b/webhooks/pkg/webhooks/manager/event.go
@@ -238,7 +238,9 @@ func (e *Event) getMeteringEvents() ([]*v1alpha1.Sfevent, error) {
 		meteringDocs = append(meteringDocs, e.getMeteringEvent(options, c.MeterStart, c.CreateEvent))
 	case c.DeleteEvent:
 		chosenOptions := oldAppliedOptions
-		if e.isDocker() {
+		// When create fails , field of appliedOptions can be empty
+		// In such cases chose options
+		if chosenOptions.ServiceID == "" {
 			chosenOptions = options
 		}
 		if err = e.validateOptions(chosenOptions); err != nil {

--- a/webhooks/pkg/webhooks/manager/event_test.go
+++ b/webhooks/pkg/webhooks/manager/event_test.go
@@ -576,7 +576,7 @@ var _ = Describe("Event", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).To(Equal("ServiceID not found"))
 		})
-		It("Should throw error when AppliedOptions is empty when event type is delete", func() {
+		It("Should throw error when AppliedOptions is empty and Options is empty", func() {
 			evt, _ := NewEvent(&ar)
 			evt.crd.Status.State = "delete"
 			evt.crd.SetLastOperation(resources.GenericLastOperation{
@@ -584,6 +584,7 @@ var _ = Describe("Event", func() {
 				State: "delete",
 			})
 			evt.oldCrd.Status.AppliedOptions = "{}"
+			evt.crd.Spec.Options = "{}"
 			_, err := evt.getMeteringEvents()
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).To(Equal("ServiceID not found"))


### PR DESCRIPTION
When create of director/docker fails the 'appliedOptions' field is empty.
In such scenarios use 'options'