### PR TITLE
Enabling liveness and readiness probe for broker and interoperator pods

### DIFF
--- a/helm-charts/sources/interoperator/templates/broker.yaml
+++ b/helm-charts/sources/interoperator/templates/broker.yaml
@@ -75,6 +75,26 @@ spec:
         volumeMounts:
         - name: settings
           mountPath: {{.Values.broker.settings_mount_path }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 9293
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 9293
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
       volumes:
         - name: settings
           configMap:

--- a/helm-charts/sources/interoperator/templates/multiclusterdeployer.yaml
+++ b/helm-charts/sources/interoperator/templates/multiclusterdeployer.yaml
@@ -32,4 +32,24 @@ spec:
           requests:
             cpu: {{ .Values.interoperator.resources.requests.cpu }}
             memory: {{ .Values.interoperator.resources.requests.memory }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 9877
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 9877
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
       restartPolicy: Always

--- a/helm-charts/sources/interoperator/templates/provisioner.yaml
+++ b/helm-charts/sources/interoperator/templates/provisioner.yaml
@@ -37,6 +37,26 @@ spec:
           requests:
             cpu: {{ .Values.interoperator.resources.requests.cpu }}
             memory: {{ .Values.interoperator.resources.requests.memory }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 9877
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 9877
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
       terminationGracePeriodSeconds: 10
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/helm-charts/sources/interoperator/templates/scheduler.yaml
+++ b/helm-charts/sources/interoperator/templates/scheduler.yaml
@@ -32,4 +32,24 @@ spec:
           requests:
             cpu: {{ .Values.interoperator.resources.requests.cpu }}
             memory: {{ .Values.interoperator.resources.requests.memory }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 9877
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 9877
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
       restartPolicy: Always


### PR DESCRIPTION
* Enabled liveness and readiness probe for broker pod

TODO:
* Enable the same for provisioner and multiclusterdeploy pods as well