### PR TITLE
Returning 429 (too-many-requests) on timeout

### DIFF
--- a/api-controllers/ServiceBrokerApiController.js
+++ b/api-controllers/ServiceBrokerApiController.js
@@ -14,6 +14,7 @@ const PreconditionFailed = errors.PreconditionFailed;
 const NotFound = errors.NotFound;
 const ContinueWithNext = errors.ContinueWithNext;
 const Conflict = errors.Conflict;
+const Timeout = errors.Timeout;
 const CONST = require('../common/constants');
 const eventmesh = require('../data-access-layer/eventmesh');
 const formatUrl = require('url').format;
@@ -384,7 +385,10 @@ class ServiceBrokerApiController extends FabrikBaseController {
         return eventmesh.apiServerClient.getSecret(secretName, eventmesh.apiServerClient.getNamespaceId(params.instance_id))
           .then(secret => done(secret.data.response));
       })
-      .catch(Conflict, conflict);
+      .catch(Conflict, conflict)
+      .catch(Timeout, err => {
+        res.status(CONST.HTTP_STATUS_CODE.TOO_MANY_REQUESTS).send({});
+      });
   }
 
   deleteBinding(req, res) {
@@ -434,7 +438,10 @@ class ServiceBrokerApiController extends FabrikBaseController {
         timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC
       }))
       .then(done.bind(this))
-      .catch(NotFound, gone);
+      .catch(NotFound, gone)
+      .catch(Timeout, err => {
+        res.status(CONST.HTTP_STATUS_CODE.TOO_MANY_REQUESTS).send({});
+      });
   }
 
   getDashboardUrl(context) {

--- a/common/constants.js
+++ b/common/constants.js
@@ -66,7 +66,7 @@ module.exports = Object.freeze({
     PROCESSING: 'processing'
   },
   OSB_OPERATION: {
-    OSB_SYNC_OPERATION_TIMEOUT_IN_SEC: 55 // in sec
+    OSB_SYNC_OPERATION_TIMEOUT_IN_SEC: 50 // in sec
   },
   DIRECTOR_RESOURCE_POLLER_INTERVAL: 50000, // in ms
   POLLER_RELAXATION_TIME: 5000, // in ms
@@ -130,6 +130,7 @@ module.exports = Object.freeze({
     GONE: 410,
     PRECONDITION_FAILED: 412,
     UNPROCESSABLE_ENTITY: 422,
+    TOO_MANY_REQUESTS: 429,
     INTERNAL_SERVER_ERROR: 500,
     TIMEOUT: 504
   },

--- a/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/test/test_broker/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -1501,7 +1501,7 @@ describe('service-broker-api-2.0', function () {
             .catch(err => err.response)
             .then(res => {
               CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC = timeout;
-              expect(res).to.have.status(500);
+              expect(res).to.have.status(429);
               mocks.verify();
               done();
             });


### PR DESCRIPTION
* Return HTTP Code 429 (indicating "Too Many Requests") on Bind timeouts instead of 500, as Bind timeout will usually mean high load scenario.