### PR TITLE
Assigning dashboard client as reference

### DIFF
--- a/interoperator/pkg/apis/osb/v1alpha1/sfservice_types.go
+++ b/interoperator/pkg/apis/osb/v1alpha1/sfservice_types.go
@@ -39,7 +39,7 @@ type SFServiceSpec struct {
 	InstanceRetrievable bool                  `json:"instanceRetrievable,omitempty"`
 	BindingRetrievable  bool                  `json:"bindingRetrievable,omitempty"`
 	Metadata            *runtime.RawExtension `json:"metadata,omitempty"`
-	DashboardClient     DashboardClient       `json:"dashboardClient,omitempty"`
+	DashboardClient     *DashboardClient      `json:"dashboardClient,omitempty"`
 	PlanUpdatable       bool                  `json:"planUpdatable,omitempty"`
 	RawContext          *runtime.RawExtension `json:"context,omitempty"`
 }

--- a/interoperator/pkg/apis/osb/v1alpha1/sfservice_types_test.go
+++ b/interoperator/pkg/apis/osb/v1alpha1/sfservice_types_test.go
@@ -56,7 +56,7 @@ func TestStorageSFService(t *testing.T) {
 			InstanceRetrievable: true,
 			BindingRetrievable:  true,
 			Metadata:            re,
-			DashboardClient: DashboardClient{
+			DashboardClient: &DashboardClient{
 				ID:          "id",
 				Secret:      "secret",
 				RedirectURI: "redirecturi",
@@ -104,7 +104,9 @@ func TestStorageSFService(t *testing.T) {
 	copiedStatus := updated.Status.DeepCopy()
 	g.Expect(copiedStatus).To(gomega.Equal(&updated.Status))
 	copiedDashboardClient := updated.Spec.DashboardClient.DeepCopy()
-	g.Expect(copiedDashboardClient).To(gomega.Equal(&updated.Spec.DashboardClient))
+	g.Expect(copiedDashboardClient.ID).To(gomega.Equal(updated.Spec.DashboardClient.ID))
+	g.Expect(copiedDashboardClient.Secret).To(gomega.Equal(updated.Spec.DashboardClient.Secret))
+	g.Expect(copiedDashboardClient.RedirectURI).To(gomega.Equal(updated.Spec.DashboardClient.RedirectURI))
 
 	// Test Delete
 	g.Expect(c.Delete(context.TODO(), fetched)).NotTo(gomega.HaveOccurred())

--- a/interoperator/pkg/apis/osb/v1alpha1/zz_generated.deepcopy.go
+++ b/interoperator/pkg/apis/osb/v1alpha1/zz_generated.deepcopy.go
@@ -497,7 +497,11 @@ func (in *SFServiceSpec) DeepCopyInto(out *SFServiceSpec) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	out.DashboardClient = in.DashboardClient
+	if in.DashboardClient != nil {
+		in, out := &in.DashboardClient, &out.DashboardClient
+		*out = new(DashboardClient)
+		**out = **in
+	}
 	if in.RawContext != nil {
 		in, out := &in.RawContext, &out.RawContext
 		*out = new(runtime.RawExtension)

--- a/interoperator/pkg/controller/sfplan/sfplan_controller_test.go
+++ b/interoperator/pkg/controller/sfplan/sfplan_controller_test.go
@@ -80,7 +80,7 @@ func TestReconcile(t *testing.T) {
 			InstanceRetrievable: true,
 			BindingRetrievable:  true,
 			Metadata:            nil,
-			DashboardClient: osbv1alpha1.DashboardClient{
+			DashboardClient: &osbv1alpha1.DashboardClient{
 				ID:          "id",
 				Secret:      "secret",
 				RedirectURI: "redirecturi",

--- a/interoperator/pkg/controller/sfservice/sfservice_controller_test.go
+++ b/interoperator/pkg/controller/sfservice/sfservice_controller_test.go
@@ -53,7 +53,7 @@ func TestReconcile(t *testing.T) {
 			InstanceRetrievable: true,
 			BindingRetrievable:  true,
 			Metadata:            nil,
-			DashboardClient: osbv1alpha1.DashboardClient{
+			DashboardClient: &osbv1alpha1.DashboardClient{
 				ID:          "id",
 				Secret:      "secret",
 				RedirectURI: "redirecturi",

--- a/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller_test.go
+++ b/interoperator/pkg/controller/sfservicebinding/sfservicebinding_controller_test.go
@@ -81,7 +81,7 @@ var service = &osbv1alpha1.SFService{
 		InstanceRetrievable: true,
 		BindingRetrievable:  true,
 		Metadata:            nil,
-		DashboardClient: osbv1alpha1.DashboardClient{
+		DashboardClient: &osbv1alpha1.DashboardClient{
 			ID:          "id",
 			Secret:      "secret",
 			RedirectURI: "redirecturi",

--- a/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller_test.go
+++ b/interoperator/pkg/controller/sfserviceinstance/sfserviceinstance_controller_test.go
@@ -85,7 +85,7 @@ var service = &osbv1alpha1.SFService{
 		InstanceRetrievable: true,
 		BindingRetrievable:  true,
 		Metadata:            nil,
-		DashboardClient: osbv1alpha1.DashboardClient{
+		DashboardClient: &osbv1alpha1.DashboardClient{
 			ID:          "id",
 			Secret:      "secret",
 			RedirectURI: "redirecturi",

--- a/interoperator/pkg/internal/resources/resources_test.go
+++ b/interoperator/pkg/internal/resources/resources_test.go
@@ -140,7 +140,7 @@ func Test_resourceManager_fetchResources(t *testing.T) {
 			InstanceRetrievable: true,
 			BindingRetrievable:  true,
 			Metadata:            nil,
-			DashboardClient: osbv1alpha1.DashboardClient{
+			DashboardClient: &osbv1alpha1.DashboardClient{
 				ID:          "id",
 				Secret:      "secret",
 				RedirectURI: "redirecturi",
@@ -403,7 +403,7 @@ func Test_resourceManager_ComputeExpectedResources(t *testing.T) {
 			InstanceRetrievable: true,
 			BindingRetrievable:  true,
 			Metadata:            nil,
-			DashboardClient: osbv1alpha1.DashboardClient{
+			DashboardClient: &osbv1alpha1.DashboardClient{
 				ID:          "id",
 				Secret:      "secret",
 				RedirectURI: "redirecturi",
@@ -1155,7 +1155,7 @@ directorbind:
 			InstanceRetrievable: true,
 			BindingRetrievable:  true,
 			Metadata:            nil,
-			DashboardClient: osbv1alpha1.DashboardClient{
+			DashboardClient: &osbv1alpha1.DashboardClient{
 				ID:          "id",
 				Secret:      "secret",
 				RedirectURI: "redirecturi",

--- a/interoperator/pkg/internal/services/services_test.go
+++ b/interoperator/pkg/internal/services/services_test.go
@@ -116,7 +116,7 @@ func TestFindServiceInfo(t *testing.T) {
 			InstanceRetrievable: true,
 			BindingRetrievable:  true,
 			Metadata:            nil,
-			DashboardClient: osbv1alpha1.DashboardClient{
+			DashboardClient: &osbv1alpha1.DashboardClient{
 				ID:          "id",
 				Secret:      "secret",
 				RedirectURI: "redirecturi",

--- a/interoperator/pkg/watches/watches_test.go
+++ b/interoperator/pkg/watches/watches_test.go
@@ -319,7 +319,7 @@ func _getDummyService() *osbv1alpha1.SFService {
 			InstanceRetrievable: true,
 			BindingRetrievable:  true,
 			Metadata:            nil,
-			DashboardClient: osbv1alpha1.DashboardClient{
+			DashboardClient: &osbv1alpha1.DashboardClient{
 				ID:          "id",
 				Secret:      "secret",
 				RedirectURI: "redirecturi",


### PR DESCRIPTION
* If the service is not using CF UAA SSO [feature](https://docs.cloudfoundry.org/services/dashboard-sso.html) for dashboard, they don’t need to specify the [dashboard_client](https://github.com/openservicebrokerapi/servicebroker/blob/v2.15/profile.md#catalog-extensions) properties. 

* It is also better for services not to use this feature if the consuming platform is CF as well as k8s as this is a CF specific feature, and wouldn’t work for k8s consumption.

* This small fix in interoperator code supports blank dashboard_client feature. 