### PR TITLE
Removing empty dashboard client as defaults

### DIFF
--- a/common/models/Service.js
+++ b/common/models/Service.js
@@ -17,7 +17,7 @@ class Service {
         metadata: null,
         requires: [],
         plan_updateable: true,
-        dashboard_client: {},
+        // dashboard_client: {},
         application_access_ports: null,
         service_tags: {}
       })

--- a/test/test_broker/models.Service.spec.js
+++ b/test/test_broker/models.Service.spec.js
@@ -36,7 +36,7 @@ describe('models', () => {
           requires: [],
           service_tags: {},
           plan_updateable: true,
-          dashboard_client: {},
+          //dashboard_client: {},
           plans: [],
           application_access_ports: null
         });


### PR DESCRIPTION
CF does not allow empty one, if you do not have id and secret defined.