### PR TITLE
Support kubernetes version 1.14

### DIFF
--- a/common/ExpressApp.js
+++ b/common/ExpressApp.js
@@ -23,7 +23,11 @@ class ExpressApp {
       .set('_', _)
       .set('yaml', yaml)
       .commit();
-
+    // requireEventLogging should be done as early as possible
+    // Else some events published by dbManager are missed
+    if (cfg.log_event) {
+      app.use(middleware.requireEventLogging(cfg, type));
+    }
     app.set('env', process.env.NODE_ENV || 'development');
     app.set('port', cfg.port);
     app.set('type', type);
@@ -50,9 +54,6 @@ class ExpressApp {
       extended: true
     }));
     app.use(bodyParser.json());
-    if (cfg.log_event) {
-      app.use(middleware.requireEventLogging(cfg, type));
-    }
     // routes
     addRoutes(app);
 

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -67,6 +67,10 @@ function convertToHttpErrorAndThrow(err) {
 }
 
 class ApiServerClient {
+  constructor() {	
+    this.ready = false;
+    this.init();
+  }
 
   init() {
     return Promise.try(() => {
@@ -74,11 +78,10 @@ class ApiServerClient {
         apiserver.addCustomResourceDefinition(yaml.safeLoad(Buffer.from(crdTemplate, 'base64')));
       })
         .tap(() => {
-          this.ready = true;
-          logger.debug('Successfully loaded ApiServer Spec');
+          logger.debug('Successfully added enpoints to apiserver client');
         })
         .catch(err => {
-          logger.error('Error occured while loading ApiServer Spec', err);
+          logger.error('Error occured while adding enpoints to apiserver client', err);
           return convertToHttpErrorAndThrow(err);
         });
     });

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "js-yaml": "3.6.1",
     "json-stream": "^1.0.0",
     "jsonwebtoken": "8.1.0",
-    "kubernetes-client": "6.12.0",
+    "kubernetes-client": "7.0.1",
     "lodash": "4.17.5",
     "moment": "2.19.3",
     "mongoose": "4.8.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "js-yaml": "3.6.1",
     "json-stream": "^1.0.0",
     "jsonwebtoken": "8.1.0",
-    "kubernetes-client": "5.3.0",
+    "kubernetes-client": "6.12.0",
     "lodash": "4.17.5",
     "moment": "2.19.3",
     "mongoose": "4.8.2",

--- a/test/test_broker/mocks/apiServerEventMesh.js
+++ b/test/test_broker/mocks/apiServerEventMesh.js
@@ -7,7 +7,6 @@ const CONST = require('../../../common/constants');
 const apiServerHost = `https://${config.apiserver.ip}:${config.apiserver.port}`;
 
 
-exports.nockLoadSpec = nockLoadSpec;
 exports.nockCreateResource = nockCreateResource;
 exports.nockPatchResource = nockPatchResource;
 exports.nockGetResource = nockGetResource;
@@ -55,21 +54,6 @@ const expectedGetConfigMapResponseDisabled = {
     uid: '4e47d831-f881-11e8-9055-123c04a61866'
   }
 };
-
-function nockLoadSpec(times) {
-  nock(apiServerHost)
-    .get('/swagger.json')
-    .times(times || 1)
-    .reply(200, {
-      paths: {
-        '/api/': {
-          get: {
-            operationId: 'getCoreAPIVersions'
-          }
-        }
-      }
-    });
-}
 
 function nockCreateCrd(resourceGroup, resourceType, response, times) {
   nock(apiServerHost)

--- a/test/test_broker/operators.BackupService.spec.js
+++ b/test/test_broker/operators.BackupService.spec.js
@@ -305,7 +305,6 @@ describe('operators', function () {
         mocks.cloudProvider.list(container, `${prefix}/${service_id}.${instance_id}.${backup_guid}`, [filename]);
         mocks.cloudProvider.remove(pathname);
         mocks.cloudProvider.download(pathname, data);
-        mocks.apiServerEventMesh.nockLoadSpec();
         mocks.apiServerEventMesh.nockPatchResourceRegex(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP, {
           status: {
             state: 'deleting'

--- a/test/test_broker/support/index.js
+++ b/test/test_broker/support/index.js
@@ -37,8 +37,3 @@ global.expect = global.chai.expect;
  */
 global.chai.use(require('sinon-chai'));
 global.chai.use(require('chai-http'));
-
-/**
- * Registering def for first and only time.
- */
-require('../../../data-access-layer/eventmesh').apiServerClient.init();

--- a/test/test_broker/support/index.js
+++ b/test/test_broker/support/index.js
@@ -39,7 +39,6 @@ global.chai.use(require('sinon-chai'));
 global.chai.use(require('chai-http'));
 
 /**
- * Loading it from the first time before the test starts and mocking it here so that the tests need not do it.
+ * Registering def for first and only time.
  */
-mocks.apiServerEventMesh.nockLoadSpec();
 require('../../../data-access-layer/eventmesh').apiServerClient.init();


### PR DESCRIPTION
`swagger.json` is removed in kubernetes version `1.14`

> kube-apiserver now only aggregates openapi schemas from /openapi/v2 endpoints of aggregated API servers. The fallback to aggregate from /swagger.json has been removed. Ensure aggregated API servers provide schema information via /openapi/v2 (available since v1.10)

This PR upgrades `kubernetes-client` version to `7.0.1`, which supports `1.14`