### PR TITLE
Removing bosh property related operations from codebase

### DIFF
--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -536,16 +536,6 @@ class BoshDirectorClient extends HttpClient {
       .catch(err => this.convertHttpErrorAndThrow(err));
   }
 
-  /* Property operations */
-  getDeploymentProperties(deploymentName) {
-    return this
-      .makeRequest({
-        method: 'GET',
-        url: `/deployments/${deploymentName}/properties`
-      }, 200, deploymentName)
-      .then(res => JSON.parse(res.body));
-  }
-
   getDeploymentIps(deploymentName) {
     return Promise.try(() => {
       if (this.deploymentIpsCache[deploymentName] !== undefined) {
@@ -741,66 +731,6 @@ class BoshDirectorClient extends HttpClient {
       const timer = setInterval(statePoller,
         pollInterval || this.activePrimary[0].default_task_poll_interval);
     });
-  }
-
-  createDeploymentProperty(deploymentName, propertyName, propertyValue) {
-    return this
-      .makeRequest({
-        method: 'POST',
-        url: `/deployments/${deploymentName}/properties`,
-        json: true,
-        body: {
-          name: propertyName,
-          value: propertyValue
-        }
-      }, 204, deploymentName);
-  }
-
-  updateDeploymentProperty(deploymentName, propertyName, propertyValue) {
-    return this
-      .makeRequest({
-        method: 'PUT',
-        url: `/deployments/${deploymentName}/properties/${propertyName}`,
-        json: true,
-        body: {
-          value: propertyValue
-        }
-      }, 204, deploymentName);
-  }
-
-  createOrUpdateDeploymentProperty(deploymentName, propertyName, propertyValue) {
-    return this
-      .createDeploymentProperty(deploymentName, propertyName, propertyValue)
-      .catch(BadRequest, err => {
-        /* jshint unused:false */
-        return this.updateDeploymentProperty(deploymentName, propertyName, propertyValue);
-      });
-  }
-
-  updateOrCreateDeploymentProperty(deploymentName, propertyName, propertyValue) {
-    return this
-      .updateDeploymentProperty(deploymentName, propertyName, propertyValue)
-      .catch(NotFound, err => {
-        /* jshint unused:false */
-        return this.createDeploymentProperty(deploymentName, propertyName, propertyValue);
-      });
-  }
-
-  getDeploymentProperty(deploymentName, propertyName) {
-    return this
-      .makeRequest({
-        method: 'GET',
-        url: `/deployments/${deploymentName}/properties/${propertyName}`
-      }, 200, deploymentName)
-      .then(res => JSON.parse(res.body).value);
-  }
-
-  deleteDeploymentProperty(deploymentName, propertyName) {
-    return this
-      .makeRequest({
-        method: 'DELETE',
-        url: `/deployments/${deploymentName}/properties/${propertyName}`
-      }, 204, deploymentName);
   }
 
   /*  Task operations */

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -56,27 +56,12 @@ class DirectorService extends BaseDirectorService {
   get platformContext() {
     return this.getContextFromResource()
       .then(context => {
-        if (context) {
-          return context;
-        }
-        logger.debug(`Fetching context from etcd failed for ${this.guid}. Trying to fetch from Bosh...`);
-        return Promise.try(() => _.isInteger(this.networkSegmentIndex) ? this.deploymentName : this.director.getDeploymentNameForInstanceId(this.guid))
-          .then(deploymentName => this.director.getDeploymentProperty(deploymentName, CONST.PLATFORM_CONTEXT_KEY))
-          .then(context => JSON.parse(context))
-          .catch(NotFound, () => {
-            /* Following is to handle existing deployments. 
-                For them platform-context is not saved in deployment property. Defaults to CF.
-            */
-            /* TODO: Remove the code for querying bosh for property.
-             */
-            logger.warn(`Deployment property '${CONST.PLATFORM_CONTEXT_KEY}' not found for instance '${this.guid}'.\ 
-          Setting default platform as '${CONST.PLATFORM.CF}'`);
-
-            const context = {
-              platform: CONST.PLATFORM.CF
-            };
-            return context;
-          });
+        if (!context) {
+          context = {
+            platform: CONST.PLATFORM.CF
+          };
+        } 
+        return context;
       });
   }
 
@@ -842,7 +827,7 @@ class DirectorService extends BaseDirectorService {
           .all([
             Promise.resolve(preUnbindResponse),
             this.getDeploymentIps(deploymentName),
-            this.getCredentials(deploymentName, id)
+            this.getCredentials(id)
           ]))
       .spread((preUnbindResponse, ips, credentials) => utils.retry(() => this.agent.deleteCredentials(ips, credentials, preUnbindResponse), {
         operation: 'DELETE_CREDENTIAL_AGENT',
@@ -861,42 +846,28 @@ class DirectorService extends BaseDirectorService {
       });
   }
 
-  getCredentials(deploymentName, id) {
-    return this.getCredentialsFromResource(id)
-      .then(credentials => {
-        if (credentials) {
-          return credentials;
-        }
-        logger.info(`[getCredentials] Fetching property from bosh for binding ${id}`);
-        return this.getBindingProperty(deploymentName, id)
-          .then(binding => binding.credentials);
-      });
-  }
-
-  getCredentialsFromResource(id) {
+  getCredentials(id) {
     logger.info(`[getCredentials] making request to ApiServer for binding ${id}`);
-    return eventmesh.apiServerClient.getResource({
-      resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BIND,
-      resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND,
-      resourceId: id
-    })
-      .then(resource => {
-        let response = _.get(resource, 'status.response', undefined);
-        if (!_.isEmpty(response)) {
-          return utils.decodeBase64(response);
-        }
+    return utils.retry(tries => {
+      logger.debug(`+-> Attempt ${tries + 1} to get binding ${id} from apiserver`);
+      eventmesh.apiServerClient.getResponse({
+        resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BIND,
+        resourceType: CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND,
+        resourceId: id
       })
-      .catch(err => {
-        logger.error(`[getCredentials] error while fetching resource for binding ${id} - `, err);
-        return;
-      });
-  }
-
-  getBindingProperty(deploymentName, id) {
-    return this.director
-      .getDeploymentProperty(deploymentName, `binding-${id}`)
-      .then(result => JSON.parse(result))
-      .catchThrow(NotFound, new ServiceBindingNotFound(id));
+      .then(response => {
+          if (response) {
+            return utils.decodeBase64(response);
+          }
+        })
+    }, {
+      maxAttempts: 5,
+      minDelay: 1000
+    })
+    .catch(err => {
+      logger.error(`[getCredentials] error while fetching resource for binding ${id} - `, err);
+      throw err;
+    })
   }
 
   diffManifest(deploymentName, opts) {

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -55,7 +55,7 @@ class DirectorService extends BaseDirectorService {
   get platformContext() {
     return this.getContextFromResource()
       .then(context => {
-        if (!context) {
+        if (_.isEmpty(context)) {
           context = {
             platform: CONST.PLATFORM.CF
           };
@@ -861,7 +861,7 @@ class DirectorService extends BaseDirectorService {
           }
         });
     }, {
-      maxAttempts: 5,
+      maxAttempts: 3,
       minDelay: 1000,
       predicate: err => !(err instanceof NotFound)
     })

--- a/operators/virtualhost-operator/VirtualHostService.js
+++ b/operators/virtualhost-operator/VirtualHostService.js
@@ -103,7 +103,7 @@ class VirtualHostService extends BaseService {
     logger.info(`Creating binding '${binding.id}' with binding parameters ${binding.parameters} for deployment '${deploymentName}', virtual host '${instanceId}'...`);
     return this.director.getDeploymentIps(deploymentName)
       .then(ips => this.agent.createCredentials(ips, instanceId, binding.parameters))
-      .then(credentials =>  _.set(binding, 'credentials', credentials))
+      .then(credentials => _.set(binding, 'credentials', credentials))
       .then(() => binding.credentials)
       .tap(() => {
         const bindCreds = _.cloneDeep(binding.credentials);
@@ -136,24 +136,24 @@ class VirtualHostService extends BaseService {
     logger.info(`[getCredentials] making request to ApiServer for binding ${id}`);
     return utils.retry(tries => {
       logger.debug(`+-> Attempt ${tries + 1} to get binding ${id} from apiserver`);
-      eventmesh.apiServerClient.getResponse({
+      return eventmesh.apiServerClient.getResponse({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.BIND,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.VIRTUALHOST_BIND,
         resourceId: id
       })
-      .then(response => {
+        .then(response => {
           if (response) {
             return utils.decodeBase64(response);
           }
-        })
+        });
     }, {
       maxAttempts: 5,
       minDelay: 1000
     })
-    .catch(err => {
-      logger.error(`[getCredentials] error while fetching resource for binding ${id} - `, err);
-      throw err;
-    })
+      .catch(err => {
+        logger.error(`[getCredentials] error while fetching resource for binding ${id} - `, err);
+        throw err;
+      });
   }
 
   /* Dashboard rendering functions */

--- a/operators/virtualhost-operator/VirtualHostService.js
+++ b/operators/virtualhost-operator/VirtualHostService.js
@@ -147,8 +147,9 @@ class VirtualHostService extends BaseService {
           }
         });
     }, {
-      maxAttempts: 5,
-      minDelay: 1000
+      maxAttempts: 3,
+      minDelay: 1000,
+      predicate: err => !(err instanceof NotFound)
     })
       .catch(err => {
         logger.error(`[getCredentials] error while fetching resource for binding ${id} - `, err);

--- a/test/test_broker/bosh.BoshDirectorClient.spec.js
+++ b/test/test_broker/bosh.BoshDirectorClient.spec.js
@@ -680,26 +680,6 @@ describe('bosh', () => {
       });
     });
 
-    describe('#getDeploymentProperties', () => {
-      it('returns a JSON object', (done) => {
-        let request = {
-          method: 'GET',
-          url: `/deployments/${id}/properties`
-        };
-        let response = {
-          body: JSON.stringify({
-            uuid: uuid.v4()
-          }),
-          statusCode: 200
-        };
-
-        new MockBoshDirectorClient(request, response).getDeploymentProperties(id).then((content) => {
-          expect(content).to.eql(JSON.parse(response.body));
-          done();
-        }).catch(done);
-      });
-    });
-
     describe('#errands', () => {
       it('should return errands array for the deployment', () => {
         const req = {
@@ -940,52 +920,6 @@ describe('bosh', () => {
       });
     });
 
-    describe('#createDeploymentProperty', () => {
-      it('returns correct status code', (done) => {
-        let request = {
-          method: 'POST',
-          url: `/deployments/${id}/properties`,
-          json: true,
-          body: {}
-        };
-        let response = {
-          body: JSON.stringify({
-            uuid: uuid.v4()
-          }),
-          statusCode: 204
-        };
-
-        new MockBoshDirectorClient(request, response).createDeploymentProperty(id).then((content) => {
-          expect(content.statusCode).to.eql(204);
-          done();
-        }).catch(done);
-      });
-    });
-
-    describe('#updateDeploymentProperty', () => {
-      it('returns correct status code', (done) => {
-        let request = {
-          method: 'PUT',
-          url: `/deployments/${id}/properties/${id}`,
-          json: true,
-          body: {
-            value: id
-          }
-        };
-        let response = {
-          body: JSON.stringify({
-            uuid: uuid.v4()
-          }),
-          statusCode: 204
-        };
-
-        new MockBoshDirectorClient(request, response).updateDeploymentProperty(id, id, id).then((content) => {
-          expect(content.statusCode).to.eql(204);
-          done();
-        }).catch(done);
-      });
-    });
-
     describe('#stopDeployment', () => {
       let sandbox, getDirectorConfigStub, request, response;
       let mockBoshDirectorClient;
@@ -1061,100 +995,6 @@ describe('bosh', () => {
           .then(taskId => {
             expect(taskId).to.equal(`${deployment_name}_taskId`);
           });
-      });
-    });
-
-    describe('#createOrUpdateDeploymentProperty', () => {
-      it('returns correct status code', (done) => {
-        let request = {
-          method: 'PUT',
-          url: `/deployments/${id}/properties/${id}`,
-          json: true,
-          body: {
-            value: id
-          }
-        };
-        let response = {
-          body: JSON.stringify({
-            uuid: uuid.v4()
-          }),
-          statusCode: 400
-        };
-
-        new MockBoshDirectorClient(request, response).createOrUpdateDeploymentProperty(id, id, id)
-          .then(() => {
-            done();
-          })
-          .catch((content) => {
-            expect(content.statusCode).to.eql(204);
-            done();
-          });
-      });
-    });
-
-    describe('#updateOrCreateDeploymentProperty', () => {
-      it('returns correct status code', (done) => {
-        let request = {
-          method: 'POST',
-          url: `/deployments/${id}/properties`,
-          json: true,
-          body: {
-            name: id,
-            value: id
-          }
-        };
-        let response = {
-          body: JSON.stringify({
-            uuid: uuid.v4()
-          }),
-          statusCode: 404
-        };
-
-        new MockBoshDirectorClient(request, response).updateOrCreateDeploymentProperty(id, id, id)
-          .then(() => {
-            done();
-          })
-          .catch((content) => {
-            expect(content.statusCode).to.eql(204);
-            done();
-          });
-      });
-    });
-
-    describe('#getDeploymentProperty', () => {
-      it('returns an integer (task-id)', (done) => {
-        let request = {
-          method: 'GET',
-          url: `/deployments/${id}/properties/${id}`
-        };
-        let response = {
-          body: JSON.stringify({
-            value: id
-          }),
-          statusCode: 200
-        };
-
-        new MockBoshDirectorClient(request, response).getDeploymentProperty(id, id).then((content) => {
-          expect(content).to.eql(id);
-          done();
-        }).catch(done);
-      });
-    });
-
-    describe('#deleteDeploymentProperty', () => {
-      it('returns correct status code', (done) => {
-        let request = {
-          method: 'DELETE',
-          url: `/deployments/${id}/properties/${id}`
-        };
-        let response = {
-          statusCode: 204
-        };
-
-        new MockBoshDirectorClient(request, response).deleteDeploymentProperty(id, id).then((content) => {
-          expect(content.statusCode).to.eql(204);
-          done();
-        }).catch(done);
       });
     });
 

--- a/test/test_broker/mocks/director.js
+++ b/test/test_broker/mocks/director.js
@@ -72,18 +72,10 @@ exports.deleteDeployment = deleteDeployment;
 exports.getDeploymentTask = getDeploymentTask;
 exports.getDeploymentManifest = getDeploymentManifest;
 exports.diffDeploymentManifest = diffDeploymentManifest;
-exports.getBindingProperty = getBindingProperty;
-exports.createBindingProperty = createBindingProperty;
-exports.updateBindingProperty = updateBindingProperty;
-exports.deleteBindingProperty = deleteBindingProperty;
-exports.createDeploymentProperty = createDeploymentProperty;
-exports.getDeploymentProperty = getDeploymentProperty;
 exports.bindDeployment = bindDeployment;
 exports.unbindDeployment = unbindDeployment;
 exports.getDeploymentVms = getDeploymentVms;
 exports.verifyDeploymentLockStatus = verifyDeploymentLockStatus;
-exports.acquireLock = acquireLock;
-exports.releaseLock = releaseLock;
 exports.manifest = manifest;
 exports.getDeploymentInstances = getDeploymentInstances;
 
@@ -307,87 +299,6 @@ function diffDeploymentManifest(times, diff) {
     });
 }
 
-function createBindingProperty(binding_id, parameters, deployment, binding_credentials) {
-  const deploymentName = deployment || deploymentNameByIndex(networkSegmentIndex);
-
-  return nock(directorUrl)
-    .post(`/deployments/${deploymentName}/properties`, body => {
-      return body.name === `binding-${binding_id}` &&
-        _.isEqual(JSON.parse(body.value), {
-          id: binding_id,
-          credentials: binding_credentials || credentials,
-          parameters: parameters || {}
-        });
-    })
-    .reply(204);
-}
-
-function createDeploymentProperty(name, value, deployment) {
-  const deploymentName = deployment || deploymentNameByIndex(networkSegmentIndex);
-
-  return nock(directorUrl)
-    .post(`/deployments/${deploymentName}/properties`, body => {
-      return body.name === name &&
-        _.isEqual(JSON.parse(body.value), value);
-    })
-    .reply(204);
-}
-
-function getDeploymentProperty(deploymentName, found, key, value) {
-  if (!found) {
-    return nock(directorUrl)
-      .replyContentLength()
-      .get(`/deployments/${deploymentName}/properties/${key}`)
-      .reply(404, {});
-  }
-  return nock(directorUrl)
-    .replyContentLength()
-    .get(`/deployments/${deploymentName}/properties/${key}`)
-    .reply(200,
-      JSON.stringify({
-        value: JSON.stringify(value)
-      } || {})
-    );
-}
-
-function updateBindingProperty(binding_id, parameters, binding_credentials) {
-  return nock(directorUrl)
-    .put(`/deployments/${deploymentNameByIndex(networkSegmentIndex)}/properties/binding-${binding_id}`, body => {
-      return _.isEqual(JSON.parse(body.value), {
-        id: binding_id,
-        credentials: binding_credentials || credentials,
-        parameters: parameters || {}
-      });
-    })
-    .reply(204);
-}
-
-function deleteBindingProperty(binding_id, deployment) {
-  const deploymentName = deployment || deploymentNameByIndex(networkSegmentIndex);
-  return nock(directorUrl)
-    .delete(`/deployments/${deploymentName}/properties/binding-${binding_id}`)
-    .reply(204);
-}
-
-function getBindingProperty(binding_id, parameters, deployment, notFound, binding_credentials) {
-  const deploymentName = deployment || deploymentNameByIndex(networkSegmentIndex);
-  if (notFound) {
-    return nock(directorUrl)
-      .replyContentLength()
-      .get(`/deployments/${deploymentName}/properties/binding-${binding_id}`)
-      .reply(404, {});
-  }
-  return nock(directorUrl)
-    .replyContentLength()
-    .get(`/deployments/${deploymentName}/properties/binding-${binding_id}`)
-    .reply(200, {
-      value: JSON.stringify({
-        id: binding_id,
-        credentials: binding_credentials || credentials,
-        parameters: parameters || {}
-      })
-    });
-}
 
 function verifyDeploymentLockStatus(deployment, locked, params) {
   const deploymentName = deployment || deploymentNameByIndex(networkSegmentIndex);


### PR DESCRIPTION
* All calls to bosh deployment properties API are being removed in this PR.
* Following are the changes:
1. Modification in `getCredentials` during unbind operation of director and virtualhost resources. Earlier provision of fallback to bosh deployment property is removed and we are now completely dependent on ApiServer to obtain credentials in unbind flow.
2. Modification in `DBManager` initialization flow to be dependent on ApiServer only.
3. Removal of various deployment property API calls from `BoshDirectorClient`
4. Corresponding changes in UTs.