### PR TITLE
Improving label selector scheduler performance

### DIFF
--- a/helm-charts/interoperator/templates/sfcluster.yaml
+++ b/helm-charts/interoperator/templates/sfcluster.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: sfclusters.resource.servicefabrik.io
 spec:
@@ -10,7 +12,9 @@ spec:
     listKind: SFClusterList
     plural: sfclusters
     singular: sfcluster
-  scope: ""
+  scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: SFCluster is the Schema for the sfclusters API
@@ -40,6 +44,9 @@ spec:
           type: object
         status:
           description: SFClusterStatus defines the observed state of SFCluster
+          properties:
+            serviceInstanceCount:
+              type: integer
           type: object
       type: object
   version: v1alpha1

--- a/helm-charts/interoperator/templates/sfcluster.yaml
+++ b/helm-charts/interoperator/templates/sfcluster.yaml
@@ -6,6 +6,10 @@ metadata:
   creationTimestamp: null
   name: sfclusters.resource.servicefabrik.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.serviceInstanceCount
+    name: numserviceinstance
+    type: integer
   group: resource.servicefabrik.io
   names:
     kind: SFCluster

--- a/helm-charts/interoperator/templates/sfserviceinstance.yaml
+++ b/helm-charts/interoperator/templates/sfserviceinstance.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: sfserviceinstances.osb.servicefabrik.io
 spec:
@@ -11,13 +13,16 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: age
     type: date
+  - JSONPath: .spec.clusterId
+    name: clusterid
+    type: string
   group: osb.servicefabrik.io
   names:
     kind: SFServiceInstance
     listKind: SFServiceInstanceList
     plural: sfserviceinstances
     singular: sfserviceinstance
-  scope: ""
+  scope: Namespaced
   subresources: {}
   validation:
     openAPIV3Schema:

