### PR TITLE
Adding ArchiveMeteredEvents job

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,7 @@
       }
     ],
     "comma-dangle": [2, "never"],
-    "complexity": [2, 17],
+    "complexity": [2, 20],
     "consistent-return": 0,
     "curly": [2, "all"],
     "dot-notation": 2,

--- a/common/constants.js
+++ b/common/constants.js
@@ -131,7 +131,7 @@ module.exports = Object.freeze({
   },
   JOB_NAME_ATTRIB: '_n_a_m_e_',
   METERING_ARCHIVE_JOB_FILE_PREFIX: 'MeteringArchive-',
-  ARCHIVE_METERED_EVENTS_RUN_THRESHOLD: 100,
+  ARCHIVE_METERED_EVENTS_RUN_THRESHOLD: 500,
   METERING_ARCHIVE_ROOT_FOLDER: 'MeteringArchive',
   JOB: {
     // Define names of scheduled JOBS

--- a/common/constants.js
+++ b/common/constants.js
@@ -130,6 +130,9 @@ module.exports = Object.freeze({
     TIMEOUT: 504
   },
   JOB_NAME_ATTRIB: '_n_a_m_e_',
+  METERING_ARCHIVE_JOB_FILE_PREFIX: 'MeteringArchive-',
+  ARCHIVE_METERED_EVENTS_RUN_THRESHOLD: 100,
+  METERING_ARCHIVE_ROOT_FOLDER: 'MeteringArchive',
   JOB: {
     // Define names of scheduled JOBS
     SCHEDULED_BACKUP: 'ScheduledBackup',
@@ -140,7 +143,8 @@ module.exports = Object.freeze({
     BACKUP_REAPER: 'BackupReaper',
     SERVICE_INSTANCE_UPDATE: 'ServiceInstanceAutoUpdate',
     DB_COLLECTION_REAPER: 'DbCollectionReaper',
-    METER_INSTANCE: 'MeterInstance'
+    METER_INSTANCE: 'MeterInstance',
+    ARCHIVE_METERED_EVENTS: 'ArchiveMeteredEvents'
   },
   JOB_RUN_STATUS_CODE: {
     SUCCEEDED: '0'

--- a/common/utils/index.js
+++ b/common/utils/index.js
@@ -71,6 +71,11 @@ exports.getAllServices = getAllServices;
 exports.getAllPlansForService = getAllPlansForService;
 exports.loadCatalogFromAPIServer = loadCatalogFromAPIServer;
 exports.getDefaultErrorMsg = getDefaultErrorMsg;
+exports.sleep = sleep;
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 function isRestorePossible(plan_id, plan) {
   const settings = plan.manager.settings;

--- a/data-access-layer/iaas/MeteringArchiveStore.js
+++ b/data-access-layer/iaas/MeteringArchiveStore.js
@@ -21,7 +21,7 @@ class MeteringArchiveStore {
 
   async patchEventToArchiveFile(event, timeStamp) {
     const fileName = this.getMeteringArchiveFileName(timeStamp);
-    let data = await this.cloudProvider.downloadJson(filename);
+    let data = await this.cloudProvider.downloadJson(fileName);
     data.meteredEvents.push(event);
     await this.cloudProvider.uploadJson(fileName, data);
     logger.info(`Patched metered event ${event.metadata.name} to archive ${fileName}`);

--- a/data-access-layer/iaas/MeteringArchiveStore.js
+++ b/data-access-layer/iaas/MeteringArchiveStore.js
@@ -2,6 +2,7 @@
 
 const CONST = require('../../common/constants');
 const path = require('path');
+const logger = require('../../common/logger');
 
 class MeteringArchiveStore {
   constructor(cloudProvider) {

--- a/data-access-layer/iaas/MeteringArchiveStore.js
+++ b/data-access-layer/iaas/MeteringArchiveStore.js
@@ -10,7 +10,7 @@ class MeteringArchiveStore {
   }
 
   getMeteringArchiveFileName(timeStamp) {
-    return path.posix.join(CONST.METERING_ARCHIVE_ROOT_FOLDER, `${CONST.METERING_ARCHIVE_JOB_FILE_PREFIX}${timeStamp}`);
+    return path.posix.join(CONST.METERING_ARCHIVE_ROOT_FOLDER, `${CONST.METERING_ARCHIVE_JOB_FILE_PREFIX}${timeStamp}.json`);
   }
 
   async putArchiveFile(timeStamp) {
@@ -21,10 +21,10 @@ class MeteringArchiveStore {
 
   async patchEventToArchiveFile(event, timeStamp) {
     const fileName = this.getMeteringArchiveFileName(timeStamp);
-    logger.info(`Patching metered event ${event.metadata.name} to archive ${fileName}`);
     let data = await this.cloudProvider.downloadJson(filename);
     data.meteredEvents.push(event);
     await this.cloudProvider.uploadJson(fileName, data);
+    logger.info(`Patched metered event ${event.metadata.name} to archive ${fileName}`);
   }
 }
 

--- a/data-access-layer/iaas/MeteringArchiveStore.js
+++ b/data-access-layer/iaas/MeteringArchiveStore.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const CONST = require('../../common/constants');
+const path = require('path');
+
+class MeteringArchiveStore {
+  constructor(cloudProvider) {
+    this.cloudProvider = cloudProvider;
+  }
+
+  getMeteringArchiveFileName(timeStamp) {
+    return path.posix.join(CONST.METERING_ARCHIVE_ROOT_FOLDER, `${CONST.METERING_ARCHIVE_JOB_FILE_PREFIX}${timeStamp}`);
+  }
+
+  async putArchiveFile(timeStamp) {
+    const fileName = this.getMeteringArchiveFileName(timeStamp);
+    await this.cloudProvider.uploadJson(fileName, { 'meteredEvents':[] });
+    logger.info(`Created Metering Archive file: ${fileName}`);
+  }
+
+  async patchEventToArchiveFile(event, timeStamp) {
+    const fileName = this.getMeteringArchiveFileName(timeStamp);
+    logger.info(`Patching metered event ${event.metadata.name} to archive ${fileName}`);
+    let data = await this.cloudProvider.downloadJson(filename);
+    data.meteredEvents.push(event);
+    await this.cloudProvider.uploadJson(fileName, data);
+  }
+}
+
+module.exports = MeteringArchiveStore;

--- a/data-access-layer/iaas/index.js
+++ b/data-access-layer/iaas/index.js
@@ -9,6 +9,7 @@ const BackupStore = require('./BackupStore');
 const BackupStoreForServiceInstance = require('./BackupStoreForServiceInstance');
 const BackupStoreForOob = require('./BackupStoreForOob');
 const BaseCloudClient = require('./BaseCloudClient');
+const MeteringArchiveStore = require('./MeteringArchiveStore');
 
 const getCloudClient = function (settings) {
   switch (settings.name) {
@@ -37,3 +38,4 @@ exports.BaseCloudClient = BaseCloudClient;
 exports.cloudProvider = cloudProvider;
 exports.backupStore = new BackupStoreForServiceInstance(cloudProvider);
 exports.backupStoreForOob = new BackupStoreForOob(cloudProvider);
+exports.meteringArchiveStore = new MeteringArchiveStore(cloudProvider);

--- a/jobs/ArchiveMeteredEventsJob.js
+++ b/jobs/ArchiveMeteredEventsJob.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const _ = require('lodash');
+const CONST = require('../common/constants');
+const config = require('../common/config');
+const apiServerClient = require('../data-access-layer/eventmesh').apiServerClient;
+const meteringArchiveStore = require('../data-access-layer/iaas').meteringArchiveStore;
+
+class ArchiveMeteredEventsJob {
+
+  static async run(job, done) {
+    try {
+      logger.info(`-> Starting ArchiveMeteredEventsJob -  name: ${job.attrs.data[CONST.JOB_NAME_ATTRIB]} - with options: ${JSON.stringify(job.attrs.data)} `);
+      const events = await this.getMeteredEvents();
+      logger.info(`Total number of metered events obtained from ApiServer: ${events.length}`);
+      const meteringFileTimeStamp = new Date();
+      const successfullyPatchedEvents = await this.patchToMeteringStore(events, meteringFileTimeStamp.toISOString());
+      logger.info(`No of processed metered events: ${successfullyPatchedEvents}`);
+      return this.runSucceeded({}, job, done);
+    } catch(err) {
+      return this.runFailed(err, {}, job, done);
+    }
+  }
+
+  static async getMeteredEvents() {
+    try {
+      let selector = `state in (${CONST.METER_STATE.METERED})`;
+      const options = {
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INSTANCE,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.SFEVENT,
+        query: {
+          labelSelector: selector
+        }
+      };
+      return apiServerClient.getResources(options);
+    } catch(err) {
+      logger.error('Error while getting events from the ApiServer', err);
+      throw err;
+    }
+  }
+
+  static async patchToMeteringStore(events, timeStamp) {
+    try {
+      await meteringArchiveStore.putArchiveFile(timeStamp);
+      const noEventsToPatch = Math.min(config.system_jobs.archive_metered_events.job_data.events_to_patch, events.length, 
+        CONST.ARCHIVE_METERED_EVENTS_RUN_THRESHOLD);
+      const eventsToPatch = _.slice(events, 0, noEventsToPatch);
+      _.forEach(eventsToPatch, async event => {
+        await this.processEvent(event, timeStamp);
+      });
+      return noEventsToPatch;
+    } catch(err) {
+      logger.error('Error while archiving events in the MeteringStore: ', err);
+      throw err;
+    }
+  }
+
+  static async processEvent(event, timeStamp) {
+    logger.info(`Processing event: ${event.metadata.name}`);
+    await meteringArchiveStore.patchEventToArchiveFile(event, timeStamp);
+    return utils.retry(tries => {
+      logger.debug(`Trying to delete ${event.metadata.name}. Total retries yet: ${tries}`);
+      return apiServerClient.deleteResource({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INSTANCE,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.SFEVENT,
+        resourceId: `${event.metadata.name}`
+      });
+    }, {
+      maxAttempts: 4,
+      minDelay: 1000
+    });
+  }
+}
+
+module.exports = ArchiveMeteredEventsJob;

--- a/jobs/ArchiveMeteredEventsJob.js
+++ b/jobs/ArchiveMeteredEventsJob.js
@@ -7,6 +7,7 @@ const apiServerClient = require('../data-access-layer/eventmesh').apiServerClien
 const meteringArchiveStore = require('../data-access-layer/iaas').meteringArchiveStore;
 const BaseJob = require('./BaseJob');
 const logger = require('../common/logger');
+const utils = require('../common/utils');
 
 class ArchiveMeteredEventsJob extends BaseJob {
 
@@ -50,9 +51,9 @@ class ArchiveMeteredEventsJob extends BaseJob {
       const noEventsToPatch = Math.min(_.get(config, 'system_jobs.archive_metered_events.job_data.events_to_patch', 100), events.length, 
         CONST.ARCHIVE_METERED_EVENTS_RUN_THRESHOLD);
       const eventsToPatch = _.slice(events, 0, noEventsToPatch);
-      _.forEach(eventsToPatch, async event => {
-        await this.processEvent(event, timeStamp);
-      });
+      for(let i = 0; i < eventsToPatch.length; i++) {
+        await this.processEvent(eventsToPatch[i], timeStamp);
+      }
       return noEventsToPatch;
     } catch(err) {
       logger.error('Error while archiving events in the MeteringStore: ', err);

--- a/jobs/ArchiveMeteredEventsJob.js
+++ b/jobs/ArchiveMeteredEventsJob.js
@@ -43,8 +43,7 @@ class ArchiveMeteredEventsJob extends BaseJob {
   static async patchToMeteringStore(events, timeStamp, sleepDuration, attempts) {
     try {
       await meteringArchiveStore.putArchiveFile(timeStamp);
-      const noEventsToPatch = Math.min(_.get(config, 'system_jobs.archive_metered_events.job_data.events_to_patch', 100), events.length, 
-        CONST.ARCHIVE_METERED_EVENTS_RUN_THRESHOLD);
+      const noEventsToPatch = Math.min(_.get(config, 'system_jobs.archive_metered_events.job_data.events_to_patch', CONST.ARCHIVE_METERED_EVENTS_RUN_THRESHOLD), events.length);
       const eventsToPatch = _.slice(events, 0, noEventsToPatch);
       for(let i = 0; i < eventsToPatch.length; i++) {
         await this.processEvent(eventsToPatch[i], timeStamp, attempts || 4);

--- a/jobs/JobFabrik.js
+++ b/jobs/JobFabrik.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const CONST = require('../common/constants');
 let ScheduleBackupJob, ScheduledOobDeploymentBackupJob, OperationStatusPollerJob, BackupReaperJob, ServiceInstanceUpdateJob, DbCollectionReaperJob, BluePrintJob,
-  MeterInstanceJob;
+  MeterInstanceJob, ArchiveMeteredEventsJob;
 
 class JobFabrik {
   static getJob(jobType) {
@@ -48,6 +48,11 @@ class JobFabrik {
           MeterInstanceJob = require('./MeterInstanceJob');
         }
         return MeterInstanceJob;
+      case CONST.JOB.ARCHIVE_METERED_EVENTS:
+        if (ArchiveMeteredEventsJob === undefined) {
+          ArchiveMeteredEventsJob = require('./ArchiveMeteredEventsJob');
+        }
+        return ArchiveMeteredEventsJob;
       default:
         assert.fail(jobType, [CONST.JOB.SCHEDULED_BACKUP, CONST.JOB.SERVICE_FABRIK_BACKUP, CONST.JOB.SCHEDULED_OOB_DEPLOYMENT_BACKUP, CONST.JOB.OPERATION_STATUS_POLLER, CONST.JOB.BACKUP_REAPER], `Invalid job type. ${jobType} does not exist`, 'in');
     }

--- a/test/test_broker/iaas.MeteringArchiveStore.spec.js
+++ b/test/test_broker/iaas.MeteringArchiveStore.spec.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const meteringArchiveStore = require('../../data-access-layer/iaas').meteringArchiveStore;
+const cloudProvider = require('../../data-access-layer/iaas').cloudProvider;
+const CONST = require('../../common/constants');
+
+describe('iaas', () => {
+    describe('meteringArchiveStore', () => {
+        describe('putArchiveFile', () => {
+            let sandbox, uploadJsonStub;
+            beforeEach(() => {
+                sandbox = sinon.createSandbox();
+                uploadJsonStub = sandbox.stub(cloudProvider, 'uploadJson');
+            });
+            afterEach(() => {
+                sandbox.restore();
+            });
+            it('creates a file based on timestamp provided', () => {
+                uploadJsonStub.resolves();
+                return meteringArchiveStore.putArchiveFile('dummy-timestamp')
+                .then(() => {
+                    expect(uploadJsonStub.callCount).to.eql(1);
+                    const expectedFileName = `${CONST.METERING_ARCHIVE_ROOT_FOLDER}/${CONST.METERING_ARCHIVE_JOB_FILE_PREFIX}dummy-timestamp.json`;
+                    expect(uploadJsonStub.firstCall.args[0]).to.eql(expectedFileName);
+                    expect(uploadJsonStub.firstCall.args[1]).to.deep.eql({ 'meteredEvents':[] }); 
+                });
+            });
+        });
+        describe('patchEventToArchiveFile', () => {
+            let sandbox, uploadJsonStub, downloadJsonStub;
+            const dummyArchiveData = { 
+                'meteredEvents':[
+                    {
+                        "metadata": {
+                            "labels": {
+                                "event_type": "create",
+                                "instance_guid": "f4c513a4-d913-49a5-822e-cd763fe85206",
+                                "state": "METERED"
+                            },
+                            "name": "sfevent-1"
+                        },
+                        "status": {
+                            "state": "METERED"
+                        }
+                    },
+                    {
+                        "metadata": {
+                            "labels": {
+                                "event_type": "delete",
+                                "instance_guid": "f4c513a4-d913-49a5-822e-cd763fe85206",
+                                "state": "METERED"
+                            },
+                            "name": "sfevent-2"
+                        },
+                        "status": {
+                            "state": "METERED"
+                        }
+                    },
+                ] 
+            };
+            const newEvent = {
+                "metadata": {
+                    "labels": {
+                        "event_type": "create",
+                        "instance_guid": "6b75cf42-a7a1-4fa0-a7f9-f5e900664f06",
+                        "state": "METERED"
+                    },
+                    "name": "sfevent-1"
+                },
+                "status": {
+                    "state": "METERED"
+                }
+            };
+
+            beforeEach(() => {
+                sandbox = sinon.createSandbox();
+                uploadJsonStub = sandbox.stub(cloudProvider, 'uploadJson');
+                downloadJsonStub = sandbox.stub(cloudProvider, 'downloadJson');
+            });
+            afterEach(() => {
+                sandbox.restore();
+            });
+            it('successfully patches new event to existing data in file', () => {
+                uploadJsonStub.resolves();
+                downloadJsonStub.resolves(dummyArchiveData);
+                return meteringArchiveStore.patchEventToArchiveFile(newEvent, 'dummy-timestamp')
+                .then(() => {
+                    expect(uploadJsonStub.callCount).to.eql(1);
+                    expect(downloadJsonStub.callCount).to.eql(1);
+                    const expectedFileName = `${CONST.METERING_ARCHIVE_ROOT_FOLDER}/${CONST.METERING_ARCHIVE_JOB_FILE_PREFIX}dummy-timestamp.json`;
+                    expect(uploadJsonStub.firstCall.args[0]).to.eql(expectedFileName);
+                    expect(uploadJsonStub.firstCall.args[1]).to.deep.eql(dummyArchiveData);
+                 });
+            });
+        });
+    });
+});

--- a/test/test_broker/jobs.ArchiveMeteredEventsJob.spec.js
+++ b/test/test_broker/jobs.ArchiveMeteredEventsJob.spec.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const _ = require('lodash');
+const ArchiveMeteredEventsJob = require('../../jobs/ArchiveMeteredEventsJob');
+const meteringArchiveStore = require('../../data-access-layer/iaas').meteringArchiveStore;
+const eventmesh = require('../../data-access-layer/eventmesh');
+
+describe('Jobs', () => {
+    describe('ArchiveMeteredEventsJob', () => {
+        const dummyMeteredEvents = [
+        {
+            "metadata": {
+                "labels": {
+                    "event_type": "create",
+                    "instance_guid": "f4c513a4-d913-49a5-822e-cd763fe85206",
+                    "state": "METERED"
+                },
+                "name": "sfevent-1"
+            },
+            "status": {
+                "state": "METERED"
+            }
+        },
+        {
+            "metadata": {
+                "labels": {
+                    "event_type": "delete",
+                    "instance_guid": "f4c513a4-d913-49a5-822e-cd763fe85206",
+                    "state": "METERED"
+                },
+                "name": "sfevent-2"
+            },
+            "status": {
+                "state": "METERED"
+            }
+        },
+        {
+            "metadata": {
+                "labels": {
+                    "event_type": "create",
+                    "instance_guid": "6b75cf42-a7a1-4fa0-a7f9-f5e900664f06",
+                    "state": "METERED"
+                },
+                "name": "sfevent-1"
+            },
+            "status": {
+                "state": "METERED"
+            }
+        }
+        ];
+        describe('run', () => {
+            let sandbox, putArchiveFileStub, deleteResourceStub, patchEventToArchiveFileStub, getResourcesStub, runSucceededStub, runFailedStub;
+            const job = {
+                attrs: {
+                  name: `ArchiveMeteredEvents`,
+                  data: {
+                    'sleepDuration': 100,
+                    'deleteAttempts': 2
+                  }
+                }
+              };
+            beforeEach(() => {
+                sandbox = sinon.createSandbox();
+                putArchiveFileStub = sandbox.stub(meteringArchiveStore, 'putArchiveFile');
+                patchEventToArchiveFileStub = sandbox.stub(meteringArchiveStore, 'patchEventToArchiveFile');
+                deleteResourceStub = sandbox.stub(eventmesh.apiServerClient, 'deleteResource');
+                getResourcesStub = sandbox.stub(eventmesh.apiServerClient, 'getResources');
+                runSucceededStub = sandbox.stub(ArchiveMeteredEventsJob, 'runSucceeded');
+                runFailedStub = sandbox.stub(ArchiveMeteredEventsJob, 'runFailed');
+            });
+            afterEach(() => {
+                sandbox.restore();
+            });
+            it('handles error in getMeteredEvents', () => {
+                getResourcesStub.rejects('forced-exception');
+                return ArchiveMeteredEventsJob.run(job, {})
+                .then(() => {
+                    expect(getResourcesStub.callCount).to.eql(1);
+                    expect(runFailedStub.callCount).to.eql(1);
+                });
+            });
+            it('returns if no metered events are found', () => {
+                getResourcesStub.resolves([]);
+                return ArchiveMeteredEventsJob.run(job, {})
+                .then(() => {
+                    expect(getResourcesStub.callCount).to.eql(1);
+                    expect(runSucceededStub.callCount).to.eql(1);
+                });
+            });
+            it('successfully processes metered events', () => {
+                getResourcesStub.resolves(dummyMeteredEvents);
+                putArchiveFileStub.resolves();
+                patchEventToArchiveFileStub.resolves();
+                deleteResourceStub.resolves();
+                runSucceededStub.resolves();
+                return ArchiveMeteredEventsJob.run(job, {})
+                .then(() => {
+                    expect(getResourcesStub.callCount).to.eql(1);
+                    expect(runSucceededStub.callCount).to.eql(1);
+                    expect(putArchiveFileStub.callCount).to.eql(1);
+                    expect(patchEventToArchiveFileStub.callCount).to.eql(dummyMeteredEvents.length);
+                    expect(deleteResourceStub.callCount).to.eql(dummyMeteredEvents.length);
+                });
+            });
+        });
+
+        describe('patchToMeteringStore', () => {
+            let sandbox, putArchiveFileStub, deleteResourceStub, patchEventToArchiveFileStub;
+            beforeEach(() => {
+                sandbox = sinon.createSandbox();
+                putArchiveFileStub = sandbox.stub(meteringArchiveStore, 'putArchiveFile');
+                patchEventToArchiveFileStub = sandbox.stub(meteringArchiveStore, 'patchEventToArchiveFile');
+                deleteResourceStub = sandbox.stub(eventmesh.apiServerClient, 'deleteResource');
+            });
+            afterEach(() => {
+                sandbox.restore();
+            });
+            it('processes events based on the config', () => {
+                putArchiveFileStub.resolves();
+                patchEventToArchiveFileStub.resolves();
+                deleteResourceStub.resolves();
+                return ArchiveMeteredEventsJob.patchToMeteringStore(dummyMeteredEvents, 'dummy-timestamp', 20)
+                .then(eventsPatched => {
+                    expect(eventsPatched).to.eql(dummyMeteredEvents.length);
+                    expect(putArchiveFileStub.callCount).to.eql(1);
+                    expect(patchEventToArchiveFileStub.callCount).to.eql(dummyMeteredEvents.length);
+                    expect(deleteResourceStub.callCount).to.eql(dummyMeteredEvents.length);
+                });
+            });
+            it('handles error while processing event', () => {
+                putArchiveFileStub.resolves();
+                patchEventToArchiveFileStub.rejects();
+                return ArchiveMeteredEventsJob.patchToMeteringStore(dummyMeteredEvents, 'dummy-timestamp', 20)
+                .catch(err => {
+                    expect(putArchiveFileStub.callCount).to.eql(1);
+                    expect(patchEventToArchiveFileStub.callCount).to.eql(1);
+                });
+            });
+        });
+
+        describe('processEvent', () => {
+            let sandbox, patchEventToArchiveFileStub, deleteResourceStub;
+            beforeEach(() => {
+                sandbox = sinon.createSandbox();
+                patchEventToArchiveFileStub = sandbox.stub(meteringArchiveStore, 'patchEventToArchiveFile');
+                deleteResourceStub = sandbox.stub(eventmesh.apiServerClient, 'deleteResource');
+            });
+            afterEach(() => {
+                sandbox.restore();
+            });
+            it('patches event to MeteringStore and deletes it from ApiServer', () => {
+                patchEventToArchiveFileStub.resolves();
+                deleteResourceStub.resolves();
+                let dummyTimeStamp = 'dummyTimeStamp';
+                return ArchiveMeteredEventsJob.processEvent(dummyMeteredEvents[0], dummyTimeStamp)
+                .then(() => {
+                    expect(patchEventToArchiveFileStub.callCount).to.eql(1);
+                    expect(patchEventToArchiveFileStub.firstCall.args[0].metadata.name).to.eql('sfevent-1');
+                    expect(patchEventToArchiveFileStub.firstCall.args[1]).to.eql(dummyTimeStamp);
+                    expect(deleteResourceStub.callCount).to.eql(1);
+                });
+            });
+
+            it('retries deleteResource call in case of failure', () => {
+                patchEventToArchiveFileStub.resolves();
+                deleteResourceStub.rejects('forced-exception');
+                let dummyTimeStamp = 'dummyTimeStamp';
+                return ArchiveMeteredEventsJob.processEvent(dummyMeteredEvents[0], dummyTimeStamp, 2)
+                .catch(err => {
+                    expect(patchEventToArchiveFileStub.callCount).to.eql(1);
+                    expect(patchEventToArchiveFileStub.firstCall.args[0].metadata.name).to.eql('sfevent-1');
+                    expect(patchEventToArchiveFileStub.firstCall.args[1]).to.eql(dummyTimeStamp);
+                    expect(deleteResourceStub.callCount).to.eql(2);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
* In each run job will patch a certain number of already `METERED` sfevents to service-fabrik-broker container in BackupStore and remove it from ApiServer.
* In each run a json file with path `MeteringArchive/MeteringArchive-<TimeStamp>.json` will be created.
* Number of events to be patched in a run and schedule for the job is configurable.