### PR TITLE
Update nodejs & go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# FROM node:8-alpine also works here for a smaller image
-FROM node:8-alpine
+# FROM node:12.13-alpine also works here for a smaller image
+FROM node:12.13-alpine
 
 # set our node environment, either development or production
 # defaults to production, compose overrides this to development on build and run

--- a/interoperator/Dockerfile
+++ b/interoperator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13.4 as builder
+FROM golang:1.13 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
- Use 12.13 nodejs version
- Use 1.13 golang version
- Uses the latest patch version

Feature: HCPCFS-2591