### PR TITLE
Adding env by default while enriching the metering crd

### DIFF
--- a/jobs/MeterInstanceJob.js
+++ b/jobs/MeterInstanceJob.js
@@ -84,7 +84,7 @@ class MeterInstanceJob extends BaseJob {
     options.consumer.region = config.metering.region;
     if (!options.consumer.environment) {
       // By default environment should be cloudfoundry for now
-      options.consumer.environment = "CF"
+      options.consumer.environment = 'CF';
     }
     logger.info('Enriched metering document', options);
     return options;

--- a/jobs/MeterInstanceJob.js
+++ b/jobs/MeterInstanceJob.js
@@ -82,6 +82,10 @@ class MeterInstanceJob extends BaseJob {
     options.service.plan = catalog.getPlanSKUFromPlanGUID(serviceId, planId);
     options.service = _.omit(options.service, ['service_guid', 'plan_guid']);
     options.consumer.region = config.metering.region;
+    if (!options.consumer.environment) {
+      // By default environment should be cloudfoundry for now
+      options.consumer.environment = "CF"
+    }
     logger.info('Enriched metering document', options);
     return options;
   }

--- a/test/test_broker/jobs.MeteringInstanceJobs.spec.js
+++ b/test/test_broker/jobs.MeteringInstanceJobs.spec.js
@@ -349,7 +349,7 @@ describe('Jobs', () => {
         options_json.service.plan_guid = not_excluded_plan;
         expect(MeterInstanceJob.enrichEvent(options_json)).to.eql({
           'consumer': {
-            'environment': '',
+            'environment': 'CF',
             'instance': '4e099918-1b37-42a8-9dbd-a752225fcd07',
             'org': '33915d88-6002-4e83-b154-9ec2075e1435',
             'region': 'asia',


### PR DESCRIPTION
* Currently MaaS expects `consumer.environment` to be one of `(cf|CF|neo|NEO)`. Therefore we can have `CF` as default value for now.