### PR TITLE
Returning dashboardUrl only if external endpoint attributes are set

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -73,9 +73,10 @@ class ServiceBrokerApiController extends FabrikBaseController {
 
     function done() {
       let statusCode = CONST.HTTP_STATUS_CODE.CREATED;
-      const body = {
-        dashboard_url: dashboardUrl
-      };
+      const body = {};
+      if (dashboardUrl) {
+        body.dashboard_url = dashboardUrl;
+      }
       if (plan.manager.async) {
         statusCode = CONST.HTTP_STATUS_CODE.ACCEPTED;
         body.operation = utils.encodeBase64({
@@ -444,14 +445,17 @@ class ServiceBrokerApiController extends FabrikBaseController {
         return dashboardUrl;
       }
       throw new errors.UnprocessableEntity(`Unable to generate valid dashboard URL with the template '${urlTemplate}'`);
+    } else if (_.get(config, 'external.protocol') !== undefined && _.get(config, 'external.host') !== undefined) {
+      return formatUrl(_
+        .chain(config.external)
+        .pick('protocol', 'host')
+        .set('slashes', true)
+        .set('pathname', `manage/dashboards/${context.plan.manager.name}/instances/${context.instance_id}`)
+        .value()
+      );
+    } else {
+      return null;
     }
-    return formatUrl(_
-      .chain(config.external)
-      .pick('protocol', 'host')
-      .set('slashes', true)
-      .set('pathname', `manage/dashboards/${context.plan.manager.name}/instances/${context.instance_id}`)
-      .value()
-    );
   }
 
 }


### PR DESCRIPTION
* Currently, if the external app is not used, dashboard url is returned with broker link
* Returning the custom dashboard if the template is set, else return the SF dashboard if external attributes exist, or else do not return any dashboard url