### PR TITLE
Don't merge spec.parameters in sfserviceinstance on update call

### DIFF
--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -940,8 +940,12 @@ class ApiServerClient {
           const spec = _.merge(resource.spec, camelcaseKeys(opts.spec));
           _.set(opts, 'spec', spec);
         }
-        return this.updateOSBResource(opts);
-      });
+        if(_.get(opts, 'status.state') === CONST.APISERVER.RESOURCE_STATE.UPDATE && !_.isEmpty(_.get(resource, 'spec.parameters'))) {
+          // set parameters field to null
+          const clearParamsReqOpts = _.pick(opts, ['resourceGroup', 'resourceType', 'resourceId']);
+          return this.updateOSBResource(_.extend(clearParamsReqOpts, { 'spec': { 'parameters': null } }));
+        }
+      }).then(() => this.updateOSBResource(opts));
   }
 
   /**

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -602,7 +602,6 @@ describe('service-broker-api-2.0', function () {
           });
           const testPayload = _.cloneDeep(payload1);
           testPayload.spec = camelcaseKeys(payload1.spec);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {spec: {parameters: {key: 'val'}}});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, {spec: {parameters: null}});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, testPayload);
           return chai.request(app)
@@ -651,7 +650,7 @@ describe('service-broker-api-2.0', function () {
           });
           const testPayload = _.cloneDeep(payload);
           testPayload.spec = camelcaseKeys(payload.spec);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, {spec: {parameters: null}});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, testPayload);
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}?accepts_incomplete=true`)
@@ -828,7 +827,6 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           return chai.request(app)
@@ -897,7 +895,6 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           return chai.request(app)
@@ -933,7 +930,6 @@ describe('service-broker-api-2.0', function () {
               resourceVersion: 10
             }
           });
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockDeleteResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           return chai.request(app)

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -602,7 +602,8 @@ describe('service-broker-api-2.0', function () {
           });
           const testPayload = _.cloneDeep(payload1);
           testPayload.spec = camelcaseKeys(payload1.spec);
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {spec: {parameters: {key: 'val'}}});
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, {spec: {parameters: null}});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, testPayload);
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}?accepts_incomplete=true`)

--- a/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
@@ -280,8 +280,7 @@ describe('service-broker-api', function () {
 
           const testPayload2 = _.cloneDeep(payload2);
           testPayload2.spec = camelcaseKeys(payload2.spec);
-
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, {spec: {parameters: null}});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2 , 1);
           return chai.request(app)
@@ -317,7 +316,7 @@ describe('service-broker-api', function () {
 
           const testPayload2 = _.cloneDeep(payload2K8s);
           testPayload2.spec = camelcaseKeys(payload2K8s.spec);
-
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, {spec: {parameters: null}});
           mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload, 1);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);

--- a/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
@@ -281,9 +281,9 @@ describe('service-broker-api', function () {
           const testPayload2 = _.cloneDeep(payload2);
           testPayload2.spec = camelcaseKeys(payload2.spec);
 
-          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload, 1);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {});
-          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2 , 1);
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}`)
             .send({

--- a/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -1140,34 +1140,15 @@ describe('eventmesh', () => {
     });
     describe('patchOSBResource', () => {
       it('Patches osb resource with spec and status', () => {
-        const expectedGetResponse = {
-          spec: {
-            plan_id: 'plan1',
-            params: {
-              foo: 'bar'
-            },
-            context: {
-              organization_guid: 'org1',
-              space_guid: 'space1'
-            }
-          },
-          status: {
-            state: 'in_queue',
-            description: 'desc'
-          }
-        };
         const expectedResponse = {};
         const payload = {
           spec: {
             planId: 'plan2',
-            params: {
-              foo: 'bar'
-            },
+            serviceId: 'service2',
             context: {
               organization_guid: 'org2',
               space_guid: 'space2'
-            },
-            serviceId: 'service2'
+            }
           },
           metadata: {
             labels: {
@@ -1179,7 +1160,6 @@ describe('eventmesh', () => {
             description: ''
           }
         };
-        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'default', expectedGetResponse);
         nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'default', expectedResponse, payload);
         return apiserver.patchOSBResource({
             resourceId: 'deployment1',
@@ -1206,62 +1186,48 @@ describe('eventmesh', () => {
       });
 
       it('Patches osb resource in a namespace with spec and status', () => {
-        const expectedGetResponse = {
-          spec: {
-            plan_id: 'plan1',
-            params: {
-              foo: 'bar'
-            },
-            context: {
-              organization_guid: 'org1',
-              space_guid: 'space1'
-            }
-          },
-          status: {
-            state: 'in_queue',
-            description: 'desc'
-          }
-        };
         const expectedResponse = {};
         const payload = {
           spec: {
             planId: 'plan2',
-            params: {
-              foo: 'bar'
-            },
+            serviceId: 'service2',
             context: {
               organization_guid: 'org2',
               space_guid: 'space2'
             },
-            serviceId: 'service2'
+            params: {
+              foo: 'bar'
+            }
           },
           metadata: {
             labels: {
-              state: 'in_progress'
+              state: 'update'
             }
           },
           status: {
-            state: 'in_progress',
+            state: 'update',
             description: ''
           }
         };
-        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'namespace-id', expectedGetResponse);
-        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'namespace-id', expectedResponse, payload);
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'default', expectedResponse, {spec: {parameters: null}});
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'default', expectedResponse, payload);
         return apiserver.patchOSBResource({
             resourceId: 'deployment1',
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
-            namespaceId: 'namespace-id',
             spec: {
               plan_id: 'plan2',
               service_id: 'service2',
               context: {
                 organization_guid: 'org2',
                 space_guid: 'space2'
+              },
+              params: {
+                foo: 'bar'
               }
             },
             status: {
-              state: 'in_progress',
+              state: 'update',
               description: ''
             }
           })
@@ -1273,23 +1239,26 @@ describe('eventmesh', () => {
       });
 
       it('Patches osb resource fails with error', () => {
-        const expectedGetResponse = {
+        const payload = {
           spec: {
-            plan_id: 'plan1',
-            params: {
-              foo: 'bar'
-            },
+            planId: 'plan2',
+            serviceId: 'service2',
             context: {
-              organization_guid: 'org1',
-              space_guid: 'space1'
+              organization_guid: 'org2',
+              space_guid: 'space2'
+            }
+          },
+          metadata: {
+            labels: {
+              state: 'in_progress'
             }
           },
           status: {
-            state: 'in_queue',
-            description: 'desc'
+            state: 'in_progress',
+            description: ''
           }
         };
-        nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'default', expectedGetResponse);
+        nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, 'deployment1', 'default', {}, undefined, 404);
         return apiserver.patchOSBResource({
             resourceId: 'deployment1',
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,


### PR DESCRIPTION
Earlier on receiving update call, we were doing deep merge of spec. It was leading to merging of parameters field also.
For example old existing spec was like below:
```javascript
spec: {
  parameters: {
    param1: value1
  }
}
```
Now when user fires update call with -c params as `-c {param2 : value2}`
Ideally old parameters should get overwritten in spec object but with current approach it was resulting in following spec because of deep merging
```javascript
spec: {
  parameters: {
    param1: value1,
    param2: value2,
  }
}
```

With this fix, we will start getting desired result