### PR TITLE
Adding 'timeBased=true' query paramater to metering URL

### DIFF
--- a/data-access-layer/metering/MeteringClient.js
+++ b/data-access-layer/metering/MeteringClient.js
@@ -53,6 +53,9 @@ class MeteringClient extends HttpClient {
       auth: {
         bearer: this.tokenInfo.accessToken
       },
+      qs: {
+        timeBased: 'true'
+      },
       body: usageRecords,
       json: true
     }, CONST.HTTP_STATUS_CODE.OK);

--- a/test/test_broker/mocks/metering.js
+++ b/test/test_broker/mocks/metering.js
@@ -34,5 +34,8 @@ function mockSendUsageRecord(token, response_code, test_body_fn) {
       }
     })
     .put('/usage/v2/usage/documents', test_body_fn || true)
+    .query({
+      timeBased: 'true'
+    })
     .reply(response_code);
 }


### PR DESCRIPTION
* As we are reporting time based usage to MaaS, we need to add above query parameter to metering URL.