### PR TITLE
Modify runNow API to schedule the job after one minute

### DIFF
--- a/api-controllers/ServiceFabrikAdminController.js
+++ b/api-controllers/ServiceFabrikAdminController.js
@@ -757,9 +757,10 @@ class ServiceFabrikAdminController extends FabrikBaseController {
     const jobData = instance_guid == undefined ? {} : {
       instance_guid: instance_guid
     };
+    const interval = utils.getCronAfterXMinuteFromNow(1);
     return ScheduleManager
-      .runNow(req.body.job_name, req.params.job_type, jobData, req.user)
-      .then(body => res.status(200).send(body));
+      .runAt(req.body.job_name, req.params.job_type, interval, jobData, req.user)
+      .then(body => res.status(CONST.HTTP_STATUS_CODE.CREATED).send(body));
   }
 
   createUpdateConfig(req, res) {

--- a/common/utils/index.js
+++ b/common/utils/index.js
@@ -46,6 +46,7 @@ exports.getRandomCronForOnceEveryXDays = getRandomCronForOnceEveryXDays;
 exports.getRandomCronForOnceEveryXDaysWeekly = getRandomCronForOnceEveryXDaysWeekly;
 exports.getRandomCronForEveryDayAtXHoursInterval = getRandomCronForEveryDayAtXHoursInterval;
 exports.getCronWithIntervalAndAfterXminute = getCronWithIntervalAndAfterXminute;
+exports.getCronAfterXMinuteFromNow = getCronAfterXMinuteFromNow;
 exports.isDBConfigured = isDBConfigured;
 exports.isFeatureEnabled = isFeatureEnabled;
 exports.isServiceFabrikOperation = isServiceFabrikOperation;
@@ -524,6 +525,18 @@ function getCronWithIntervalAndAfterXminute(interval, afterXminute) {
       message: 'interval should \'daily\' or in \'x hours\' format'
     });
   }
+  return interval;
+}
+
+function getCronAfterXMinuteFromNow(afterXminute) {
+  afterXminute = afterXminute || 3;
+  const currentTime = new Date().getTime();
+  const timeAfterXMinute = new Date(currentTime + afterXminute * 60 * 1000);
+  const hr = timeAfterXMinute.getHours();
+  const min = timeAfterXMinute.getMinutes();
+  const date = timeAfterXMinute.getDate();
+  const month = timeAfterXMinute.getMonth();
+  const interval = `${min} ${hr} ${date} ${month} *`;
   return interval;
 }
 

--- a/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
+++ b/test/test_broker/acceptance/service-fabrik-admin.updates.spec.js
@@ -58,10 +58,10 @@ describe('service-fabrik-admin', function () {
     };
 
     let sandbox = sinon.createSandbox();
-    let runNowStub = sandbox.stub(ScheduleManager, 'runNow').callsFake(() => Promise.resolve(jobResponse));
+    let runAtStub = sandbox.stub(ScheduleManager, 'runAt').callsFake(() => Promise.resolve(jobResponse));
 
     afterEach(function () {
-      runNowStub.resetHistory();
+      runAtStub.resetHistory();
     });
     after(function () {
       sandbox.restore();
@@ -78,14 +78,14 @@ describe('service-fabrik-admin', function () {
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
-          expect(runNowStub).to.be.calledOnce; // jshint ignore:line
-          expect(runNowStub.firstCall.args[0]).to.be.equal('Meter_Instance');
-          expect(runNowStub.firstCall.args[1]).to.be.equal('MeterInstance');
-          expect(runNowStub.firstCall.args[2]).to.deep.equal({});
-          expect(runNowStub.firstCall.args[3]).to.deep.equal({
+          expect(runAtStub).to.be.calledOnce; // jshint ignore:line
+          expect(runAtStub.firstCall.args[0]).to.be.equal('Meter_Instance');
+          expect(runAtStub.firstCall.args[1]).to.be.equal('MeterInstance');
+          expect(runAtStub.firstCall.args[3]).to.deep.equal({});
+          expect(runAtStub.firstCall.args[4]).to.deep.equal({
             name: config.username
           });
-          expect(res).to.have.status(200);
+          expect(res).to.have.status(CONST.HTTP_STATUS_CODE.CREATED);
           expect(res.body.name).to.equal(jobResponse.name);
         });
     });
@@ -101,16 +101,16 @@ describe('service-fabrik-admin', function () {
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
-          expect(runNowStub).to.be.calledOnce; // jshint ignore:line
-          expect(runNowStub.firstCall.args[0]).to.be.equal('Meter_Instance');
-          expect(runNowStub.firstCall.args[1]).to.be.equal('MeterInstance');
-          expect(runNowStub.firstCall.args[2]).to.deep.equal({
+          expect(runAtStub).to.be.calledOnce; // jshint ignore:line
+          expect(runAtStub.firstCall.args[0]).to.be.equal('Meter_Instance');
+          expect(runAtStub.firstCall.args[1]).to.be.equal('MeterInstance');
+          expect(runAtStub.firstCall.args[3]).to.deep.equal({
             instance_guid: 'fake_instance_guid'
           });
-          expect(runNowStub.firstCall.args[3]).to.deep.equal({
+          expect(runAtStub.firstCall.args[4]).to.deep.equal({
             name: config.username
           });
-          expect(res).to.have.status(200);
+          expect(res).to.have.status(CONST.HTTP_STATUS_CODE.CREATED);
           expect(res.body.name).to.equal(jobResponse.name);
         });
     });


### PR DESCRIPTION
Currently runNow Admin API runs the job as part of `service-fabrik-broker` process, which could be harmful to broker availability if the job run fails.
Also if the job runs for a long time it will hamper the broker performance. 
This PR handles this by moving actual job run to `service-fabrik-schedule` process.