### PR TITLE
[interoperator] Add sprig libary to gotemplates

### DIFF
--- a/interoperator/go.mod
+++ b/interoperator/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
-	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/interoperator/internal/renderer/gotemplate/fuctions.go
+++ b/interoperator/internal/renderer/gotemplate/fuctions.go
@@ -4,8 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"text/template"
+
+	"github.com/Masterminds/sprig"
 )
 
 // encodeToString converts a string to base64 encoded string
@@ -38,39 +39,16 @@ func marshalJSON(src map[string]interface{}) (string, error) {
 	return string(options[:]), err
 }
 
-func quote(str ...interface{}) string {
-	out := make([]string, len(str))
-	for i, s := range str {
-		out[i] = fmt.Sprintf("%q", strval(s))
-	}
-	return strings.Join(out, " ")
-}
-
-func squote(str ...interface{}) string {
-	out := make([]string, len(str))
-	for i, s := range str {
-		out[i] = fmt.Sprintf("'%v'", s)
-	}
-	return strings.Join(out, " ")
-}
-
-func strval(v interface{}) string {
-	switch v := v.(type) {
-	case string:
-		return v
-	default:
-		return fmt.Sprintf("%v", v)
-	}
-}
-
 func getFuncMap() template.FuncMap {
-	funcMap := template.FuncMap{
+	funcMap := sprig.TxtFuncMap()
+	localFuncMap := template.FuncMap{
 		"b64enc":        encodeToString,
 		"b64dec":        decodeString,
 		"unmarshalJSON": unmarshalJSON,
 		"marshalJSON":   marshalJSON,
-		"quote":         quote,
-		"squote":        squote,
+	}
+	for k, v := range localFuncMap {
+		funcMap[k] = v
 	}
 	return funcMap
 }

--- a/interoperator/internal/renderer/gotemplate/functions_test.go
+++ b/interoperator/internal/renderer/gotemplate/functions_test.go
@@ -9,6 +9,8 @@ import (
 func TestGoTemplateFunctions(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
+	funcMap := getFuncMap()
+
 	g.Expect(encodeToString("Hello")).To(gomega.Equal("SGVsbG8="))
 	g.Expect(decodeString("SGVsbG8=")).To(gomega.Equal("Hello"))
 
@@ -37,20 +39,34 @@ func TestGoTemplateFunctions(t *testing.T) {
 	g.Expect(invalidObj2).To(gomega.BeNil())
 	g.Expect(err2).To(gomega.HaveOccurred())
 
-	str := `{"hello":"world","hi":"india"}`
-	quotedStr := quote(str)
-	g.Expect(quotedStr).To(gomega.Equal(`"{\"hello\":\"world\",\"hi\":\"india\"}"`))
+	if f, ok := funcMap["quote"].(func(str ...interface{}) string); ok {
+		quote := (func(str ...interface{}) string)(f)
+		str := `{"hello":"world","hi":"india"}`
+		quotedStr := quote(str)
+		g.Expect(quotedStr).To(gomega.Equal(`"{\"hello\":\"world\",\"hi\":\"india\"}"`))
+	} else {
+		g.Expect(ok).To(gomega.BeTrue())
+	}
 
-	str2 := `{"hello":"world","hi":"india"}`
-	quotedStr2 := squote(str2)
-	g.Expect(quotedStr2).To(gomega.Equal(`'{"hello":"world","hi":"india"}'`))
+	if f, ok := funcMap["squote"].(func(str ...interface{}) string); ok {
+		squote := (func(str ...interface{}) string)(f)
+		str2 := `{"hello":"world","hi":"india"}`
+		quotedStr2 := squote(str2)
+		g.Expect(quotedStr2).To(gomega.Equal(`'{"hello":"world","hi":"india"}'`))
+	} else {
+		g.Expect(ok).To(gomega.BeTrue())
+	}
 
-	str3 := "helloWorld"
-	str3Val := strval(str3)
-	g.Expect(str3Val).To(gomega.Equal("helloWorld"))
+	if f, ok := funcMap["toString"].(func(str interface{}) string); ok {
+		strval := (func(str interface{}) string)(f)
+		str3 := "helloWorld"
+		str3Val := strval(str3)
+		g.Expect(str3Val).To(gomega.Equal("helloWorld"))
 
-	int := 10
-	intVal := strval(int)
-	g.Expect(intVal).To(gomega.Equal("10"))
-
+		int := 10
+		intVal := strval(int)
+		g.Expect(intVal).To(gomega.Equal("10"))
+	} else {
+		g.Expect(ok).To(gomega.BeTrue())
+	}
 }


### PR DESCRIPTION
- Provide a hierarchical structure for SFPlan's Context attribute
- Removed our fns which were exact copy
- b64dec is not exact copy. So kept both b64dec and b64enc
- Modify tests

Feature: HCPCFS-2483