### PR TITLE
Support other osb response params for bind request

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -342,11 +342,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
       .set('instance_id', req.params.instance_id)
       .value();
 
-    function done(encodedCredentials) {
-      const credentials = utils.decodeBase64(encodedCredentials);
-      res.status(CONST.HTTP_STATUS_CODE.CREATED).send({
-        credentials: credentials
-      });
+    function done(bindResponse) {
+      const response = utils.decodeBase64(bindResponse);
+      res.status(CONST.HTTP_STATUS_CODE.CREATED).send(response);
     }
 
     function conflict(err) {

--- a/broker/config/samples/templates/gotemplates/director/status.yaml
+++ b/broker/config/samples/templates/gotemplates/director/status.yaml
@@ -58,7 +58,8 @@ bind:
 {{- if eq $stateString "failed" }}
   error: {{ $error | quote }}
 {{- end }}
-  response: {{ $response }}
+  response:
+    credentials: {{ $response }}
 {{- with .directorbind.status.response }}
   {{- $response = (b64dec . | quote) }}
 {{- end }}

--- a/broker/config/samples/templates/gotemplates/director/status.yaml
+++ b/broker/config/samples/templates/gotemplates/director/status.yaml
@@ -38,7 +38,7 @@ provision:
 {{- end }}
   dashboardUrl: ""
 {{- with .directorbind.status.response }}
-  {{- $response = (b64dec . | quote) }}
+  {{- $response = (b64dec .) }}
 {{- end }}
 {{- $stateString = "in progress" }} 
 {{- with .directorbind }}
@@ -58,8 +58,7 @@ bind:
 {{- if eq $stateString "failed" }}
   error: {{ $error | quote }}
 {{- end }}
-  response:
-    credentials: {{ $response }}
+  response: {{ (printf "'{ \"credentials\" : %s }'" $response ) }}
 {{- with .directorbind.status.response }}
   {{- $response = (b64dec . | quote) }}
 {{- end }}

--- a/broker/config/samples/templates/gotemplates/docker/status.yaml
+++ b/broker/config/samples/templates/gotemplates/docker/status.yaml
@@ -32,7 +32,7 @@ provision:
 {{- end }}
   dashboardUrl: ""
 {{- with .dockerbind.status.response }}
-  {{- $response = (b64dec . | quote) }}
+  {{- $response = (b64dec .) }}
 {{- end }}
 {{- $stateString = "in progress" }} 
 {{- with .dockerbind }}
@@ -52,8 +52,7 @@ bind:
 {{- if eq $stateString "failed" }}
   error: {{ $error | quote}}
 {{- end }}
-  response:
-    credentials: {{ $response }}
+  response: {{ (printf "'{ \"credentials\" : %s }'" $response ) }}
 {{- with .dockerbind.status.response }}
   {{- $response = (b64dec . | quote) }}
 {{- end }}

--- a/broker/config/samples/templates/gotemplates/docker/status.yaml
+++ b/broker/config/samples/templates/gotemplates/docker/status.yaml
@@ -52,7 +52,8 @@ bind:
 {{- if eq $stateString "failed" }}
   error: {{ $error | quote}}
 {{- end }}
-  response: {{ $response }}
+  response:
+    credentials: {{ $response }}
 {{- with .dockerbind.status.response }}
   {{- $response = (b64dec . | quote) }}
 {{- end }}

--- a/broker/config/samples/templates/gotemplates/postgres/properties.yaml
+++ b/broker/config/samples/templates/gotemplates/postgres/properties.yaml
@@ -24,7 +24,8 @@ provision:
 bind:
   state: {{ printf "%s" $stateString }}
   error: ""
-  response: {{ (printf `"{ \"host\": \"%s\", \"username\": \"postgres\", \"password\": \"%s\" }"` $host  $pass ) }} 
+  response:
+    credentials: {{ (printf `"{ \"host\": \"%s\", \"username\": \"postgres\", \"password\": \"%s\" }"` $host  $pass ) }} 
 {{- $stateString = "succeeded" }}
 unbind:
   state: {{ printf "%s" $stateString }}

--- a/interoperator/config/samples/templates/helmtemplates/postgresqlStatus/templates/status.yaml
+++ b/interoperator/config/samples/templates/helmtemplates/postgresqlStatus/templates/status.yaml
@@ -13,4 +13,4 @@ status:
   description: {{ .Values.postgresql.status.reason | quote }}
 binding:
   error: ""
-  response: {{ (printf "{ \"host\": \"%s\", \"username\": \"postgres\", \"password\": \"%s\" }" .Values.service.spec.clusterIP  (.Values.secret.data.POSTGRES_PASSWORD | b64dec ) ) | b64enc }} 
+  response: {{ (printf "{\"credentials\":{\"host\": \"%s\", \"username\": \"postgres\", \"password\": \"%s\"}}" .Values.service.spec.clusterIP  (.Values.secret.data.POSTGRES_PASSWORD | b64dec ) ) | b64enc }} 

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -1315,7 +1315,7 @@ describe('service-broker-api-2.0', function () {
           });
           mocks.apiServerEventMesh.nockGetSecret('secret-name', 'default', {
             data: {
-              response: utils.encodeBase64(mocks.agent.credentials)
+              response: utils.encodeBase64({credentials: mocks.agent.credentials})
             }
           });
           return chai.request(app)
@@ -1362,7 +1362,7 @@ describe('service-broker-api-2.0', function () {
           });
           mocks.apiServerEventMesh.nockGetSecret('secret-name', 'default', {
             data: {
-              response: utils.encodeBase64(mocks.agent.credentials)
+              response: utils.encodeBase64({credentials: mocks.agent.credentials})
             }
           });
           return chai.request(app)
@@ -1409,7 +1409,7 @@ describe('service-broker-api-2.0', function () {
           });
           mocks.apiServerEventMesh.nockGetSecret('secret-name', 'default', {
             data: {
-              response: utils.encodeBase64(mocks.agent.credentials)
+              response: utils.encodeBase64({credentials: mocks.agent.credentials})
             }
           });
           return chai.request(app)

--- a/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
@@ -659,7 +659,7 @@ describe('service-broker-api', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
           mocks.apiServerEventMesh.nockGetSecret(binding_id, CONST.APISERVER.DEFAULT_NAMESPACE, {
             data: {
-              response: utils.encodeBase64(secretData)
+              response: utils.encodeBase64({credentials: secretData})
             }
           });
           return chai.request(app)


### PR DESCRIPTION
Bind request response can contain [other params](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#body-9) like `syslog_drain_url`, `route_service_url` etc.

Currently broker only supports credentials key. If following PR is merged... service operators can write entire osb conforming bind response object in `status` template.