### PR TITLE
Also honor the description response in error forwarding

### DIFF
--- a/common/utils/HttpClient.js
+++ b/common/utils/HttpClient.js
@@ -135,8 +135,10 @@ class HttpClient {
       logger.debug('Received HTTP response:', result);
       if (expectedStatusCode && res.statusCode !== expectedStatusCode) {
         let message = `Got HTTP Status Code ${res.statusCode} expected ${expectedStatusCode}`;
-        if ((res.body && res.body.message) || res.statusMessage) {
-          message = res.body && res.body.message ? `${message}. ${res.body.message}` : `${message}. ${res.statusMessage}`;
+        if ((res.body && (res.body.message || res.body.description))) {
+          message = `${message}. ${res.body.message || res.body.description}`;
+        } else if (res.statusMessage) {
+          message = `${message}. ${res.statusMessage}`;
         }
         let err;
         switch (res.statusCode) {


### PR DESCRIPTION
Since the internal error handler forwards the error messages in the description field, adapt the client to also encapsulate this field, when wrapping request errors.