### PR TITLE
Add default ecs endpoint aliclient

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -497,6 +497,7 @@ module.exports = Object.freeze({
   },
   ALI_CLIENT:{
     ECS:{
+      DOMAIN: 'https://ecs.aliyuncs.com',
       API_VERSION: '2014-05-26',
       REQ_TIMEOUT: 20000, // 20 seconds
       AVAILABILITY_POLLER_DELAY: 1000, // 1sec

--- a/data-access-layer/iaas/AliClient.js
+++ b/data-access-layer/iaas/AliClient.js
@@ -281,6 +281,7 @@ class AliClient extends BaseCloudClient {
     // Thing to remember is that disk can't be reinitialised if parent snapshot is deleted
   
     const params = {
+      'RegionId': this.settings.region,
       'SnapshotId': snapshotId,
       'Force': true
     };
@@ -303,7 +304,7 @@ class AliClient extends BaseCloudClient {
       accessKeyId: options.keyId,
       accessKeySecret: options.key,
       apiVersion: CONST.ALI_CLIENT.ECS.API_VERSION,
-      endpoint: 'https://ecs.' + options.region + '.aliyuncs.com'
+      endpoint: CONST.ALI_CLIENT.ECS.DOMAIN
     });
   }
 

--- a/test/test_broker/iaas.AliClient.spec.js
+++ b/test/test_broker/iaas.AliClient.spec.js
@@ -187,7 +187,7 @@ describe('iaas', function () {
         expect(responseAliComputeObject.accessKeyId).to.equal(settings.keyId);
         expect(responseAliComputeObject.accessKeySecret).to.equal(settings.key);
         expect(responseAliComputeObject.apiVersion).to.equal(CONST.ALI_CLIENT.ECS.API_VERSION);
-        expect(responseAliComputeObject.endpoint).to.equal('https://ecs.' + settings.region + '.aliyuncs.com');
+        expect(responseAliComputeObject.endpoint).to.equal('https://ecs.aliyuncs.com');
       });
     });
 
@@ -377,6 +377,7 @@ describe('iaas', function () {
         reqStub.withArgs('CreateDisk', createDiskParams, createDiskrequestOption).callsFake(createDiskStub);
 
         const deleteSnapshotParams = {
+          RegionId: 'region-name',
           'SnapshotId': 'snappy',
           'Force': true
         };
@@ -525,6 +526,7 @@ describe('iaas', function () {
       it('throws error if delete snapshot fails', function () {
         sandbox.restore();
         const deleteSnapshotFailParams = {
+          'RegionId': settings.region,
           'SnapshotId': 'snappy',
           'Force': true
         };


### PR DESCRIPTION
Some regions like cn-shanghai doesn't support region specific endpoint. hence changing to default endpoint

> https://www.alibabacloud.com/help/doc-detail/25489.html?spm=a2c5t.11065259.1996646101.searchclickresult.6fc447efi35uHt