### PR TITLE
Add post processing polling to bosh manager

### DIFF
--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -118,7 +118,6 @@ defaults: &defaults
     ServiceInstanceAutoUpdate: true #Switch to turn on / turn off schedule_update feature
     EnableSecurityGroupsOps: true
     AllowInstanceSharing: true
-    ServiceInstancePostProcessing: false
   # this timeout is set to 175 secs by default because CF has a default timeout of 180 secs
   http_timeout: 175000
   deployment_action_timeout: 80000

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -118,6 +118,7 @@ defaults: &defaults
     ServiceInstanceAutoUpdate: true #Switch to turn on / turn off schedule_update feature
     EnableSecurityGroupsOps: true
     AllowInstanceSharing: true
+    ServiceInstancePostProcessing: false
   # this timeout is set to 175 secs by default because CF has a default timeout of 180 secs
   http_timeout: 175000
   deployment_action_timeout: 80000

--- a/common/constants.js
+++ b/common/constants.js
@@ -367,6 +367,7 @@ module.exports = Object.freeze({
       IN_QUEUE: 'in_queue',
       IN_PROGRESS: 'in_progress',
       WAITING: 'waiting',
+      POST_PROCESSING: 'post_processing',
       DELETE: 'delete',
       DELETED: 'deleted',
       SUCCEEDED: 'succeeded',

--- a/data-access-layer/service-agent/Agent.js
+++ b/data-access-layer/service-agent/Agent.js
@@ -209,8 +209,8 @@ class Agent extends HttpClient {
    * @returns {*} The response of the agent
    */
   getProcessingState(ips, eventType, lifecycleState) {
-    const featureName = `processing.${lifecycleState}${eventType}`; // TODO check feature name
-    const pathname = `processing/${lifecycleState}${eventType}`; // TODO check route
+    const featureName = `lifecycle.async.${lifecycleState}${eventType}`;
+    const pathname = `lifecycle/${lifecycleState}${eventType}`;
 
     return this
       .getHost(ips, featureName)

--- a/data-access-layer/service-agent/Agent.js
+++ b/data-access-layer/service-agent/Agent.js
@@ -200,6 +200,29 @@ class Agent extends HttpClient {
       .then(ip => this.post(ip, 'lifecycle/preupdate', context, CONST.HTTP_STATUS_CODE.OK, agentCredsBeforeUpdate));
   }
 
+  /**
+   * Poll the agent for the process of the lifecycle last operation within the deployment
+   *
+   * @param ips The ip addresses of all available agents
+   * @param {string} eventType The current lifecycle event, supported values: "create", "update"
+   * @param {string} lifecycleState The current lifecycle state of the operation, supported values: "post"
+   * @returns {*} The response of the agent
+   */
+  getProcessingState(ips, eventType, lifecycleState) {
+    const featureName = `processing.${lifecycleState}${eventType}`; // TODO check feature name
+    const pathname = `processing/${lifecycleState}${eventType}`; // TODO check route
+
+    return this
+      .getHost(ips, featureName)
+      .then(ip => this.getUrl(ip, pathname))
+      .then(url => this.request({
+        method: 'GET',
+        url: url,
+        auth: this.auth
+      }, CONST.HTTP_STATUS_CODE.OK))
+      .then(res => res.body);
+  }
+
   createCredentials(ips, parameters, preBindResponse) {
     const body = {
       parameters: parameters,

--- a/operators/StartBoshOperators.js
+++ b/operators/StartBoshOperators.js
@@ -4,11 +4,13 @@ const BoshOperator = require('./bosh-operator/BoshOperator');
 const BoshBindOperator = require('./bosh-operator/BoshBindOperator');
 const BoshTaskStatusPoller = require('./bosh-operator/BoshTaskStatusPoller');
 const BoshStaggeredDeploymentPoller = require('./bosh-operator/BoshStaggeredDeploymentPoller');
+const BoshPostProcessingPoller = require('./bosh-operator/BoshPostProcessingPoller');
 
 const boshOperator = new BoshOperator();
 const boshBindOperator = new BoshBindOperator();
 /* jshint nonew:false */
 new BoshTaskStatusPoller();
 new BoshStaggeredDeploymentPoller();
+new BoshPostProcessingPoller(); // TODO maybe disable this with the feature switch
 boshOperator.init();
 boshBindOperator.init();

--- a/operators/StartBoshOperators.js
+++ b/operators/StartBoshOperators.js
@@ -11,6 +11,6 @@ const boshBindOperator = new BoshBindOperator();
 /* jshint nonew:false */
 new BoshTaskStatusPoller();
 new BoshStaggeredDeploymentPoller();
-new BoshPostProcessingPoller(); // TODO maybe disable this with the feature switch
+new BoshPostProcessingPoller();
 boshOperator.init();
 boshBindOperator.init();

--- a/operators/bosh-operator/BoshPostProcessingPoller.js
+++ b/operators/bosh-operator/BoshPostProcessingPoller.js
@@ -32,7 +32,7 @@ class BoshPostProcessingPoller extends BaseStatusPoller {
     }
     return DirectorService
       .createInstance(instanceId, resourceOptions)
-      .then(directorService => directorService.getAgentPostProcessingStatus(operationType, deploymentName))
+      .then(directorService => directorService.getAgentLifecyclePostProcessingStatus(operationType, deploymentName))
       .tap(agentResponse => logger.debug('agent response is ', agentResponse))
       .then(agentResponse => Promise.all([eventmesh.apiServerClient.updateResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,

--- a/operators/bosh-operator/BoshPostProcessingPoller.js
+++ b/operators/bosh-operator/BoshPostProcessingPoller.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const _ = require('lodash');
+const Promise = require('bluebird');
+const eventmesh = require('../../data-access-layer/eventmesh');
+const CONST = require('../../common/constants');
+const logger = require('../../common/logger');
+const utils = require('../../common/utils');
+const DirectorService = require('./DirectorService');
+const BaseStatusPoller = require('../BaseStatusPoller');
+
+class BoshPostProcessingPoller extends BaseStatusPoller {
+  constructor() {
+    super({
+      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+      validStateList: [CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING],
+      validEventList: [CONST.API_SERVER.WATCH_EVENT.ADDED, CONST.API_SERVER.WATCH_EVENT.MODIFIED],
+      pollInterval: CONST.DIRECTOR_RESOURCE_POLLER_INTERVAL
+    });
+  }
+
+  getStatus(resourceBody, intervalId) {
+    const instanceId = resourceBody.metadata.name;
+    const resourceOptions = _.get(resourceBody, 'spec.options');
+    const deploymentName = _.get(resourceBody, 'status.response.deployment_name');
+    const operationType = _.get(resourceBody, 'status.response.type');
+    return DirectorService
+      .createInstance(instanceId, resourceOptions)
+      .then(directorService => directorService.getAgentPostProcessingStatus(operationType, deploymentName))
+      .tap(postProcessingState => logger.debug('post processing state is ', postProcessingState))
+      .then(status => Promise.all([eventmesh.apiServerClient.updateResource({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+        resourceId: instanceId,
+        status: {
+          // TODO set response? set description?
+          // response: _.assign(resourceBody.status.response, directorResponse),
+          state: status.state
+        }
+      }), Promise.try(() => {
+        // cancel the poller and clear the array
+        if (_.includes([CONST.APISERVER.RESOURCE_STATE.SUCCEEDED, CONST.APISERVER.RESOURCE_STATE.FAILED], status.state)) {
+          this.clearPoller(instanceId, intervalId);
+        }
+      })]))
+      .catch(err => {
+        logger.error(`Error occurred while post processing deployment for instance ${instanceId}`, err);
+        const timestamp = new Date().toISOString();
+        this.clearPoller(instanceId, intervalId);
+        return eventmesh.apiServerClient.updateResource({
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR,
+          resourceId: instanceId,
+          status: {
+            state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+            lastOperation: {
+              state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+              description: `${operationType} deployment ${deploymentName} failed at ${timestamp} with Error "${err.message}"`
+            },
+            error: utils.buildErrorJson(err)
+          }
+        });
+      });
+
+  }
+}
+
+module.exports = BoshPostProcessingPoller;

--- a/operators/bosh-operator/BoshPostProcessingPoller.js
+++ b/operators/bosh-operator/BoshPostProcessingPoller.js
@@ -41,7 +41,7 @@ class BoshPostProcessingPoller extends BaseStatusPoller {
         status: {
           lastOperation: _.assign(resourceBody.status.lastOperation, {
             resourceState: agentResponse.state,
-            description: _.get(agentResponse, 'stage', description)
+            description: _.get(agentResponse, 'description', description)
           }),
           state: agentResponse.state
         }

--- a/operators/bosh-operator/BoshPostProcessingPoller.js
+++ b/operators/bosh-operator/BoshPostProcessingPoller.js
@@ -39,8 +39,9 @@ class BoshPostProcessingPoller extends BaseStatusPoller {
         resourceId: instanceId,
         status: {
           // TODO set response? set description?
-          // response: _.assign(resourceBody.status.response, directorResponse),
-          state: status.state
+          // lastOperation: _.assign(resourceBody.status.lastOperation, {}),
+          // response: _.assign(resourceBody.status.response, { agent: agentResponse }),
+          state: agentResponse.state
         }
       }), Promise.try(() => {
         // cancel the poller and clear the array

--- a/operators/bosh-operator/BoshTaskStatusPoller.js
+++ b/operators/bosh-operator/BoshTaskStatusPoller.js
@@ -130,6 +130,7 @@ class BoshTaskStatusPoller extends BaseStatusPoller {
       if (lastOperationValue.resourceState === CONST.APISERVER.RESOURCE_STATE.SUCCEEDED) {
         if (lastOperationValue.type === CONST.OPERATION_TYPE.CREATE ||
           lastOperationValue.type === CONST.OPERATION_TYPE.UPDATE) {
+          const postProcessingEnabled = _.get(config, 'feature.ServiceInstancePostProcessing', false); // TODO add as feature switch?
           return directorService.director.getDeploymentNameForInstanceId(directorService.guid)
             .then(deploymentName => directorService.director.getDeploymentIpsFromDirector(deploymentName))
             .then(ips => eventmesh.apiServerClient.updateResource({
@@ -138,7 +139,7 @@ class BoshTaskStatusPoller extends BaseStatusPoller {
               resourceId: instanceId,
               status: {
                 lastOperation: lastOperationValue,
-                state: lastOperationValue.resourceState,
+                state: postProcessingEnabled ? CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING : lastOperationValue.resourceState,
                 appliedOptions: options
               },
               metadata: {

--- a/operators/bosh-operator/BoshTaskStatusPoller.js
+++ b/operators/bosh-operator/BoshTaskStatusPoller.js
@@ -130,7 +130,7 @@ class BoshTaskStatusPoller extends BaseStatusPoller {
       if (lastOperationValue.resourceState === CONST.APISERVER.RESOURCE_STATE.SUCCEEDED) {
         if (lastOperationValue.type === CONST.OPERATION_TYPE.CREATE ||
           lastOperationValue.type === CONST.OPERATION_TYPE.UPDATE) {
-          const postProcessingEnabled = _.get(config, 'feature.ServiceInstancePostProcessing', false); // TODO add as feature switch?
+          const postProcessingEnabled = _.get(config, 'feature.ServiceInstancePostProcessing', false);
           return directorService.director.getDeploymentNameForInstanceId(directorService.guid)
             .then(deploymentName => directorService.director.getDeploymentIpsFromDirector(deploymentName))
             .then(ips => eventmesh.apiServerClient.updateResource({

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -666,9 +666,10 @@ class DirectorService extends BaseDirectorService {
           };
         })
         .catch(err => {
+          // If an unexpected error occurs (e.g. bosh not reachable) try it again later
           logger.error('Error occurred while querying agent of feature \'postprocessing\':', err);
           return {
-            state: CONST.APISERVER.RESOURCE_STATE.FAILED
+            state: CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING
           };
         });
     } else {

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -634,10 +634,7 @@ class DirectorService extends BaseDirectorService {
   }
 
   getAgentPostProcessingStatus(operationType, deploymentName) {
-    const featureName = {
-      'create': 'processing.postcreate', // TODO check feature names
-      'update': 'processing.postupdate'
-    }[operationType];
+    const featureName = `processing.post${operationType}`; // TODO check feature names
     if (_.includes(this.agent.features, featureName)) {
       return this
         .getDeploymentIps(deploymentName)

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -719,10 +719,14 @@ class DirectorService extends BaseDirectorService {
     const timestamp = new Date(task.timestamp * 1000).toISOString();
     switch (task.state) {
       case 'done':
+        // only start postprocessing if it is enabled by a feature flag and supported by the agent
+        const postProcessingFeatureName = `processing.post${operation.type}`; // TODO check feature names
+        const shallPostProcess = _.get(config, 'feature.ServiceInstancePostProcessing', false) &&
+          _.includes(this.agent.features, postProcessingFeatureName);
         return _.assign(operation, {
           description: `${action} deployment ${task.deployment} succeeded at ${timestamp}`,
           state: 'succeeded',
-          resourceState: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
+          resourceState: shallPostProcess ? CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING : CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
         });
       case 'error':
       case 'cancelled':

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -721,8 +721,7 @@ class DirectorService extends BaseDirectorService {
       case 'done':
         // only start postprocessing if it is enabled by a feature flag and supported by the agent
         const postProcessingFeatureName = `processing.post${operation.type}`; // TODO check feature names
-        const shallPostProcess = _.get(config, 'feature.ServiceInstancePostProcessing', false) &&
-          _.includes(this.agent.features, postProcessingFeatureName);
+        const shallPostProcess = _.includes(this.agent.features, postProcessingFeatureName);
         return _.assign(operation, {
           description: `${action} deployment ${task.deployment} succeeded at ${timestamp}`,
           state: 'succeeded',

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -633,6 +633,54 @@ class DirectorService extends BaseDirectorService {
       });
   }
 
+  getAgentPostProcessingStatus(operationType, deploymentName) {
+    const featureName = {
+      'create': 'processing.postcreate', // TODO check feature names
+      'update': 'processing.postupdate'
+    }[operationType];
+    if (_.includes(this.agent.features, featureName)) {
+      return this
+        .getDeploymentIps(deploymentName)
+        .then(ips => this.agent.getProcessingState(ips, operationType, 'post'))
+        .then(res => {
+          let state;
+          switch (res.state) {
+            case 'succeeded':
+              state = CONST.APISERVER.RESOURCE_STATE.SUCCEEDED;
+              break;
+            case 'processing':
+              state = CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING;
+              break;
+            case 'failed':
+            default:
+              state = CONST.APISERVER.RESOURCE_STATE.FAILED;
+              break;
+          }
+          return {
+            state,
+            stage: res.stage,
+            update_at: res.update_at
+          };
+        })
+        .catch(FeatureNotSupportedByAnyAgent, err => {
+          logger.debug('+-> Caught expected error of feature \'postprocessing\':', err);
+          return {
+            state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
+          };
+        })
+        .catch(err => {
+          logger.error('Error occurred while querying agent of feature \'postprocessing\':', err);
+          return {
+            state: CONST.APISERVER.RESOURCE_STATE.FAILED
+          };
+        });
+    } else {
+      return Promise.resolve({
+        state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
+      });
+    }
+  }
+
   getBoshTaskStatus(instanceId, operation, taskId) {
     return Promise
       .try(() => {

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -633,8 +633,8 @@ class DirectorService extends BaseDirectorService {
       });
   }
 
-  getAgentPostProcessingStatus(operationType, deploymentName) {
-    const featureName = `processing.post${operationType}`; // TODO check feature names
+  getAgentLifecyclePostProcessingStatus(operationType, deploymentName) {
+    const featureName = `lifecycle.async.post${operationType}`;
     if (_.includes(this.agent.features, featureName)) {
       return this
         .getDeploymentIps(deploymentName)
@@ -720,12 +720,12 @@ class DirectorService extends BaseDirectorService {
     switch (task.state) {
       case 'done':
         // only start postprocessing if it is enabled by a feature flag and supported by the agent
-        const postProcessingFeatureName = `processing.post${operation.type}`; // TODO check feature names
-        const shallPostProcess = _.includes(this.agent.features, postProcessingFeatureName);
+        const postProcessingFeatureName = `lifecycle.async.post${operation.type}`;
+        const shallWaitForPostProcessing = _.includes(this.agent.features, postProcessingFeatureName);
         return _.assign(operation, {
           description: `${action} deployment ${task.deployment} succeeded at ${timestamp}`,
           state: 'succeeded',
-          resourceState: shallPostProcess ? CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING : CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
+          resourceState: shallWaitForPostProcessing ? CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING : CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
         });
       case 'error':
       case 'cancelled':

--- a/test/test_broker/mocks/agent.js
+++ b/test/test_broker/mocks/agent.js
@@ -16,8 +16,8 @@ exports.getInfo = getInfo;
 exports.getState = getState;
 exports.deprovision = deprovision;
 exports.preUpdate = preUpdate;
-exports.getPostCreateProcessingState = getPostCreateProcessingState;
-exports.getPostUpdateProcessingState = getPostUpdateProcessingState;
+exports.getLifecyclePostCreateProcessingState = getLifecyclePostCreateProcessingState;
+exports.getLifecyclePostUpdateProcessingState = getLifecyclePostUpdateProcessingState;
 exports.createCredentials = createCredentials;
 exports.deleteCredentials = deleteCredentials;
 exports.startBackup = startBackup;
@@ -31,7 +31,7 @@ exports.getRestoreLogs = getRestoreLogs;
 
 function getInfo(times, featureNotSupported) {
   let supportedFeatures = ['state', 'lifecycle', 'credentials', 'backup', 'restore', 'multi_tenancy',
-    'lifecycle.preupdate', 'processing.postcreate', 'processing.postupdate'];
+    'lifecycle.preupdate', 'lifecycle.async.postcreate', 'lifecycle.async.postupdate'];
   if (featureNotSupported) {
     supportedFeatures.splice(supportedFeatures.indexOf(featureNotSupported), 1);
   }
@@ -73,16 +73,16 @@ function preUpdate(expectedReturnStatusCode) {
     .reply(expectedReturnStatusCode || 200, {});
 }
 
-function getPostCreateProcessingState(body, status) {
+function getLifecyclePostCreateProcessingState(body, status) {
   return nock(agentUrl)
     .replyContentLength()
-    .get('/v1/processing/postcreate')
+    .get('/v1/lifecycle/postcreate')
     .reply(status || 200, body);
 }
 
-function getPostUpdateProcessingState(body, status) {
+function getLifecyclePostUpdateProcessingState(body, status) {
   return nock(agentUrl)
-    .get('/v1/processing/postupdate')
+    .get('/v1/lifecycle/postupdate')
     .reply(status || 200, body);
 }
 

--- a/test/test_broker/mocks/agent.js
+++ b/test/test_broker/mocks/agent.js
@@ -16,6 +16,8 @@ exports.getInfo = getInfo;
 exports.getState = getState;
 exports.deprovision = deprovision;
 exports.preUpdate = preUpdate;
+exports.getPostCreateProcessingState = getPostCreateProcessingState;
+exports.getPostUpdateProcessingState = getPostUpdateProcessingState;
 exports.createCredentials = createCredentials;
 exports.deleteCredentials = deleteCredentials;
 exports.startBackup = startBackup;
@@ -28,7 +30,8 @@ exports.lastRestoreOperation = lastRestoreOperation;
 exports.getRestoreLogs = getRestoreLogs;
 
 function getInfo(times, featureNotSupported) {
-  let supportedFeatures = ['state', 'lifecycle', 'credentials', 'backup', 'restore', 'multi_tenancy', 'lifecycle.preupdate'];
+  let supportedFeatures = ['state', 'lifecycle', 'credentials', 'backup', 'restore', 'multi_tenancy',
+    'lifecycle.preupdate', 'processing.postcreate', 'processing.postupdate'];
   if (featureNotSupported) {
     supportedFeatures.splice(supportedFeatures.indexOf(featureNotSupported), 1);
   }
@@ -68,6 +71,19 @@ function preUpdate(expectedReturnStatusCode) {
     .replyContentLength()
     .post('/v1/lifecycle/preupdate', {})
     .reply(expectedReturnStatusCode || 200, {});
+}
+
+function getPostCreateProcessingState(body, status) {
+  return nock(agentUrl)
+    .replyContentLength()
+    .get('/v1/processing/postcreate')
+    .reply(status || 200, body);
+}
+
+function getPostUpdateProcessingState(body, status) {
+  return nock(agentUrl)
+    .get('/v1/processing/postupdate')
+    .reply(status || 200, body);
 }
 
 function createCredentials() {

--- a/test/test_broker/operators.BoshPostProcessingPoller.spec.js
+++ b/test/test_broker/operators.BoshPostProcessingPoller.spec.js
@@ -1,0 +1,401 @@
+'use strict';
+
+const _ = require('lodash');
+const CONST = require('../../common/constants');
+const proxyquire = require('proxyquire');
+const BaseStatusPoller = require('../../operators/BaseStatusPoller');
+
+describe('operators', function () {
+  describe('BoshPostProcessingPoller', function () {
+
+    const index = mocks.director.networkSegmentIndex;
+    const instance_id = mocks.director.uuidByIndex(index);
+    const plan_id = 'bc158c9a-7934-401e-94ab-057082a5073f';
+
+    const resourceBody = {
+      apiVersion: 'deployment.servicefabrik.io/v1alpha1',
+      kind: 'Director',
+      metadata: {
+        annotations: {
+          lockedByManager: '',
+          lockedByTaskPoller: '{\"lockTime\":\"2018-09-06T16:38:34.919Z\",\"ip\":\"10.0.2.2\"}'
+        },
+        creationTimestamp: '2018-09-06T16:01:28Z',
+        generation: 1,
+        labels: {
+          state: 'post_processing'
+        },
+        name: instance_id,
+        namespace: 'default',
+        resourceVersion: '3364',
+        selfLink: `/apis/deployment.servicefabrik.io/v1alpha1/namespaces/default/directors/${instance_id}`,
+        uid: '1d48b3f3-b1ee-11e8-ac2a-06c007f8352b'
+      },
+      spec: {
+        options: {
+          service_id: 'service_id',
+          plan_id: plan_id,
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: 'organization_guid',
+            space_guid: 'space_guid'
+          },
+          organization_guid: 'organization_guid',
+          space_guid: 'space_guid'
+        }
+      },
+      status: {
+        state: 'post_processing',
+        lastOperation: {
+          type: 'create',
+          parameters: {'foo': 'bar'},
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: 'organization_guid',
+            space_guid: 'space_guid'
+          },
+          task_id: 'task_id',
+          deployment_name: 'deployment_name',
+          description: 'description',
+          state: 'succeeded',
+          resourceState: 'succeeded'
+        },
+        response: {
+          type: 'create',
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: 'organization_guid',
+            space_guid: 'space_guid'
+          },
+          deployment_name: 'deployment_name',
+          task_id: "task_id"
+        }
+      }
+    };
+
+
+    let sandbox, initStub, clearPollerStub, createStub, updateStub, deleteStub, getAgentPostProcessingStatusStub;
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      initStub = sandbox.stub(BaseStatusPoller.prototype, 'init');
+      clearPollerStub = sandbox.stub(BaseStatusPoller.prototype, 'clearPoller');
+      createStub = sandbox.stub();
+      updateStub = sandbox.stub();
+      deleteStub = sandbox.stub();
+      getAgentPostProcessingStatusStub = sandbox.stub();
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    after(function () {
+      sandbox.restore();
+    });
+
+    describe('#getStatus', function () {
+      it('create postprocessing should stay as long as it is processing', function (done) {
+        initStub.returns(Promise.resolve());
+        clearPollerStub.returns(Promise.resolve());
+        const BoshPostProcessingPoller = proxyquire('../../operators/bosh-operator/BoshPostProcessingPoller.js', {
+          './DirectorService': {
+            'createInstance': function () {
+              /* jshint unused:false */
+              return Promise.resolve({
+                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+              });
+            }
+          }
+        });
+        const boshPostProcessingPoller = new BoshPostProcessingPoller();
+        const resourceBodyCopy = _.cloneDeep(resourceBody);
+        const type = 'create';
+        resourceBodyCopy.status.lastOperation.type = type;
+        resourceBodyCopy.status.response.type = type;
+        getAgentPostProcessingStatusStub
+          .withArgs(type, 'deployment_name')
+          .onCall(0)
+          .returns(Promise.resolve({
+            state: CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING,
+            stage: 'Step 3/5',
+            update_at: new Date().toISOString()
+          }));
+        const expectedPayload = {
+          status: {
+            state: CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING
+          }
+        };
+        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, expectedPayload);
+        return boshPostProcessingPoller.getStatus(resourceBodyCopy, 'interval_id')
+          .spread((res) => {
+            /* jshint unused:false */
+            expect(res.statusCode).to.be.eql(200);
+            expect(res.body).to.be.eql({});
+            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(initStub.callCount).to.be.eql(1);
+            expect(clearPollerStub.callCount).to.be.eql(0);
+            mocks.verify();
+            done();
+          })
+          .catch(done);
+      });
+
+      it('update postprocessing should stay as long as it is processing', function (done) {
+        initStub.returns(Promise.resolve());
+        clearPollerStub.returns(Promise.resolve());
+        const BoshPostProcessingPoller = proxyquire('../../operators/bosh-operator/BoshPostProcessingPoller.js', {
+          './DirectorService': {
+            'createInstance': function () {
+              /* jshint unused:false */
+              return Promise.resolve({
+                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+              });
+            }
+          }
+        });
+        const boshPostProcessingPoller = new BoshPostProcessingPoller();
+        const resourceBodyCopy = _.cloneDeep(resourceBody);
+        const type = 'update';
+        resourceBodyCopy.status.lastOperation.type = type;
+        resourceBodyCopy.status.response.type = type;
+        getAgentPostProcessingStatusStub
+          .withArgs(type, 'deployment_name')
+          .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
+          .onCall(0)
+          .returns(Promise.resolve({
+            state: CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING,
+            stage: 'Step 3/5',
+            update_at: new Date().toISOString()
+          }));
+        const expectedPayload = {
+          status: {
+            state: CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING
+          }
+        };
+        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, expectedPayload);
+        return boshPostProcessingPoller.getStatus(resourceBodyCopy, 'interval_id')
+          .spread((res) => {
+            /* jshint unused:false */
+            expect(res.statusCode).to.be.eql(200);
+            expect(res.body).to.be.eql({});
+            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(initStub.callCount).to.be.eql(1);
+            expect(clearPollerStub.callCount).to.be.eql(0);
+            mocks.verify();
+            done();
+          })
+          .catch(done);
+      });
+
+      it('create postprocessing should succeed', function (done) {
+        initStub.returns(Promise.resolve());
+        clearPollerStub.returns(Promise.resolve());
+        const BoshPostProcessingPoller = proxyquire('../../operators/bosh-operator/BoshPostProcessingPoller.js', {
+          './DirectorService': {
+            'createInstance': function () {
+              /* jshint unused:false */
+              return Promise.resolve({
+                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+              });
+            }
+          }
+        });
+        const boshPostProcessingPoller = new BoshPostProcessingPoller();
+        const resourceBodyCopy = _.cloneDeep(resourceBody);
+        const type = 'create';
+        resourceBodyCopy.status.lastOperation.type = type;
+        resourceBodyCopy.status.response.type = type;
+        getAgentPostProcessingStatusStub
+          .withArgs(type, 'deployment_name')
+          .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
+          .onCall(0)
+          .returns(Promise.resolve({
+            state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED,
+            stage: 'Step 5/5',
+            update_at: new Date().toISOString()
+          }));
+        const expectedPayload = {
+          status: {
+            state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
+          }
+        };
+        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, expectedPayload);
+        return boshPostProcessingPoller.getStatus(resourceBodyCopy, 'interval_id')
+          .spread((res) => {
+            /* jshint unused:false */
+            expect(res.statusCode).to.be.eql(200);
+            expect(res.body).to.be.eql({});
+            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(initStub.callCount).to.be.eql(1);
+            expect(clearPollerStub.callCount).to.be.eql(1);
+            mocks.verify();
+            done();
+          })
+          .catch(done);
+      });
+
+      it('update postprocessing should succeed', function (done) {
+        initStub.returns(Promise.resolve());
+        clearPollerStub.returns(Promise.resolve());
+        const BoshPostProcessingPoller = proxyquire('../../operators/bosh-operator/BoshPostProcessingPoller.js', {
+          './DirectorService': {
+            'createInstance': function () {
+              /* jshint unused:false */
+              return Promise.resolve({
+                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+              });
+            }
+          }
+        });
+        const boshPostProcessingPoller = new BoshPostProcessingPoller();
+        const resourceBodyCopy = _.cloneDeep(resourceBody);
+        const type = 'update';
+        resourceBodyCopy.status.lastOperation.type = type;
+        resourceBodyCopy.status.response.type = type;
+        getAgentPostProcessingStatusStub
+          .withArgs(type, 'deployment_name')
+          .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
+          .onCall(0)
+          .returns(Promise.resolve({
+            state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED,
+            stage: 'Step 5/5',
+            update_at: new Date().toISOString()
+          }));
+        const expectedPayload = {
+          status: {
+            state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
+          }
+        };
+        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, expectedPayload);
+        return boshPostProcessingPoller.getStatus(resourceBodyCopy, 'interval_id')
+          .spread((res) => {
+            /* jshint unused:false */
+            expect(res.statusCode).to.be.eql(200);
+            expect(res.body).to.be.eql({});
+            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(initStub.callCount).to.be.eql(1);
+            expect(clearPollerStub.callCount).to.be.eql(1);
+            mocks.verify();
+            done();
+          })
+          .catch(done);
+      });
+
+      it('create postprocessing should be able to fail', function (done) {
+        initStub.returns(Promise.resolve());
+        clearPollerStub.returns(Promise.resolve());
+        const BoshPostProcessingPoller = proxyquire('../../operators/bosh-operator/BoshPostProcessingPoller.js', {
+          './DirectorService': {
+            'createInstance': function () {
+              /* jshint unused:false */
+              return Promise.resolve({
+                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+              });
+            }
+          }
+        });
+        const boshPostProcessingPoller = new BoshPostProcessingPoller();
+        const resourceBodyCopy = _.cloneDeep(resourceBody);
+        const type = 'create';
+        resourceBodyCopy.status.lastOperation.type = type;
+        resourceBodyCopy.status.response.type = type;
+        getAgentPostProcessingStatusStub
+          .withArgs(type, 'deployment_name')
+          .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
+          .onCall(0)
+          .returns(Promise.resolve({
+            state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+            stage: 'Step 3/5',
+            update_at: new Date().toISOString()
+          }));
+        const expectedPayload = {
+          status: {
+            state: CONST.APISERVER.RESOURCE_STATE.FAILED
+          }
+        };
+        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, expectedPayload);
+        return boshPostProcessingPoller.getStatus(resourceBodyCopy, 'interval_id')
+          .spread((res) => {
+            /* jshint unused:false */
+            expect(res.statusCode).to.be.eql(200);
+            expect(res.body).to.be.eql({});
+            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(initStub.callCount).to.be.eql(1);
+            expect(clearPollerStub.callCount).to.be.eql(1);
+            mocks.verify();
+            done();
+          })
+          .catch(done);
+      });
+
+
+      it('update postprocessing should be able to fail', function (done) {
+        initStub.returns(Promise.resolve());
+        clearPollerStub.returns(Promise.resolve());
+        const BoshPostProcessingPoller = proxyquire('../../operators/bosh-operator/BoshPostProcessingPoller.js', {
+          './DirectorService': {
+            'createInstance': function () {
+              /* jshint unused:false */
+              return Promise.resolve({
+                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+              });
+            }
+          }
+        });
+        const boshPostProcessingPoller = new BoshPostProcessingPoller();
+        const resourceBodyCopy = _.cloneDeep(resourceBody);
+        const type = 'update';
+        resourceBodyCopy.status.lastOperation.type = type;
+        resourceBodyCopy.status.response.type = type;
+        getAgentPostProcessingStatusStub
+          .withArgs(type, 'deployment_name')
+          .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
+          .onCall(0)
+          .returns(Promise.resolve({
+            state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+            stage: 'Step 3/5',
+            update_at: new Date().toISOString()
+          }));
+        const expectedPayload = {
+          status: {
+            state: CONST.APISERVER.RESOURCE_STATE.FAILED
+          }
+        };
+        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {}, 1, expectedPayload);
+        return boshPostProcessingPoller.getStatus(resourceBodyCopy, 'interval_id')
+          .spread((res) => {
+            /* jshint unused:false */
+            expect(res.statusCode).to.be.eql(200);
+            expect(res.body).to.be.eql({});
+            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(initStub.callCount).to.be.eql(1);
+            expect(clearPollerStub.callCount).to.be.eql(1);
+            mocks.verify();
+            done();
+          })
+          .catch(done);
+      });
+
+      it('no ops for deployment type unknown', function (done) {
+        initStub.returns(Promise.resolve());
+        clearPollerStub.returns(Promise.resolve());
+        const BoshPostProcessingPoller = proxyquire('../../operators/bosh-operator/BoshPostProcessingPoller.js', {
+          './DirectorService': {}
+        });
+        const resourceBodyCopy = _.cloneDeep(resourceBody);
+        resourceBodyCopy.status.lastOperation.type = 'random';
+        resourceBodyCopy.status.response.type = 'random';
+        const boshPostProcessingPoller = new BoshPostProcessingPoller();
+        return boshPostProcessingPoller.getStatus(resourceBodyCopy, 'interval_id')
+          .then(() => {
+            expect(createStub.callCount).to.be.eql(0);
+            expect(initStub.callCount).to.be.eql(1);
+            expect(clearPollerStub.callCount).to.be.eql(0);
+            done();
+          })
+          .catch(done);
+      });
+
+    });
+  });
+});

--- a/test/test_broker/operators.BoshPostProcessingPoller.spec.js
+++ b/test/test_broker/operators.BoshPostProcessingPoller.spec.js
@@ -74,7 +74,7 @@ describe('operators', function () {
     };
 
 
-    let sandbox, initStub, clearPollerStub, createStub, updateStub, deleteStub, getAgentPostProcessingStatusStub;
+    let sandbox, initStub, clearPollerStub, createStub, updateStub, deleteStub, getAgentLifecyclePostProcessingStatusStub;
     beforeEach(function () {
       sandbox = sinon.createSandbox();
       initStub = sandbox.stub(BaseStatusPoller.prototype, 'init');
@@ -82,7 +82,7 @@ describe('operators', function () {
       createStub = sandbox.stub();
       updateStub = sandbox.stub();
       deleteStub = sandbox.stub();
-      getAgentPostProcessingStatusStub = sandbox.stub();
+      getAgentLifecyclePostProcessingStatusStub = sandbox.stub();
     });
 
     afterEach(function () {
@@ -102,7 +102,7 @@ describe('operators', function () {
             'createInstance': function () {
               /* jshint unused:false */
               return Promise.resolve({
-                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+                'getAgentLifecyclePostProcessingStatus': getAgentLifecyclePostProcessingStatusStub
               });
             }
           }
@@ -112,7 +112,7 @@ describe('operators', function () {
         const type = 'create';
         resourceBodyCopy.status.lastOperation.type = type;
         resourceBodyCopy.status.response.type = type;
-        getAgentPostProcessingStatusStub
+        getAgentLifecyclePostProcessingStatusStub
           .withArgs(type, 'deployment_name')
           .onCall(0)
           .returns(Promise.resolve({
@@ -131,7 +131,7 @@ describe('operators', function () {
             /* jshint unused:false */
             expect(res.statusCode).to.be.eql(200);
             expect(res.body).to.be.eql({});
-            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(getAgentLifecyclePostProcessingStatusStub.callCount).to.be.eql(1);
             expect(initStub.callCount).to.be.eql(1);
             expect(clearPollerStub.callCount).to.be.eql(0);
             mocks.verify();
@@ -148,7 +148,7 @@ describe('operators', function () {
             'createInstance': function () {
               /* jshint unused:false */
               return Promise.resolve({
-                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+                'getAgentLifecyclePostProcessingStatus': getAgentLifecyclePostProcessingStatusStub
               });
             }
           }
@@ -158,7 +158,7 @@ describe('operators', function () {
         const type = 'update';
         resourceBodyCopy.status.lastOperation.type = type;
         resourceBodyCopy.status.response.type = type;
-        getAgentPostProcessingStatusStub
+        getAgentLifecyclePostProcessingStatusStub
           .withArgs(type, 'deployment_name')
           .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
           .onCall(0)
@@ -178,7 +178,7 @@ describe('operators', function () {
             /* jshint unused:false */
             expect(res.statusCode).to.be.eql(200);
             expect(res.body).to.be.eql({});
-            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(getAgentLifecyclePostProcessingStatusStub.callCount).to.be.eql(1);
             expect(initStub.callCount).to.be.eql(1);
             expect(clearPollerStub.callCount).to.be.eql(0);
             mocks.verify();
@@ -195,7 +195,7 @@ describe('operators', function () {
             'createInstance': function () {
               /* jshint unused:false */
               return Promise.resolve({
-                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+                'getAgentLifecyclePostProcessingStatus': getAgentLifecyclePostProcessingStatusStub
               });
             }
           }
@@ -205,7 +205,7 @@ describe('operators', function () {
         const type = 'create';
         resourceBodyCopy.status.lastOperation.type = type;
         resourceBodyCopy.status.response.type = type;
-        getAgentPostProcessingStatusStub
+        getAgentLifecyclePostProcessingStatusStub
           .withArgs(type, 'deployment_name')
           .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
           .onCall(0)
@@ -225,7 +225,7 @@ describe('operators', function () {
             /* jshint unused:false */
             expect(res.statusCode).to.be.eql(200);
             expect(res.body).to.be.eql({});
-            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(getAgentLifecyclePostProcessingStatusStub.callCount).to.be.eql(1);
             expect(initStub.callCount).to.be.eql(1);
             expect(clearPollerStub.callCount).to.be.eql(1);
             mocks.verify();
@@ -242,7 +242,7 @@ describe('operators', function () {
             'createInstance': function () {
               /* jshint unused:false */
               return Promise.resolve({
-                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+                'getAgentLifecyclePostProcessingStatus': getAgentLifecyclePostProcessingStatusStub
               });
             }
           }
@@ -252,7 +252,7 @@ describe('operators', function () {
         const type = 'update';
         resourceBodyCopy.status.lastOperation.type = type;
         resourceBodyCopy.status.response.type = type;
-        getAgentPostProcessingStatusStub
+        getAgentLifecyclePostProcessingStatusStub
           .withArgs(type, 'deployment_name')
           .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
           .onCall(0)
@@ -272,7 +272,7 @@ describe('operators', function () {
             /* jshint unused:false */
             expect(res.statusCode).to.be.eql(200);
             expect(res.body).to.be.eql({});
-            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(getAgentLifecyclePostProcessingStatusStub.callCount).to.be.eql(1);
             expect(initStub.callCount).to.be.eql(1);
             expect(clearPollerStub.callCount).to.be.eql(1);
             mocks.verify();
@@ -289,7 +289,7 @@ describe('operators', function () {
             'createInstance': function () {
               /* jshint unused:false */
               return Promise.resolve({
-                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+                'getAgentLifecyclePostProcessingStatus': getAgentLifecyclePostProcessingStatusStub
               });
             }
           }
@@ -299,7 +299,7 @@ describe('operators', function () {
         const type = 'create';
         resourceBodyCopy.status.lastOperation.type = type;
         resourceBodyCopy.status.response.type = type;
-        getAgentPostProcessingStatusStub
+        getAgentLifecyclePostProcessingStatusStub
           .withArgs(type, 'deployment_name')
           .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
           .onCall(0)
@@ -319,7 +319,7 @@ describe('operators', function () {
             /* jshint unused:false */
             expect(res.statusCode).to.be.eql(200);
             expect(res.body).to.be.eql({});
-            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(getAgentLifecyclePostProcessingStatusStub.callCount).to.be.eql(1);
             expect(initStub.callCount).to.be.eql(1);
             expect(clearPollerStub.callCount).to.be.eql(1);
             mocks.verify();
@@ -337,7 +337,7 @@ describe('operators', function () {
             'createInstance': function () {
               /* jshint unused:false */
               return Promise.resolve({
-                'getAgentPostProcessingStatus': getAgentPostProcessingStatusStub
+                'getAgentLifecyclePostProcessingStatus': getAgentLifecyclePostProcessingStatusStub
               });
             }
           }
@@ -347,7 +347,7 @@ describe('operators', function () {
         const type = 'update';
         resourceBodyCopy.status.lastOperation.type = type;
         resourceBodyCopy.status.response.type = type;
-        getAgentPostProcessingStatusStub
+        getAgentLifecyclePostProcessingStatusStub
           .withArgs(type, 'deployment_name')
           .withArgs(resourceBodyCopy.status.response.type, resourceBodyCopy.status.response.deployment_name)
           .onCall(0)
@@ -367,7 +367,7 @@ describe('operators', function () {
             /* jshint unused:false */
             expect(res.statusCode).to.be.eql(200);
             expect(res.body).to.be.eql({});
-            expect(getAgentPostProcessingStatusStub.callCount).to.be.eql(1);
+            expect(getAgentLifecyclePostProcessingStatusStub.callCount).to.be.eql(1);
             expect(initStub.callCount).to.be.eql(1);
             expect(clearPollerStub.callCount).to.be.eql(1);
             mocks.verify();

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -803,7 +803,6 @@ describe('#DirectorService', function () {
           supportedFeatures = _.clone(plan.manager.settings.agent.supported_features);
         });
         afterEach(function () {
-          config.feature.ServiceInstancePostProcessing = false;
           plan.manager.settings.agent.supported_features = supportedFeatures;
         });
         it('create: returns 200 OK (state = in progress)', function () {
@@ -894,7 +893,6 @@ describe('#DirectorService', function () {
           mocks.serviceFabrikClient.scheduleUpdate(instance_id, payload);
           config.scheduler.jobs.service_instance_update.run_every_xdays = 15;
           config.mongodb.provision.plan_id = 'TEST';
-          config.feature.ServiceInstancePostProcessing = true;
           const options = {
             service_id: service_id,
             plan_id: plan_id,
@@ -939,7 +937,6 @@ describe('#DirectorService', function () {
           mocks.serviceFabrikClient.scheduleUpdate(instance_id, payload);
           config.scheduler.jobs.service_instance_update.run_every_xdays = 15;
           config.mongodb.provision.plan_id = 'TEST';
-          config.feature.ServiceInstancePostProcessing = true;
           const options = {
             service_id: service_id,
             plan_id: plan_id,
@@ -1160,7 +1157,6 @@ describe('#DirectorService', function () {
           mocks.cloudController.findSecurityGroupByName(instance_id);
           config.scheduler.jobs.service_instance_update.run_every_xdays = 15;
           config.mongodb.provision.plan_id = 'TEST';
-          config.feature.ServiceInstancePostProcessing = true;
           const options = {
             service_id: service_id,
             plan_id: plan_id,
@@ -1197,7 +1193,6 @@ describe('#DirectorService', function () {
           mocks.cloudController.findSecurityGroupByName(instance_id);
           config.scheduler.jobs.service_instance_update.run_every_xdays = 15;
           config.mongodb.provision.plan_id = 'TEST';
-          config.feature.ServiceInstancePostProcessing = true;
           const options = {
             service_id: service_id,
             plan_id: plan_id,

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -652,6 +652,19 @@ describe('#DirectorService', function () {
 
 
       describe('#getAgentPostProcessingStatus', function () {
+
+        let getDeploymentIpsStub;
+        before(function () {
+          getDeploymentIpsStub = sinon.stub(DirectorService.prototype, 'getDeploymentIps');
+          getDeploymentIpsStub.returns(Promise.resolve([mocks.agent.ip]));
+        });
+        afterEach(function () {
+          getDeploymentIpsStub.resetHistory();
+        });
+        after(function () {
+          getDeploymentIpsStub.restore();
+        });
+
         const options = {
           service_id: service_id,
           plan_id: plan_id,
@@ -674,9 +687,6 @@ describe('#DirectorService', function () {
         });
 
         it('create: should return succeeded if feature is not supported by any agent', function () {
-          // TODO this response is cached and only necessary if this is the only test?
-          // mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext, 2);
-          mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo(1, 'processing.postcreate');
           return DirectorService.createInstance(instance_id, options)
             .tap(service => service.agent.settings.supported_features = _.concat(service.agent.features, 'processing.postcreate'))
@@ -690,7 +700,6 @@ describe('#DirectorService', function () {
         });
 
         it('create: should return postprocessing if agent returns processing', function () {
-          mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.getPostCreateProcessingState({
             state: 'processing',
@@ -709,7 +718,6 @@ describe('#DirectorService', function () {
         });
 
         it('create: should return succeeded if agent returns succeeded', function () {
-          mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.getPostCreateProcessingState({
             state: 'succeeded',
@@ -736,7 +744,6 @@ describe('#DirectorService', function () {
         });
 
         it('update: should return succeeded if feature is not supported by any agent', function () {
-          mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo(1, 'processing.postupdate');
           return DirectorService.createInstance(instance_id, options)
             .tap(service => service.agent.settings.supported_features = _.concat(service.agent.features, 'processing.postupdate'))
@@ -750,7 +757,6 @@ describe('#DirectorService', function () {
         });
 
         it('update: should return postprocessing if agent returns processing', function () {
-          mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.getPostUpdateProcessingState({
             state: 'processing',
@@ -769,7 +775,6 @@ describe('#DirectorService', function () {
         });
 
         it('update: should return succeeded if agent returns succeeded', function () {
-          mocks.director.getDeploymentInstances(deployment_name);
           mocks.agent.getInfo();
           mocks.agent.getPostUpdateProcessingState({
             state: 'succeeded',

--- a/test/test_broker/operators.DirectorService.spec.js
+++ b/test/test_broker/operators.DirectorService.spec.js
@@ -651,7 +651,7 @@ describe('#DirectorService', function () {
       });
 
 
-      describe('#getAgentPostProcessingStatus', function () {
+      describe('#getAgentLifecyclePostProcessingStatus', function () {
 
         let getDeploymentIpsStub;
         let supportedFeatures;
@@ -683,17 +683,17 @@ describe('#DirectorService', function () {
 
         it('create: should return succeeded if feature is not supported', function () {
           return DirectorService.createInstance(instance_id, options)
-            .then(service => service.getAgentPostProcessingStatus('create', 'deployment'))
+            .then(service => service.getAgentLifecyclePostProcessingStatus('create', 'deployment'))
             .then(res => {
               expect(_.get(res, 'state')).to.eql(CONST.APISERVER.RESOURCE_STATE.SUCCEEDED);
             });
         });
 
         it('create: should return succeeded if feature is not supported by any agent', function () {
-          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'processing.postcreate');
-          mocks.agent.getInfo(1, 'processing.postcreate');
+          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'lifecycle.async.postcreate');
+          mocks.agent.getInfo(1, 'lifecycle.async.postcreate');
           return DirectorService.createInstance(instance_id, options)
-            .then(service => service.getAgentPostProcessingStatus('create', deployment_name))
+            .then(service => service.getAgentLifecyclePostProcessingStatus('create', deployment_name))
             .then(res => {
               expect(_.pick(res, ['state'])).to.eql({
                 state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
@@ -703,15 +703,15 @@ describe('#DirectorService', function () {
         });
 
         it('create: should return postprocessing if agent returns processing', function () {
-          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'processing.postcreate');
+          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'lifecycle.async.postcreate');
           mocks.agent.getInfo();
-          mocks.agent.getPostCreateProcessingState({
+          mocks.agent.getLifecyclePostCreateProcessingState({
             state: 'processing',
             stage: 'Step 2/3',
             updated_at: new Date().toISOString()
           });
           return DirectorService.createInstance(instance_id, options)
-            .then(service => service.getAgentPostProcessingStatus('create', deployment_name))
+            .then(service => service.getAgentLifecyclePostProcessingStatus('create', deployment_name))
             .then(res => {
               expect(_.pick(res, ['state'])).to.eql({
                 state: CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING
@@ -721,15 +721,15 @@ describe('#DirectorService', function () {
         });
 
         it('create: should return succeeded if agent returns succeeded', function () {
-          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'processing.postcreate');
+          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'lifecycle.async.postcreate');
           mocks.agent.getInfo();
-          mocks.agent.getPostCreateProcessingState({
+          mocks.agent.getLifecyclePostCreateProcessingState({
             state: 'succeeded',
             stage: 'Step 3/3',
             updated_at: new Date().toISOString()
           });
           return DirectorService.createInstance(instance_id, options)
-            .then(service => service.getAgentPostProcessingStatus('create', deployment_name))
+            .then(service => service.getAgentLifecyclePostProcessingStatus('create', deployment_name))
             .then(res => {
               expect(_.pick(res, ['state'])).to.eql({
                 state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
@@ -740,17 +740,17 @@ describe('#DirectorService', function () {
 
         it('update: should return succeeded if feature is not supported', function () {
           return DirectorService.createInstance(instance_id, options)
-            .then(service => service.getAgentPostProcessingStatus('update', 'deployment'))
+            .then(service => service.getAgentLifecyclePostProcessingStatus('update', 'deployment'))
             .then(res => {
               expect(_.get(res, 'state')).to.eql(CONST.APISERVER.RESOURCE_STATE.SUCCEEDED);
             });
         });
 
         it('update: should return succeeded if feature is not supported by any agent', function () {
-          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'processing.postupdate');
-          mocks.agent.getInfo(1, 'processing.postupdate');
+          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'lifecycle.async.postupdate');
+          mocks.agent.getInfo(1, 'lifecycle.async.postupdate');
           return DirectorService.createInstance(instance_id, options)
-            .then(service => service.getAgentPostProcessingStatus('update', deployment_name))
+            .then(service => service.getAgentLifecyclePostProcessingStatus('update', deployment_name))
             .then(res => {
               expect(_.pick(res, ['state'])).to.eql({
                 state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
@@ -760,15 +760,15 @@ describe('#DirectorService', function () {
         });
 
         it('update: should return postprocessing if agent returns processing', function () {
-          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'processing.postupdate');
+          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'lifecycle.async.postupdate');
           mocks.agent.getInfo();
-          mocks.agent.getPostUpdateProcessingState({
+          mocks.agent.getLifecyclePostUpdateProcessingState({
             state: 'processing',
             stage: 'Step 2/3',
             updated_at: new Date().toISOString()
           });
           return DirectorService.createInstance(instance_id, options)
-            .then(service => service.getAgentPostProcessingStatus('update', deployment_name))
+            .then(service => service.getAgentLifecyclePostProcessingStatus('update', deployment_name))
             .then(res => {
               expect(_.pick(res, ['state'])).to.eql({
                 state: CONST.APISERVER.RESOURCE_STATE.POST_PROCESSING
@@ -778,15 +778,15 @@ describe('#DirectorService', function () {
         });
 
         it('update: should return succeeded if agent returns succeeded', function () {
-          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'processing.postupdate');
+          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'lifecycle.async.postupdate');
           mocks.agent.getInfo();
-          mocks.agent.getPostUpdateProcessingState({
+          mocks.agent.getLifecyclePostUpdateProcessingState({
             state: 'succeeded',
             stage: 'Step 3/3',
             updated_at: new Date().toISOString()
           });
           return DirectorService.createInstance(instance_id, options)
-            .then(service => service.getAgentPostProcessingStatus('update', deployment_name))
+            .then(service => service.getAgentLifecyclePostProcessingStatus('update', deployment_name))
             .then(res => {
               expect(_.pick(res, ['state'])).to.eql({
                 state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
@@ -927,7 +927,7 @@ describe('#DirectorService', function () {
         });
 
         it('create: returns 200 OK (state = succeeded, resourceState = post_processing) if postcreate is supported by agent', function () {
-          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'processing.postcreate');
+          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'lifecycle.async.postcreate');
           mocks.director.getDeploymentTask(task_id, 'done');
           mocks.cloudController.createSecurityGroup(instance_id);
           const payload = {
@@ -1183,7 +1183,7 @@ describe('#DirectorService', function () {
         });
 
         it('update: returns 200 OK (state = succeeded, resourceState = post_processing) if postupdate is supported by agent', function () {
-          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'processing.postupdate');
+          plan.manager.settings.agent.supported_features = _.concat(supportedFeatures, 'lifecycle.async.postupdate');
           const context = {
             platform: 'cloudfoundry',
             organization_guid: organization_guid,


### PR DESCRIPTION
This add the feature to query the agent for post processing operations after creating and updating a bosh deployment as requested in #389.

If the bosh operation was successful the state of the CR is switch from `in_progress` to `post_processing` instead of to `succeeded`. Then a status poller is polling the corresponding agent for the last operation of the corresponding event type. When this polling returns that the post processing succeeded the state in the CR is changed to `succeeded`.

- I implemented this behavior is an opt-in with a feature switch.
- It is explicitly written in a way that the pre_deploy and pre_delete operations may also be asynchronous in the future
- This does not require any changes in the interoperator or the templates (since the used template currently maps unknown states to in process)
- I tried to stick with the current api and conventions, but you can give me feedback if you want something different
  + ~feature switch: `feature.ServiceInstancePostProcessing`~
  + agent feature names: `lifecycle.async.postcreate` and `lifecycle.async.postupdate`
  + agent api: `GET /lifecycle/postcreate` and `GET /lifecycle/postupdate`

