### PR TITLE
Set Bind Operation timeout to < 60sec

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -378,7 +378,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
         resourceId: params.binding_id,
         namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
         start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-        started_at: new Date()
+        started_at: new Date(),
+        timeout_in_sec: CONST.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC
       }))
       .then(operationStatus => {
         const secretName = operationStatus.response.secretRef;
@@ -431,7 +432,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
         resourceId: params.binding_id,
         namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
         start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
-        started_at: new Date()
+        started_at: new Date(),
+        timeout_in_sec: CONST.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC
       }))
       .then(done.bind(this))
       .catch(NotFound, gone);

--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -379,7 +379,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
         start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
         started_at: new Date(),
-        timeout_in_sec: CONST.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC
+        timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC
       }))
       .then(operationStatus => {
         const secretName = operationStatus.response.secretRef;
@@ -433,7 +433,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
         start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
         started_at: new Date(),
-        timeout_in_sec: CONST.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC
+        timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC
       }))
       .then(done.bind(this))
       .catch(NotFound, gone);

--- a/common/constants.js
+++ b/common/constants.js
@@ -65,6 +65,7 @@ module.exports = Object.freeze({
     ABORTED: 'aborted',
     PROCESSING: 'processing'
   },
+  OSB_SYNC_OPERATION_TIMEOUT_IN_SEC: 55, // in sec
   DIRECTOR_RESOURCE_POLLER_INTERVAL: 50000, // in ms
   POLLER_RELAXATION_TIME: 5000, // in ms
   PROCESSING_REQUEST_BY_MANAGER_TIMEOUT: 300000, // 5 minutes
@@ -434,7 +435,7 @@ module.exports = Object.freeze({
       RESTORE: 'restore',
       MULTI_TENANCY: 'multi_tenancy'
     },
-    OPERATION_TIMEOUT_IN_MILLIS: 35000
+    OPERATION_TIMEOUT_IN_MILLIS: 25000
   },
   STATE: {
     ACTIVE: 'active',

--- a/common/constants.js
+++ b/common/constants.js
@@ -65,7 +65,9 @@ module.exports = Object.freeze({
     ABORTED: 'aborted',
     PROCESSING: 'processing'
   },
-  OSB_SYNC_OPERATION_TIMEOUT_IN_SEC: 55, // in sec
+  OSB_OPERATION: {
+    OSB_SYNC_OPERATION_TIMEOUT_IN_SEC: 55 // in sec
+  },
   DIRECTOR_RESOURCE_POLLER_INTERVAL: 50000, // in ms
   POLLER_RELAXATION_TIME: 5000, // in ms
   PROCESSING_REQUEST_BY_MANAGER_TIMEOUT: 300000, // 5 minutes

--- a/common/errors.js
+++ b/common/errors.js
@@ -61,11 +61,13 @@ class Timeout extends BaseError {
       this.error = new Error(error);
     }
   }
-  static timedOut(time, err) {
-    return new Timeout(`Operation timed out after ${time} ms`, err);
+  static timedOut(time, err, operation) {
+    const msg = `Operation ${operation ? operation + ' ' : ''}timed out after ${time} ms`;
+    return new Timeout(msg, err);
   }
-  static toManyAttempts(attempts, err) {
-    return new Timeout(`Operation failed after ${attempts} attempts`, err);
+  static toManyAttempts(attempts, err, operation) {
+    const msg = `Operation ${operation ? operation + ' ' : ''}failed after ${attempts} attempts`;
+    return new Timeout(msg, err);
   }
 }
 exports.Timeout = Timeout;

--- a/common/utils/RetryOperation.js
+++ b/common/utils/RetryOperation.js
@@ -44,10 +44,10 @@ class RetryOperation {
           const delay = Math.max(self.backoff(++tries) - (now - attemptStart), 0);
           const time = now + delay - retryStart;
           if (tries >= self.maxAttempts) {
-            return Promise.reject(Timeout.toManyAttempts(tries, err));
+            return Promise.reject(Timeout.toManyAttempts(tries, err, self.operation));
           }
           if (time >= self.timeout) {
-            return Promise.reject(Timeout.timedOut(time, err));
+            return Promise.reject(Timeout.timedOut(time, err, self.operation));
           }
           if (delay > 0) {
             return Promise.delay(delay).then(attempt);

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -99,6 +99,7 @@ class ApiServerClient {
    * @param {string} opts.resourceId - Id of the operation ex. backupGuid
    * @param {string} opts.start_state - start state of the operation ex. in_queue
    * @param {object} opts.started_at - Date object specifying operation start time
+   * @param {object} opts.timeout_in_sec - Req timeout in sec (optional)
    * @param {object} opts.namespaceId - namespace Id of resource
    */
   getResourceOperationStatus(opts) {
@@ -116,9 +117,9 @@ class ApiServerClient {
         if (state === opts.start_state) {
           const duration = (new Date() - opts.started_at) / 1000;
           logger.debug(`Polling for ${opts.start_state} duration: ${duration} `);
-          if (duration > CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS) {
-            logger.error(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed`);
-            throw new Timeout(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed`);
+          if (duration > (opts.timeout_in_sec ? opts.timeout_in_sec : CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS)) {
+            logger.error(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
+            throw new Timeout(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
           }
           return this.getResourceOperationStatus(opts);
         } else if (
@@ -155,6 +156,7 @@ class ApiServerClient {
    * @param {string} opts.resourceId - Id of the operation ex. instance_id
    * @param {string} opts.start_state - start state of the operation ex. in_queue
    * @param {object} opts.started_at - Date object specifying operation start time
+   * @param {object} opts.timeout_in_sec - Req timeout in seconds (optional)
    * @param {object} opts.namespaceId - namespace Id of resource
    */
   // TODO:- merge getResourceOperationStatus and getOSBResourceOperationStatus after streamlining state conventions
@@ -186,9 +188,9 @@ class ApiServerClient {
         } else {
           const duration = (new Date() - opts.started_at) / 1000;
           logger.debug(`Polling for ${opts.start_state} duration: ${duration} `);
-          if (duration > CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS) {
-            logger.error(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed`);
-            throw new Timeout(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed`);
+          if (duration > (opts.timeout_in_sec ? opts.timeout_in_sec : CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS)) {
+            logger.error(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
+            throw new Timeout(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
           }
           return this.getOSBResourceOperationStatus(opts);
         }

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -117,7 +117,7 @@ class ApiServerClient {
         if (state === opts.start_state) {
           const duration = (new Date() - opts.started_at) / 1000;
           logger.debug(`Polling for ${opts.start_state} duration: ${duration} `);
-          if (duration > (opts.timeout_in_sec ? opts.timeout_in_sec : CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS)) {
+          if (duration > _.get(opts, 'timeout_in_sec', CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS)) {
             logger.error(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
             throw new Timeout(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
           }
@@ -188,7 +188,7 @@ class ApiServerClient {
         } else {
           const duration = (new Date() - opts.started_at) / 1000;
           logger.debug(`Polling for ${opts.start_state} duration: ${duration} `);
-          if (duration > (opts.timeout_in_sec ? opts.timeout_in_sec : CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS)) {
+          if (duration > _.get(opts, 'timeout_in_sec', CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS)) {
             logger.error(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
             throw new Timeout(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
           }

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -742,6 +742,7 @@ class DirectorService extends BaseDirectorService {
       this.executeActions(CONST.SERVICE_LIFE_CYCLE.PRE_BIND, actionContext),
       this.getDeploymentIps(deploymentName),
       (preBindResponse, ips) => utils.retry(() => this.agent.createCredentials(ips, binding.parameters, preBindResponse), {
+        operation: 'CREATE_CREDENTIAL_AGENT',
         maxAttempts: 2,
         timeout: config.agent_operation_timeout || CONST.AGENT.OPERATION_TIMEOUT_IN_MILLIS
       })
@@ -789,7 +790,8 @@ class DirectorService extends BaseDirectorService {
             this.getCredentials(deploymentName, id)
           ]))
       .spread((preUnbindResponse, ips, credentials) => utils.retry(() => this.agent.deleteCredentials(ips, credentials, preUnbindResponse), {
-        maxAttempts: 3,
+        operation: 'DELETE_CREDENTIAL_AGENT',
+        maxAttempts: 2,
         timeout: config.agent_operation_timeout || CONST.AGENT.OPERATION_TIMEOUT_IN_MILLIS
       })
         .catch(errors.Timeout, err => {

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -742,7 +742,7 @@ class DirectorService extends BaseDirectorService {
       this.executeActions(CONST.SERVICE_LIFE_CYCLE.PRE_BIND, actionContext),
       this.getDeploymentIps(deploymentName),
       (preBindResponse, ips) => utils.retry(() => this.agent.createCredentials(ips, binding.parameters, preBindResponse), {
-        maxAttempts: 3,
+        maxAttempts: 2,
         timeout: config.agent_operation_timeout || CONST.AGENT.OPERATION_TIMEOUT_IN_MILLIS
       })
         .catch(errors.Timeout, err => {

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -1487,8 +1487,8 @@ describe('service-broker-api-2.0', function () {
               state: 'in progress'
             }
           });
-          const timeout = CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS;
-          CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS = 0;
+          const timeout = CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC;
+          CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC = 0;
           return chai.request(app)
             .put(`${base_url}/service_instances/${instance_id}/service_bindings/${binding_id}`)
             .set('X-Broker-API-Version', api_version)
@@ -1503,7 +1503,7 @@ describe('service-broker-api-2.0', function () {
             })
             .catch(err => err.response)
             .then(res => {
-              CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS = timeout;
+              CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC = timeout;
               expect(res).to.have.status(500);
               mocks.verify();
               done();


### PR DESCRIPTION
Cloud controller req. times out in `60sec`
https://github.com/cloudfoundry/cloud_controller_ng/blob/master/config/cloud_controller.yml#L192
It means broker should return bind credentials within these 60 seconds else it should throw timeout error.
To support this 2 changes were made
1. retry count of createCredential req to agent set to 2 and timeout set to 25sec/req
2. Entire operation should finish within 55 sec hence timeout is changed for `sync operation poller` in broker controller
