### PR TITLE
Helm chart support - Bugs

### DIFF
--- a/helm-charts/interoperator/templates/sfcluster.yaml
+++ b/helm-charts/interoperator/templates/sfcluster.yaml
@@ -28,12 +28,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/helm-charts/interoperator/templates/sfplan.yaml
+++ b/helm-charts/interoperator/templates/sfplan.yaml
@@ -22,12 +22,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/helm-charts/interoperator/templates/sfservice.yaml
+++ b/helm-charts/interoperator/templates/sfservice.yaml
@@ -22,12 +22,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/helm-charts/interoperator/templates/sfservicebinding.yaml
+++ b/helm-charts/interoperator/templates/sfservicebinding.yaml
@@ -30,12 +30,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/helm-charts/interoperator/templates/sfserviceinstance.yaml
+++ b/helm-charts/interoperator/templates/sfserviceinstance.yaml
@@ -33,12 +33,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfplans.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfplans.yaml
@@ -22,12 +22,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfservicebindings.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfservicebindings.yaml
@@ -30,12 +30,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfserviceinstances.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfserviceinstances.yaml
@@ -33,12 +33,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfservices.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfservices.yaml
@@ -22,12 +22,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/config/crd/bases/resource.servicefabrik.io_sfclusters.yaml
+++ b/interoperator/config/crd/bases/resource.servicefabrik.io_sfclusters.yaml
@@ -28,12 +28,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/interoperator/internal/dynamic/dynamic.go
+++ b/interoperator/internal/dynamic/dynamic.go
@@ -20,10 +20,14 @@ func StringToUnstructured(contentString string) ([]*unstructured.Unstructured, e
 	res := make([]*unstructured.Unstructured, 0, len(contents))
 
 	for _, content := range contents {
+		trimmedContent := strings.Trim(content, "\n")
+		if trimmedContent == "" {
+			continue
+		}
 		obj := &unstructured.Unstructured{}
 
 		var body interface{}
-		err := yaml.Unmarshal([]byte(content), &body)
+		err := yaml.Unmarshal([]byte(trimmedContent), &body)
 		if err != nil {
 			log.Error(err, "StringToUnstructured: failed to unmarshal yaml")
 			return nil, errors.NewUnmarshalError("unable to unmarshal from yaml", err)

--- a/interoperator/internal/renderer/factory/factory.go
+++ b/interoperator/internal/renderer/factory/factory.go
@@ -83,7 +83,7 @@ func GetRendererInput(template *osbv1alpha1.TemplateSpec, service *osbv1alpha1.S
 		if content == "" {
 			return nil, fmt.Errorf("content & contentEncoded fields empty for %s template ", template.Action)
 		}
-		input := gotemplate.NewInput(template.URL, content, name.Name, values)
+		input := gotemplate.NewInput(template.URL, content, fmt.Sprintf("%s-%s", name.Name, template.Action), values)
 		return input, nil
 	default:
 		return nil, fmt.Errorf("unable to create renderer for type %s. not implemented", rendererType)
@@ -111,7 +111,7 @@ func GetStatusRendererInput(template *osbv1alpha1.TemplateSpec, name types.Names
 				return nil, fmt.Errorf("unable to decode base64 content %v", err)
 			}
 		}
-		input := gotemplate.NewInput(template.URL, content, name.Name, values)
+		input := gotemplate.NewInput(template.URL, content, fmt.Sprintf("%s-%s", name.Name, template.Action), values)
 		return input, nil
 	default:
 		return nil, fmt.Errorf("unable to create renderer for type %s. not implemented", rendererType)

--- a/interoperator/internal/renderer/helm/renderer.go
+++ b/interoperator/internal/renderer/helm/renderer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/renderer"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/renderer/gotemplate"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/errors"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/utils"
 	"k8s.io/client-go/kubernetes"
 
 	chartapi "helm.sh/helm/v3/pkg/chart"
@@ -55,9 +56,10 @@ type helmInput struct {
 
 // NewInput creates a new helm Renderer input object.
 func NewInput(chartPath, releaseName, namespace string, valuesTemplate string, valuesInput map[string]interface{}) renderer.Input {
+	shortName := fmt.Sprintf("in-%s", utils.Adler32sum(releaseName))
 	return helmInput{
 		chartPath:      chartPath,
-		releaseName:    releaseName,
+		releaseName:    shortName,
 		namespace:      namespace,
 		valuesTemplate: valuesTemplate,
 		valuesInput:    valuesInput,

--- a/interoperator/internal/renderer/helm/renderer_test.go
+++ b/interoperator/internal/renderer/helm/renderer_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/renderer"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/utils"
 	chartapi "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -53,7 +54,7 @@ func TestNewInput(t *testing.T) {
 			},
 			want: helmInput{
 				chartPath:      "chartPath",
-				releaseName:    "releaseName",
+				releaseName:    fmt.Sprintf("in-%s", utils.Adler32sum("releaseName")),
 				namespace:      "namespace",
 				valuesTemplate: "valuesTemplate",
 				valuesInput:    nil,

--- a/interoperator/pkg/utils/strings.go
+++ b/interoperator/pkg/utils/strings.go
@@ -1,5 +1,10 @@
 package utils
 
+import (
+	"fmt"
+	"hash/adler32"
+)
+
 //
 // Helper functions to check and remove string from a slice of strings.
 //
@@ -26,4 +31,11 @@ func RemoveString(slice []string, s string) (result []string) {
 		result = append(result, item)
 	}
 	return
+}
+
+// Adler32sum function receives a string, and computes its Adler-32 checksum
+// Use the same definition as used in gotemplate functions
+func Adler32sum(input string) string {
+	hash := adler32.Checksum([]byte(input))
+	return fmt.Sprintf("%d", hash)
 }


### PR DESCRIPTION
- Trim empty lines in rendered output
- Use "in-<checksum of instanceid>" as helm release name
- Use Adler-32 checksum (sprig supports this)
- Append template type to go template name for debugging templates

Bug: HCPCFS-2577