### PR TITLE
Add option to disable Riemann event logging

### DIFF
--- a/common/utils/index.js
+++ b/common/utils/index.js
@@ -129,7 +129,9 @@ function initializeEventListener(appConfig, appType) {
     .assign(config.riemann)
     .set('event_type', appConfig.event_type)
     .value();
-  const riemannClient = new EventLogRiemannClient(riemannOptions); // eslint-disable-line no-unused-vars
+  if (riemannOptions.enabled !== false) {
+    const riemannClient = new EventLogRiemannClient(riemannOptions); // eslint-disable-line no-unused-vars
+  }
   // if events are to be forwarded to monitoring agent via domain socket
   if (appConfig.domain_socket && appConfig.domain_socket.fwd_events) {
     /* jshint unused:false */


### PR DESCRIPTION
This changes the behavior to only create the Riemann client if the setting `riemann.enabled` is not `false`. I.e. this adds a settings to disable Riemann.

The corresponding changes in the bosh release are in this pull request: https://github.com/cloudfoundry-incubator/service-fabrik-boshrelease/pull/181