### PR TITLE
Add schema validation for service instance operation via ajv

### DIFF
--- a/api-controllers/routes/broker/v2.js
+++ b/api-controllers/routes/broker/v2.js
@@ -31,14 +31,14 @@ router.use(commonMiddleware.error({
 
 /* Service Instance Router */
 instanceRouter.route('/')
-  .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
-  .patch([middleware.checkQuota(), middleware.validateRequest(), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
+  .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), middleware.validateSchemaForRequest('service_instance', 'create'), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
+  .patch([middleware.checkQuota(), middleware.validateRequest(), middleware.validateSchemaForRequest('service_instance', 'update'), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
   .delete([middleware.validateRequest(), controller.handleWithResourceLocking('deleteInstance', CONST.OPERATION_TYPE.DELETE)])
   .all(commonMiddleware.methodNotAllowed(['PUT', 'PATCH', 'DELETE']));
 instanceRouter.route('/last_operation')
   .get(controller.handler('getLastInstanceOperation'))
   .all(commonMiddleware.methodNotAllowed(['GET']));
 instanceRouter.route('/service_bindings/:binding_id')
-  .put([middleware.checkBlockingOperationInProgress(), controller.handler('putBinding')])
+  .put([middleware.checkBlockingOperationInProgress(), middleware.validateSchemaForRequest('service_binding', 'create'), controller.handler('putBinding')])
   .delete(middleware.checkBlockingOperationInProgress(), controller.handler('deleteBinding'))
   .all(commonMiddleware.methodNotAllowed(['PUT', 'DELETE']));

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -754,6 +754,20 @@ defaults: &defaults
       - action: bind
         type: gotemplate
         contentEncoded: <%=base64_template('samples/templates/gotemplates/director/bind.yaml') %>
+      schemas: &blueprint_schemas
+        service_instance:
+          create:
+            parameters:
+              "$schema": "http://json-schema.org/draft-04/schema#"
+              additionalProperties: true
+              properties:
+                enum_foo:
+                  description: A property of the blueprint plan
+                  type: string
+                  enum:
+                  - bar
+                  - baz
+                  default: bar
     - &blueprint_plan4
       id: 'bc158c9a-7934-401e-94ab-057082a5073e'
       name: 'v1.0-small'
@@ -828,6 +842,7 @@ defaults: &defaults
       - cf
       - sm
       templates: *director_templates
+      schemas: *blueprint_schemas
     - &blueprint_plan8
       id: 'gd158c9a-7934-401e-94ab-057082a5073e'
       name: 'v2.0-xsmall'
@@ -898,6 +913,7 @@ defaults: &defaults
         - '2 GB Memory'
         - '2 GB Disk'
       templates: *director_templates
+      schemas: *blueprint_schemas
   ####################
   # RABBITMQ SERVICE #
   ####################

--- a/broker/lib/middleware.js
+++ b/broker/lib/middleware.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ajv = require('ajv');
+const Ajv = require('ajv');
 const _ = require('lodash');
 const errors = require('../../common/errors');
 const logger = require('../../common/logger');
@@ -56,7 +56,7 @@ exports.validateSchemaForRequest = function (target, operation) {
       const parameters = _.get(req, 'body.parameters', {});
 
       const schemaVersion = schema['$schema'] || '';
-      const validator = new ajv({ schemaId: 'auto' });
+      const validator = new Ajv({ schemaId: 'auto' });
       if (schemaVersion.includes('draft-06')) {
         validator.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
       } else if (schemaVersion.includes('draft-04')) {

--- a/broker/lib/middleware.js
+++ b/broker/lib/middleware.js
@@ -55,7 +55,7 @@ exports.validateSchemaForRequest = function (target, operation) {
     if (schema) {
       const parameters = _.get(req, 'body.parameters', {});
 
-      const schemaVersion = schema['$schema'] || '';
+      const schemaVersion = schema.$schema || '';
       const validator = new Ajv({ schemaId: 'auto' });
       if (schemaVersion.includes('draft-06')) {
         validator.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));

--- a/common/errors.js
+++ b/common/errors.js
@@ -135,6 +135,13 @@ class BadRequest extends HttpClientError {
 }
 exports.BadRequest = BadRequest;
 
+class InvalidServiceParameters extends BadRequest {
+  constructor(message) {
+    super(message);
+  }
+}
+exports.InvalidServiceParameters = InvalidServiceParameters;
+
 class Unauthorized extends HttpClientError {
   constructor(message) {
     super(CONST.HTTP_STATUS_CODE.UNAUTHORIZED, 'Unauthorized', message || 'The request requires user authentication');

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@google-cloud/compute": "0.9.1",
     "@google-cloud/storage": "1.6.0",
     "agenda": "0.10.0",
+    "ajv": "^6.10.0",
     "ali-oss": "6.0.1",
     "@alicloud/pop-core": "1.7.1",
     "aws-sdk": "2.35.0",

--- a/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api.instances.director.spec.js
@@ -205,6 +205,35 @@ describe('service-broker-api', function () {
 
       });
 
+      it('returns 400 BadRequest when the parameters are invalid', function () {
+        return chai.request(app)
+          .put(`${base_url}/service_instances/${instance_id}?accepts_incomplete=true`)
+          .set('X-Broker-API-Version', api_version)
+          .set('Accept', 'application/json')
+          .auth(config.username, config.password)
+          .send({
+            service_id: service_id,
+            plan_id: plan_id,
+            organization_guid: organization_guid,
+            space_guid: space_guid,
+            context: {
+              platform: 'cloudfoundry',
+              organization_guid: organization_guid,
+              space_guid: space_guid
+            },
+            parameters: {
+              enum_foo: 'not_bar',
+            },
+            accepts_incomplete: accepts_incomplete
+          })
+          .catch(err => err.response)
+          .then(res => {
+            expect(res).to.have.status(400);
+            expect(res.body.error).to.be.eql('Bad Request');
+            expect(res.body.description).to.be.eql('Failed to validate service parameters, reason: .enum_foo should be equal to one of the allowed values');
+          });
+      });
+
     });
   });
 });


### PR DESCRIPTION
Add a  middleware, which validates the parameters based on the schemas defined in the service plan.

TODO:

- [x] Add tests
- One may add a special handling for the update case: If the deployment is updates via the `/admin` api there are special service fabrik parameters. This should still be possible. However this may also be handled in the schemas itself, since the service also needs to be able to handle it.

As discussed before this is my current implementation state as a basis for the schema validation.