### PR TITLE
[interoperator] Add sprig libary to gotemplates

### DIFF
--- a/interoperator/Gopkg.lock
+++ b/interoperator/Gopkg.lock
@@ -1089,6 +1089,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/Masterminds/sprig",
     "github.com/emicklei/go-restful",
     "github.com/golang/mock/gomock",
     "github.com/golang/mock/mockgen",
@@ -1121,6 +1122,7 @@
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/retry",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",
     "k8s.io/helm/pkg/chartutil",

--- a/interoperator/pkg/internal/renderer/gotemplate/fuctions.go
+++ b/interoperator/pkg/internal/renderer/gotemplate/fuctions.go
@@ -4,8 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"text/template"
+
+	"github.com/Masterminds/sprig"
 )
 
 // encodeToString converts a string to base64 encoded string
@@ -38,39 +39,16 @@ func marshalJSON(src map[string]interface{}) (string, error) {
 	return string(options[:]), err
 }
 
-func quote(str ...interface{}) string {
-	out := make([]string, len(str))
-	for i, s := range str {
-		out[i] = fmt.Sprintf("%q", strval(s))
-	}
-	return strings.Join(out, " ")
-}
-
-func squote(str ...interface{}) string {
-	out := make([]string, len(str))
-	for i, s := range str {
-		out[i] = fmt.Sprintf("'%v'", s)
-	}
-	return strings.Join(out, " ")
-}
-
-func strval(v interface{}) string {
-	switch v := v.(type) {
-	case string:
-		return v
-	default:
-		return fmt.Sprintf("%v", v)
-	}
-}
-
 func getFuncMap() template.FuncMap {
-	funcMap := template.FuncMap{
+	funcMap := sprig.TxtFuncMap()
+	localFuncMap := template.FuncMap{
 		"b64enc":        encodeToString,
 		"b64dec":        decodeString,
 		"unmarshalJSON": unmarshalJSON,
 		"marshalJSON":   marshalJSON,
-		"quote":         quote,
-		"squote":        squote,
+	}
+	for k, v := range localFuncMap {
+		funcMap[k] = v
 	}
 	return funcMap
 }

--- a/interoperator/pkg/internal/renderer/gotemplate/functions_test.go
+++ b/interoperator/pkg/internal/renderer/gotemplate/functions_test.go
@@ -9,6 +9,8 @@ import (
 func TestGoTemplateFunctions(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
+	funcMap := getFuncMap()
+
 	g.Expect(encodeToString("Hello")).To(gomega.Equal("SGVsbG8="))
 	g.Expect(decodeString("SGVsbG8=")).To(gomega.Equal("Hello"))
 
@@ -37,20 +39,34 @@ func TestGoTemplateFunctions(t *testing.T) {
 	g.Expect(invalidObj2).To(gomega.BeNil())
 	g.Expect(err2).To(gomega.HaveOccurred())
 
-	str := `{"hello":"world","hi":"india"}`
-	quotedStr := quote(str)
-	g.Expect(quotedStr).To(gomega.Equal(`"{\"hello\":\"world\",\"hi\":\"india\"}"`))
+	if f, ok := funcMap["quote"].(func(str ...interface{}) string); ok {
+		quote := (func(str ...interface{}) string)(f)
+		str := `{"hello":"world","hi":"india"}`
+		quotedStr := quote(str)
+		g.Expect(quotedStr).To(gomega.Equal(`"{\"hello\":\"world\",\"hi\":\"india\"}"`))
+	} else {
+		g.Expect(ok).To(gomega.BeTrue())
+	}
 
-	str2 := `{"hello":"world","hi":"india"}`
-	quotedStr2 := squote(str2)
-	g.Expect(quotedStr2).To(gomega.Equal(`'{"hello":"world","hi":"india"}'`))
+	if f, ok := funcMap["squote"].(func(str ...interface{}) string); ok {
+		squote := (func(str ...interface{}) string)(f)
+		str2 := `{"hello":"world","hi":"india"}`
+		quotedStr2 := squote(str2)
+		g.Expect(quotedStr2).To(gomega.Equal(`'{"hello":"world","hi":"india"}'`))
+	} else {
+		g.Expect(ok).To(gomega.BeTrue())
+	}
 
-	str3 := "helloWorld"
-	str3Val := strval(str3)
-	g.Expect(str3Val).To(gomega.Equal("helloWorld"))
+	if f, ok := funcMap["toString"].(func(str interface{}) string); ok {
+		strval := (func(str interface{}) string)(f)
+		str3 := "helloWorld"
+		str3Val := strval(str3)
+		g.Expect(str3Val).To(gomega.Equal("helloWorld"))
 
-	int := 10
-	intVal := strval(int)
-	g.Expect(intVal).To(gomega.Equal("10"))
-
+		int := 10
+		intVal := strval(int)
+		g.Expect(intVal).To(gomega.Equal("10"))
+	} else {
+		g.Expect(ok).To(gomega.BeTrue())
+	}
 }


### PR DESCRIPTION
- Provide a hierarchical structure for SFPlan's Context attribute
- Removed our fns which were exact copy
- `b64dec` is not exact copy. So kept both `b64dec` and `b64enc`

Feature: HCPCFS-2483