### PR TITLE
Adding schedule backup call after successful BoshBasedRestore for pitr enabled services

### DIFF
--- a/operators/BaseDirectorService.js
+++ b/operators/BaseDirectorService.js
@@ -10,6 +10,9 @@ const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const BoshDirectorClient = bosh.BoshDirectorClient;
 const Networks = bosh.manifest.Networks;
 const BaseService = require('./BaseService');
+const cf = require('../data-access-layer/cf');
+const retry = utils.retry;
+const CONST = require('../common/constants');
 
 class BaseDirectorService extends BaseService {
   constructor(plan) {
@@ -83,6 +86,25 @@ class BaseDirectorService extends BaseService {
     return this.getNetworks(index)[this.networkName];
   }
 
+  reScheduleBackup(opts) {
+    const options = {
+      instance_id: opts.instance_id,
+      repeatInterval: 'daily',
+      type: CONST.BACKUP.TYPE.ONLINE
+    };
+
+    if (this.plan.service.backup_interval) {
+      options.repeatInterval = this.plan.service.backup_interval;
+    }
+
+    options.repeatInterval = utils.getCronWithIntervalAndAfterXminute(options.repeatInterval, opts.afterXminute);
+    logger.info(`Scheduling Backup for instance : ${options.instance_id} with backup interval of - ${options.repeatInterval}`);
+    // Even if there is an error while fetching backup schedule, trigger backup schedule we would want audit log captured and riemann alert sent
+    return retry(() => cf.serviceFabrikClient.scheduleBackup(options), {
+      maxAttempts: 3,
+      minDelay: 500
+    });
+  }
 }
 
 module.exports = BaseDirectorService;

--- a/operators/BaseDirectorService.js
+++ b/operators/BaseDirectorService.js
@@ -10,7 +10,6 @@ const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const BoshDirectorClient = bosh.BoshDirectorClient;
 const Networks = bosh.manifest.Networks;
 const BaseService = require('./BaseService');
-const cf = require('../data-access-layer/cf');
 const retry = utils.retry;
 const CONST = require('../common/constants');
 
@@ -87,6 +86,7 @@ class BaseDirectorService extends BaseService {
   }
 
   reScheduleBackup(opts) {
+    const cf = require('../data-access-layer/cf');
     const options = {
       instance_id: opts.instance_id,
       repeatInterval: 'daily',

--- a/operators/bosh-restore-operator/BoshRestoreService.js
+++ b/operators/bosh-restore-operator/BoshRestoreService.js
@@ -510,12 +510,7 @@ class BoshRestoreService extends BaseDirectorService {
 
   async processPostStart(resourceOptions) { 
     await this.runErrand(resourceOptions, 'postStartErrand'); 
-    if (this.service.pitr === true) {
-      await this.reScheduleBackup({
-        instance_id: resourceOptions.instance_guid,
-        afterXminute: config.backup.reschedule_backup_delay_after_restore || CONST.BACKUP.RESCHEDULE_BACKUP_DELAY_AFTER_RESTORE
-      });
-    }
+    
     const patchObj = await this.createPatchObject(resourceOptions, 'succeeded');
     let patchResourceObj = {
       resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.RESTORE,
@@ -529,7 +524,13 @@ class BoshRestoreService extends BaseDirectorService {
       _.set(patchResourceObj, 'status.response', patchObj);
     }
     await eventmesh.apiServerClient.patchResource(patchResourceObj);
-    return this.patchRestoreFileWithFinalResult(resourceOptions, patchObj);
+    await this.patchRestoreFileWithFinalResult(resourceOptions, patchObj);
+    if (this.service.pitr === true) {
+      await this.reScheduleBackup({
+        instance_id: resourceOptions.instance_guid,
+        afterXminute: config.backup.reschedule_backup_delay_after_restore || CONST.BACKUP.RESCHEDULE_BACKUP_DELAY_AFTER_RESTORE
+      });
+    }
   }
 
   static createService(plan) {

--- a/operators/bosh-restore-operator/BoshRestoreService.js
+++ b/operators/bosh-restore-operator/BoshRestoreService.js
@@ -526,7 +526,7 @@ class BoshRestoreService extends BaseDirectorService {
     await eventmesh.apiServerClient.patchResource(patchResourceObj);
     await this.patchRestoreFileWithFinalResult(resourceOptions, patchObj);
     if (this.service.pitr === true) {
-      await this.reScheduleBackup({
+      this.reScheduleBackup({
         instance_id: resourceOptions.instance_guid,
         afterXminute: config.backup.reschedule_backup_delay_after_restore || CONST.BACKUP.RESCHEDULE_BACKUP_DELAY_AFTER_RESTORE
       });

--- a/operators/restore-operator/RestoreService.js
+++ b/operators/restore-operator/RestoreService.js
@@ -4,9 +4,6 @@ const _ = require('lodash');
 const Agent = require('../../data-access-layer/service-agent');
 const eventmesh = require('../../data-access-layer/eventmesh');
 const BaseDirectorService = require('../BaseDirectorService');
-const utils = require('../../common/utils');
-const cf = require('../../data-access-layer/cf');
-const retry = utils.retry;
 const errors = require('../../common/errors');
 const CONST = require('../../common/constants');
 const Promise = require('bluebird');
@@ -128,26 +125,6 @@ class RestoreService extends BaseDirectorService {
             });
         }
       });
-  }
-
-  reScheduleBackup(opts) {
-    const options = {
-      instance_id: opts.instance_id,
-      repeatInterval: 'daily',
-      type: CONST.BACKUP.TYPE.ONLINE
-    };
-
-    if (this.plan.service.backup_interval) {
-      options.repeatInterval = this.plan.service.backup_interval;
-    }
-
-    options.repeatInterval = utils.getCronWithIntervalAndAfterXminute(options.repeatInterval, opts.afterXminute);
-    logger.info(`Scheduling Backup for instance : ${options.instance_id} with backup interval of - ${options.repeatInterval}`);
-    // Even if there is an error while fetching backup schedule, trigger backup schedule we would want audit log captured and riemann alert sent
-    return retry(() => cf.serviceFabrikClient.scheduleBackup(options), {
-      maxAttempts: 3,
-      minDelay: 500
-    });
   }
 
   startRestore(opts) {

--- a/test/test_broker/operators.BoshRestoreService.spec.js
+++ b/test/test_broker/operators.BoshRestoreService.spec.js
@@ -755,12 +755,16 @@ describe('operators', function () {
       it('should call runErrand for postStartErrand and update ApiServer resource', () => {
         let restoreOptions = {
           restoreMetadata: restoreMetadata,
-          restore_guid: 'dummyGuid'
+          restore_guid: 'dummyGuid',
+          instance_guid: 'dummyInstanceGuid'
         };
         let getRestoreFileStub = sandbox.stub(backupStore, 'getRestoreFile').resolves();
         let patchRestoreFileStub = sandbox.stub(backupStore, 'patchRestoreFile').resolves();
         patchResourceStub.resolves();
         runErrandStub.resolves();
+        mocks.serviceFabrikClient.scheduleBackup('dummyInstanceGuid', function (body) {
+          return body.type === CONST.BACKUP.TYPE.ONLINE;
+        });
         return BoshRestoreService.createService(plan)
           .then(rs => rs.processPostStart(restoreOptions))
           .then(() => {


### PR DESCRIPTION
* Adding a schedule backup call similar to [this](https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/rel-2019.T03a/operators/restore-operator/RestoreService.js#L120) for BoshBasedRestore.