### PR TITLE
Override canaries and max_in_flight bosh properties

### DIFF
--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -460,7 +460,7 @@ class BoshDirectorClient extends HttpClient {
   }
 
   createOrUpdateDeployment(action, manifest, opts, scheduled) {
-    const query = opts ? _.pick(opts, 'recreate', 'skip_drain', 'context') : undefined;
+    const query = opts ? ( (action === CONST.OPERATION_TYPE.CREATE) ? _.pick(opts, 'recreate', 'skip_drain', 'context', 'canaries', 'max_in_flight') :  _.pick(opts, 'recreate', 'skip_drain', 'context')) : undefined;
     const deploymentName = yaml.safeLoad(manifest).name;
     const boshDirectorName = _.get(opts, 'bosh_director_name');
     delete this.deploymentIpsCache[deploymentName];

--- a/data-access-layer/bosh/BoshDirectorClient.js
+++ b/data-access-layer/bosh/BoshDirectorClient.js
@@ -460,7 +460,7 @@ class BoshDirectorClient extends HttpClient {
   }
 
   createOrUpdateDeployment(action, manifest, opts, scheduled) {
-    const query = opts ? ( (action === CONST.OPERATION_TYPE.CREATE) ? _.pick(opts, 'recreate', 'skip_drain', 'context', 'canaries', 'max_in_flight') :  _.pick(opts, 'recreate', 'skip_drain', 'context')) : undefined;
+    const query = opts ? ((action === CONST.OPERATION_TYPE.CREATE) ? _.pick(opts, 'recreate', 'skip_drain', 'context', 'canaries', 'max_in_flight') : _.pick(opts, 'recreate', 'skip_drain', 'context')) : undefined;
     const deploymentName = yaml.safeLoad(manifest).name;
     const boshDirectorName = _.get(opts, 'bosh_director_name');
     delete this.deploymentIpsCache[deploymentName];

--- a/operators/bosh-operator/DirectorService.js
+++ b/operators/bosh-operator/DirectorService.js
@@ -432,6 +432,14 @@ class DirectorService extends BaseDirectorService {
     const opts = _.omit(params, 'previous_values');
     args = args || {};
     args = _.set(args, 'bosh_director_name', _.get(params, 'parameters.bosh_director_name'));
+    if (action == CONST.OPERATION_TYPE.CREATE) {
+      if (_.has(this.plan, 'manager.settings.canaries')) {
+        _.set(args, 'canaries', this.plan.manager.settings.canaries);
+      }
+      if (_.has(this.plan, 'manager.settings.max_in_flight')) {
+        _.set(args, 'max_in_flight', this.plan.manager.settings.max_in_flight);
+      }
+    }
     const username = _.get(params, 'parameters.username');
     const password = _.get(params, 'parameters.password');
     logger.info(`Starting to ${action} deployment '${deploymentName}'...`);


### PR DESCRIPTION
To speedup an initial bosh deployment it can be useful to override the "canaries" and "max_in_flight" settings defined in the manifest, which are typically optimized to allow downtime free updates. bosh cli and REST API offer this feature. The feature was temporarily broken in the bosh director but now it is fixed:

https://github.com/cloudfoundry/bosh/issues/2193#issuecomment-514406655
https://github.com/cloudfoundry/bosh/commit/756d6f0fcab557708149bdc1392bb106298204c9#diff-3eaf271cb508f0088110a241848205cd

This change allows to specify plan.manager.settings.canaries and plan.manager.settings.max_in_flight in a service plan. If done so this settings are passed to the bosh director when creating a new deployment, updates are not effected an continue using the settings from the deployment manifest.

This small change allow us to significantly speedup the deployment of ABAP systems in our Steampunk project.