### PR TITLE
[interoperator] Plan controller Optimization

### DIFF
--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -1,5 +1,7 @@
 package constants
 
+import "time"
+
 // Constants used by interoperator
 const (
 	LeaderElectionID = "interoperator-leader-election-helper"
@@ -16,4 +18,6 @@ const (
 	DefaultInstanceWorkerCount    = 10
 	DefaultBindingWorkerCount     = 20
 	DefaultSchedulerWorkerCount   = 10
+
+	PlanWatchDrainTimeout = time.Second * 2
 )

--- a/interoperator/pkg/controller/sfplan/sfplan_controller.go
+++ b/interoperator/pkg/controller/sfplan/sfplan_controller.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/apis/osb/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -49,7 +51,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	initWatches := make(chan struct{})
+	initWatches := make(chan struct{}, 50)
 	stopWatches := make(chan struct{})
 	go restartOnWatchUpdate(mgr, initWatches, stopWatches)
 	return &ReconcileSfPlan{
@@ -80,6 +82,21 @@ func restartOnWatchUpdate(mgr manager.Manager, initWatches, stop <-chan struct{}
 	for {
 		select {
 		case <-initWatches:
+			drainTimeout := time.After(constants.PlanWatchDrainTimeout)
+		DrainLoop:
+			for {
+				select {
+				case <-initWatches:
+					// NOP
+					// Since the InitWatchConfig performs the same computation
+					// regardless of which plan has changed, drain all the
+					// events occuring in a 2 second window and call
+					// InitWatchConfig only once. This significantly improves
+					// startup and watch refreshes.
+				case <-drainTimeout:
+					break DrainLoop
+				}
+			}
 			toUpdate, err := watches.InitWatchConfig(mgr.GetConfig(), mgr.GetScheme(), mgr.GetRESTMapper())
 			if err != nil {
 				log.Error(err, "unable initializing interoperator watch list")


### PR DESCRIPTION
- Plan controller recomputes watchlist on all events
- On startup and watch refresh, this cause redundant computations
- Wait 2 sec and drain all events

Feature: HCPCFS-2352