### PR TITLE
[Potential test cycle fix]introducing separate error for ApiServer page not found

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -156,6 +156,14 @@ class NotFound extends HttpClientError {
 }
 exports.NotFound = NotFound;
 
+class PageNotFound extends NotFound {
+  constructor(message, statusCode) {
+    super(CONST.HTTP_STATUS_CODE.NOT_FOUND, 'Page Not Found', message, statusCode);
+  }  
+}
+
+exports.PageNotFound = PageNotFound;
+
 class MethodNotAllowed extends HttpClientError {
   constructor(method, allow) {
     let message = `The method ${method} is not allowed for the resource identified by the URI`;

--- a/data-access-layer/db/DBManager/DBManager.js
+++ b/data-access-layer/db/DBManager/DBManager.js
@@ -71,7 +71,7 @@ class DBManager {
       }
     })
       .catch(NotFound , err => {
-          logger.warn('MongoDB binding to ServiceFabrik not found. This generally should not occur. More Info:', err);
+        logger.warn('MongoDB binding to ServiceFabrik not found. This generally should not occur. More Info:', err);
       })
       .catch(err => {
         logger.error('Error occurred while initializing DB ...', err);

--- a/data-access-layer/eventmesh/ApiServerClient.js
+++ b/data-access-layer/eventmesh/ApiServerClient.js
@@ -13,6 +13,7 @@ const errors = require('../../common/errors');
 const Timeout = errors.Timeout;
 const BadRequest = errors.BadRequest;
 const NotFound = errors.NotFound;
+const PageNotFound = errors.PageNotFound;
 const Conflict = errors.Conflict;
 const camelcaseKeys = require('camelcase-keys');
 const InternalServerError = errors.InternalServerError;
@@ -48,7 +49,11 @@ function convertToHttpErrorAndThrow(err) {
       newErr = new BadRequest(message);
       break;
     case CONST.HTTP_STATUS_CODE.NOT_FOUND:
-      newErr = new NotFound(message);
+      if (message.includes('page not found')) {
+        newErr = new PageNotFound(message);
+      } else {
+        newErr = new NotFound(message);
+      }
       break;
     case CONST.HTTP_STATUS_CODE.CONFLICT:
       newErr = new Conflict(message);


### PR DESCRIPTION
* Sometimes, during initialisation, 404 is thrown by ApiServer with the message as `page not found`, even when the resource actually exists.
* `DbManager` treats it as binding not found scenario and stops retrying for connection, which is incorrect behaviour. Modifying this flow by distinguishing between `resource not found` and `page not found` scenarios. 