--- a/interoperator/api/osb/v1alpha1/sfserviceinstance_types.go
+++ b/interoperator/api/osb/v1alpha1/sfserviceinstance_types.go
@@ -51,6 +51,7 @@ type SFServiceInstanceStatus struct {
 // +genclient:noStatus
 // +kubebuilder:printcolumn:name="state",type=string,JSONPath=`.status.state`
 // +kubebuilder:printcolumn:name="age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="clusterid",type=string,JSONPath=`.spec.clusterId`
 
 // SFServiceInstance is the Schema for the sfserviceinstances API
 type SFServiceInstance struct {

--- a/interoperator/api/resource/v1alpha1/sfcluster_types.go
+++ b/interoperator/api/resource/v1alpha1/sfcluster_types.go
@@ -37,6 +37,7 @@ type SFClusterStatus struct {
 
 // SFCluster is the Schema for the sfclusters API
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="numserviceinstance",type=integer,JSONPath=`.status.serviceInstanceCount`
 type SFCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/interoperator/api/resource/v1alpha1/sfcluster_types.go
+++ b/interoperator/api/resource/v1alpha1/sfcluster_types.go
@@ -30,11 +30,13 @@ type SFClusterSpec struct {
 
 // SFClusterStatus defines the observed state of SFCluster
 type SFClusterStatus struct {
+	ServiceInstanceCount int `json:"serviceInstanceCount,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
 // SFCluster is the Schema for the sfclusters API
+// +kubebuilder:subresource:status
 type SFCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfserviceinstances.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfserviceinstances.yaml
@@ -15,6 +15,9 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: age
     type: date
+  - JSONPath: .spec.clusterId
+    name: clusterid
+    type: string
   group: osb.servicefabrik.io
   names:
     kind: SFServiceInstance

--- a/interoperator/config/crd/bases/resource.servicefabrik.io_sfclusters.yaml
+++ b/interoperator/config/crd/bases/resource.servicefabrik.io_sfclusters.yaml
@@ -15,6 +15,8 @@ spec:
     plural: sfclusters
     singular: sfcluster
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: SFCluster is the Schema for the sfclusters API
@@ -44,6 +46,9 @@ spec:
           type: object
         status:
           description: SFClusterStatus defines the observed state of SFCluster
+          properties:
+            serviceInstanceCount:
+              type: integer
           type: object
       type: object
   version: v1alpha1

--- a/interoperator/config/crd/bases/resource.servicefabrik.io_sfclusters.yaml
+++ b/interoperator/config/crd/bases/resource.servicefabrik.io_sfclusters.yaml
@@ -8,6 +8,10 @@ metadata:
   creationTimestamp: null
   name: sfclusters.resource.servicefabrik.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.serviceInstanceCount
+    name: numserviceinstance
+    type: integer
   group: resource.servicefabrik.io
   names:
     kind: SFCluster

--- a/interoperator/controllers/schedulers/setup_schedulers.go
+++ b/interoperator/controllers/schedulers/setup_schedulers.go
@@ -21,6 +21,7 @@ package schedulers
 import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfdefaultscheduler"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sflabelselectorscheduler"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfserviceinstancecounter"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -29,6 +30,14 @@ import (
 func SetupWithManager(mgr ctrl.Manager) error {
 	var err error
 	setupLog := ctrl.Log.WithName("setup").WithName("schedulers")
+
+	if err = (&sfserviceinstancecounter.SFServiceInstanceCounter{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("scheduler-helper").WithName("sfserviceinstance-counter"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create sfserviceinstance-counter", "scheduler-helper", "SFServiceInstanceCounter")
+		return err
+	}
 
 	if err = (&sfdefaultscheduler.SFDefaultScheduler{
 		Client: mgr.GetClient(),

--- a/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller.go
+++ b/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2018 The Service Fabrik Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfserviceinstancecounter
+
+import (
+	"context"
+	"os"
+
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/utils"
+	"github.com/go-logr/logr"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SFServiceInstanceCounter reconciles a SFServiceInstance object
+type SFServiceInstanceCounter struct {
+	client.Client
+	Log             logr.Logger
+	scheme          *runtime.Scheme
+	clusterRegistry registry.ClusterRegistry
+}
+
+// Reconcile schedules the SFServiceInstance to one SFCluster and sets the ClusterID in
+// SFServiceInstance.Spec.ClusterID. It chooses the destination cluster based on clusterSelector
+// template provided in the plan.
+func (r *SFServiceInstanceCounter) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	log := r.Log.WithValues("sfserviceinstance-counter", req.NamespacedName)
+
+	instance := &osbv1alpha1.SFServiceInstance{}
+	err := r.Get(ctx, req.NamespacedName, instance)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if instance.Spec.ClusterID != "" { //act only if the clusterID is not set
+		log.Info("ClusterID is set", "function", "Reconcile", "ClusterID", instance.Spec.ClusterID)
+		if instance.GetDeletionTimestamp().IsZero() { // not marked for deletion
+			if !utils.ContainsString(instance.GetFinalizers(), constants.SFServiceInstanceCounterFinalizerName) {
+				log.Info("Finalizer not yet set", "function", "Reconcile", "Finalizer", constants.SFServiceInstanceCounterFinalizerName)
+				//add the finalizer and count ++
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					instance.SetFinalizers(append(instance.GetFinalizers(), constants.SFServiceInstanceCounterFinalizerName))
+					if err1 := r.Update(ctx, instance); err1 != nil {
+						_ = r.Get(ctx, req.NamespacedName, instance)
+						return err1
+					}
+					return nil
+				})
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+
+				sfNamespace := os.Getenv(constants.NamespaceEnvKey)
+				if sfNamespace == "" {
+					sfNamespace = constants.DefaultServiceFabrikNamespace
+				}
+				sfCluster := &resourcev1alpha1.SFCluster{}
+				namespacedName := types.NamespacedName{
+					Name:      instance.Spec.ClusterID,
+					Namespace: sfNamespace,
+				}
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					err1 := r.Get(ctx, namespacedName, sfCluster)
+					if err1 != nil {
+						return err1
+					}
+					currentCount := sfCluster.Status.ServiceInstanceCount
+					sfCluster.Status.ServiceInstanceCount = currentCount + 1
+					return r.Status().Update(ctx, sfCluster)
+				})
+				if err != nil {
+					log.Error(err, "Error occured while increasing the service instance count", "cluster-name", sfCluster.GetName(), "current-count", sfCluster.Status.ServiceInstanceCount)
+					return ctrl.Result{}, err
+				}
+				log.Info("Cluster labeling complete", "cluster name", sfCluster.GetName(), "cluster size", sfCluster.Status.ServiceInstanceCount)
+			}
+		} else {
+			if utils.ContainsString(instance.GetFinalizers(), constants.SFServiceInstanceCounterFinalizerName) && !utils.ContainsString(instance.GetFinalizers(), constants.FinalizerName) {
+				//remove the finalizer and count --
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					instance.SetFinalizers(utils.RemoveString(instance.GetFinalizers(), constants.SFServiceInstanceCounterFinalizerName))
+					if err1 := r.Update(ctx, instance); err1 != nil {
+						return err1
+					}
+					return nil
+				})
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+
+				sfNamespace := os.Getenv(constants.NamespaceEnvKey)
+				if sfNamespace == "" {
+					sfNamespace = constants.DefaultServiceFabrikNamespace
+				}
+				sfCluster := &resourcev1alpha1.SFCluster{}
+				namespacedName := types.NamespacedName{
+					Name:      instance.Spec.ClusterID,
+					Namespace: sfNamespace,
+				}
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					err1 := r.Get(ctx, namespacedName, sfCluster)
+					if err1 != nil {
+						return err1
+					}
+					currentCount := sfCluster.Status.ServiceInstanceCount
+					sfCluster.Status.ServiceInstanceCount = currentCount - 1
+					return r.Status().Update(ctx, sfCluster)
+				})
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the least utilized scheduler with manager
+// and setups the watches.
+func (r *SFServiceInstanceCounter) SetupWithManager(mgr ctrl.Manager) error {
+	clusterRegistry, err := registry.New(mgr.GetConfig(), mgr.GetScheme(), mgr.GetRESTMapper())
+	if err != nil {
+		return err
+	}
+	r.clusterRegistry = clusterRegistry
+
+	r.scheme = mgr.GetScheme()
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("scheduler_helper_sfserviceinstance_counter").
+		For(&osbv1alpha1.SFServiceInstance{}).
+		Complete(r)
+}

--- a/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller.go
+++ b/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller.go
@@ -106,6 +106,7 @@ func (r *SFServiceInstanceCounter) Reconcile(req ctrl.Request) (ctrl.Result, err
 				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					instance.SetFinalizers(utils.RemoveString(instance.GetFinalizers(), constants.SFServiceInstanceCounterFinalizerName))
 					if err1 := r.Update(ctx, instance); err1 != nil {
+						_ = r.Get(ctx, req.NamespacedName, instance)
 						return err1
 					}
 					return nil

--- a/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller_suit_test.go
+++ b/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller_suit_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Service Fabrik Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfserviceinstancecounter
+
+import (
+	stdlog "log"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testLog logr.Logger
+
+func TestMain(m *testing.M) {
+	var err error
+	logf.SetLogger(zap.LoggerTo(ginkgo.GinkgoWriter, true))
+	testLog = ctrl.Log.WithName("test").WithName("sflabelselectorscheduler")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+	}
+
+	err = osbv1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	err = resourcev1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	if cfg, err = testEnv.Start(); err != nil {
+		stdlog.Fatal(err)
+	}
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	code := m.Run()
+	testEnv.Stop()
+	os.Exit(code)
+}
+
+// StartTestManager adds recFn
+func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}, *sync.WaitGroup) {
+	stop := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		g.Expect(mgr.Start(stop)).NotTo(gomega.HaveOccurred())
+	}()
+	return stop, wg
+}

--- a/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller_test.go
+++ b/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2018 The Service Fabrik Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfserviceinstancecounter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfdefaultscheduler"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/golang/mock/gomock"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlrun "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var c client.Client
+
+const timeout = time.Second * 5
+
+func TestReconcile(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	configMap := _getDummyConfigMap()
+
+	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
+	// channel when it is finished.
+	mgr, err := manager.New(cfg, manager.Options{
+		MetricsBindAddress: "0",
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	c, err = client.New(cfg, client.Options{
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	g.Expect(c.Create(context.TODO(), configMap)).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), configMap)
+
+	SFServiceInstanceCounter := &SFServiceInstanceCounter{
+		Client: mgr.GetClient(),
+		Log:    ctrlrun.Log.WithName("scheduler-helper").WithName("sfserviceinstance-counter"),
+	}
+	g.Expect(SFServiceInstanceCounter.SetupWithManager(mgr)).NotTo(gomega.HaveOccurred())
+
+	g.Expect((&sfdefaultscheduler.SFDefaultScheduler{
+		Client: mgr.GetClient(),
+		Log:    ctrlrun.Log.WithName("schedulers").WithName("default"),
+	}).SetupWithManager(mgr)).NotTo(gomega.HaveOccurred())
+
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	sfcluster1 := &resourcev1alpha1.SFCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "1",
+			Namespace: constants.DefaultServiceFabrikNamespace,
+		},
+	}
+	g.Expect(c.Create(context.TODO(), sfcluster1)).NotTo(gomega.HaveOccurred())
+
+	// when cluster selector evaluates to single cluster
+	instance1 := _getDummySFServiceInstance("foo1", "plan-id-1")
+	g.Expect(c.Create(context.TODO(), instance1)).NotTo(gomega.HaveOccurred())
+	//defer c.Delete(context.TODO(), instance1)
+
+	instance2 := _getDummySFServiceInstance("foo2", "plan-id-2")
+	g.Expect(c.Create(context.TODO(), instance2)).NotTo(gomega.HaveOccurred())
+	//defer c.Delete(context.TODO(), instance2)
+
+	sfCluster := &resourcev1alpha1.SFCluster{}
+	g.Eventually(func() error {
+		err := c.Get(context.TODO(), types.NamespacedName{
+			Name:      "1",
+			Namespace: constants.DefaultServiceFabrikNamespace,
+		}, sfCluster)
+		if err != nil {
+			return err
+		}
+		serviceInstanceCount := sfCluster.Status.ServiceInstanceCount
+		if serviceInstanceCount != 2 {
+			return errors.New("service intance count is not 2")
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+	g.Expect(sfCluster.Status.ServiceInstanceCount).To(gomega.Equal(2))
+
+	g.Expect(c.Delete(context.TODO(), instance1)).NotTo(gomega.HaveOccurred())
+	g.Expect(c.Delete(context.TODO(), instance2)).NotTo(gomega.HaveOccurred())
+
+	sfcluster2 := &resourcev1alpha1.SFCluster{}
+	g.Eventually(func() error {
+		err := c.Get(context.TODO(), types.NamespacedName{
+			Name:      "foo1",
+			Namespace: constants.DefaultServiceFabrikNamespace,
+		}, instance1)
+		if err == nil {
+			return errors.New("instance not deleted")
+		}
+		err = c.Get(context.TODO(), types.NamespacedName{
+			Name:      "foo2",
+			Namespace: constants.DefaultServiceFabrikNamespace,
+		}, instance2)
+		if err == nil {
+			return errors.New("instance not deleted")
+		}
+		err = c.Get(context.TODO(), types.NamespacedName{
+			Name:      "1",
+			Namespace: constants.DefaultServiceFabrikNamespace,
+		}, sfcluster2)
+		if err != nil {
+			return err
+		}
+		serviceInstanceCount := sfcluster2.Status.ServiceInstanceCount
+		if serviceInstanceCount != 0 {
+			return errors.New("service intance count is not 0")
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+	g.Expect(sfcluster2.Status.ServiceInstanceCount).To(gomega.Equal(0))
+
+}
+
+func _getDummyConfigMap() *corev1.ConfigMap {
+	data := make(map[string]string)
+	config := "schedulerType: label-selector"
+	data[constants.ConfigMapKey] = config
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.ConfigMapName,
+			Namespace: constants.DefaultServiceFabrikNamespace,
+		},
+		Data: data,
+	}
+}
+
+func _getDummySFServiceInstance(name string, planID string) *osbv1alpha1.SFServiceInstance {
+	return &osbv1alpha1.SFServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				"state": "in_queue",
+			},
+		},
+		Spec: osbv1alpha1.SFServiceInstanceSpec{
+			ServiceID:        "service-id",
+			PlanID:           planID,
+			RawContext:       nil,
+			OrganizationGUID: "organization-guid",
+			SpaceGUID:        "space-guid",
+			RawParameters:    nil,
+			PreviousValues:   nil,
+			//			ClusterID:        "1",
+		},
+		Status: osbv1alpha1.SFServiceInstanceStatus{
+			State: "in_queue",
+		},
+	}
+}
+
+func _getSFClusterList(clusters ...resourcev1alpha1.SFCluster) *resourcev1alpha1.SFClusterList {
+	return &resourcev1alpha1.SFClusterList{
+		Items: clusters,
+	}
+}
+
+func _getKey(obj metav1.Object) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+}

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -6,10 +6,11 @@ import (
 
 // Constants used by interoperator
 const (
-	FinalizerName    = "interoperator.servicefabrik.io"
-	ErrorCountKey    = "interoperator.servicefabrik.io/error"
-	LastOperationKey = "interoperator.servicefabrik.io/lastoperation"
-	ErrorThreshold   = 10
+	FinalizerName                         = "interoperator.servicefabrik.io"
+	SFServiceInstanceCounterFinalizerName = "sfserviceinstancecounter.servicefabrik.io"
+	ErrorCountKey                         = "interoperator.servicefabrik.io/error"
+	LastOperationKey                      = "interoperator.servicefabrik.io/lastoperation"
+	ErrorThreshold                        = 10
 
 	ConfigMapName          = "interoperator-config"
 	ConfigMapKey           = "config"


### PR DESCRIPTION
* Adding ServiceInstanceCount under sfcluster status
* Adding sfcluster status as sub resource
* Adding SFServiceInstanceCounter controller as part of the scheduler binary
* SFServiceInstanceCounter controller updates the ServiceInstanceCount under the status of a sfcluster when an sfserviceinstance is scheduled in a cluster and also updates the same when the instance is deleted.