### PR TITLE
Edit response field also when abort/delete backup fails

### DIFF
--- a/operators/backup-operator/BackupService.js
+++ b/operators/backup-operator/BackupService.js
@@ -263,20 +263,7 @@ class BackupService extends BaseDirectorService {
         status: {
           'state': CONST.APISERVER.RESOURCE_STATE.DELETED
         }
-      }))
-      .catch(err => {
-        return Promise
-          .try(() => logger.error('Error during delete of backup', err))
-          .then(() => eventmesh.apiServerClient.updateResource({
-            resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
-            resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-            resourceId: options.backup_guid,
-            status: {
-              state: CONST.APISERVER.RESOURCE_STATE.DELETE_FAILED,
-              error: utils.buildErrorJson(err)
-            }
-          }));
-      });
+      }));
   }
 
   abortLastBackup(abortOptions, force) {
@@ -308,17 +295,6 @@ class BackupService extends BaseDirectorService {
           default:
             return _.pick(metadata, 'state');
         }
-      })
-      .catch(e => {
-        return eventmesh.apiServerClient.updateResource({
-          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
-          resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-          resourceId: abortOptions.guid,
-          status: {
-            state: CONST.APISERVER.RESOURCE_STATE.FAILED,
-            error: utils.buildErrorJson(e)
-          }
-        });
       });
   }
 

--- a/operators/backup-operator/DefaultBackupOperator.js
+++ b/operators/backup-operator/DefaultBackupOperator.js
@@ -30,18 +30,23 @@ class DefaultBackupOperator extends BaseOperator {
       } else if (changeObjectBody.status.state === CONST.APISERVER.RESOURCE_STATE.DELETE) {
         return DefaultBackupOperator._processDelete(changeObjectBody);
       }
-    }).catch(err => {
-      logger.error('Error occurred in processing request by DefaultBackupOperator', err);
-      return eventmesh.apiServerClient.updateResource({
-        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
-        resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
-        resourceId: changeObjectBody.metadata.name,
-        status: {
-          state: CONST.APISERVER.RESOURCE_STATE.FAILED,
-          error: utils.buildErrorJson(err)
-        }
+    })
+      .catch(err => {
+        logger.error(`Error occurred in processing request ${changeObjectBody.status.state} for guid ${changeObjectBody.metadata.name} by DefaultBackupOperator`, err);
+        return eventmesh.apiServerClient.updateResource({
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BACKUP,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
+          resourceId: changeObjectBody.metadata.name,
+          status: {
+            state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+            response: {
+              state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+              description: err.message
+            },
+            error: utils.buildErrorJson(err)
+          }
+        });
       });
-    });
   }
 
   static _processBackup(changeObjectBody) {


### PR DESCRIPTION
When `abort/delete` backup is attempted, backup operator writes state as `failed` but doesn't change the `response` field which remains in `processing` state.
Hence when lastBackupState is called, it still shows `processing` state.