### PR TITLE
Adding support for Mass Update of service instances

### DIFF
--- a/helm-charts/interoperator/templates/sfplan.yaml
+++ b/helm-charts/interoperator/templates/sfplan.yaml
@@ -8,6 +8,13 @@ metadata:
   creationTimestamp: null
   name: sfplans.osb.servicefabrik.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.name
+    name: display-name
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: osb.servicefabrik.io
   names:
     kind: SFPlan
@@ -15,6 +22,8 @@ spec:
     plural: sfplans
     singular: sfplan
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: SFPlan is the Schema for the sfplans API
@@ -34,6 +43,8 @@ spec:
         spec:
           description: SFPlanSpec defines the desired state of SFPlan
           properties:
+            autoUpdateInstances:
+              type: boolean
             bindable:
               type: boolean
             context:
@@ -132,6 +143,9 @@ spec:
           type: object
         status:
           description: SFPlanStatus defines the observed state of SFPlan
+          properties:
+            specHash:
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/helm-charts/interoperator/templates/sfservice.yaml
+++ b/helm-charts/interoperator/templates/sfservice.yaml
@@ -8,6 +8,13 @@ metadata:
   creationTimestamp: null
   name: sfservices.osb.servicefabrik.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.name
+    name: display-name
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: osb.servicefabrik.io
   names:
     kind: SFService
@@ -15,6 +22,7 @@ spec:
     plural: sfservices
     singular: sfservice
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: SFService is the Schema for the sfservices API

--- a/interoperator/.gitignore
+++ b/interoperator/.gitignore
@@ -6,6 +6,8 @@
 *.so
 *.dylib
 bin
+sample*.*
+kubeconfig*.*
 
 # Test binary, build with `go test -c`
 *.test

--- a/interoperator/api/osb/v1alpha1/sfplan_types.go
+++ b/interoperator/api/osb/v1alpha1/sfplan_types.go
@@ -71,30 +71,33 @@ type ServiceSchemas struct {
 
 // SFPlanSpec defines the desired state of SFPlan
 type SFPlanSpec struct {
-	Name          string                `json:"name"`
-	ID            string                `json:"id"`
-	Description   string                `json:"description"`
-	Metadata      *runtime.RawExtension `json:"metadata,omitempty"`
-	Free          bool                  `json:"free"`
-	Bindable      bool                  `json:"bindable"`
-	PlanUpdatable bool                  `json:"planUpdatable,omitempty"`
-	Schemas       *ServiceSchemas       `json:"schemas,omitempty"`
-	Templates     []TemplateSpec        `json:"templates"`
-	ServiceID     string                `json:"serviceId"`
-	RawContext    *runtime.RawExtension `json:"context,omitempty"`
-	Manager       *runtime.RawExtension `json:"manager,omitempty"`
+	Name                string                `json:"name"`
+	ID                  string                `json:"id"`
+	Description         string                `json:"description"`
+	Metadata            *runtime.RawExtension `json:"metadata,omitempty"`
+	Free                bool                  `json:"free"`
+	Bindable            bool                  `json:"bindable"`
+	PlanUpdatable       bool                  `json:"planUpdatable,omitempty"`
+	AutoUpdateInstances bool                  `json:"autoUpdateInstances,omitempty"`
+	Schemas             *ServiceSchemas       `json:"schemas,omitempty"`
+	Templates           []TemplateSpec        `json:"templates"`
+	ServiceID           string                `json:"serviceId"`
+	RawContext          *runtime.RawExtension `json:"context,omitempty"`
+	Manager             *runtime.RawExtension `json:"manager,omitempty"`
 	// Add supported_platform field
 }
 
 // SFPlanStatus defines the observed state of SFPlan
 type SFPlanStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	SpecHash string `json:"specHash,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +genclient
 // +genclient:noStatus
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="display-name",type=string,JSONPath=`.spec.name`
+// +kubebuilder:printcolumn:name="age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // SFPlan is the Schema for the sfplans API
 type SFPlan struct {

--- a/interoperator/api/osb/v1alpha1/sfservice_types.go
+++ b/interoperator/api/osb/v1alpha1/sfservice_types.go
@@ -53,6 +53,8 @@ type SFServiceStatus struct {
 // +kubebuilder:object:root=true
 // +genclient
 // +genclient:noStatus
+// +kubebuilder:printcolumn:name="display-name",type=string,JSONPath=`.spec.name`
+// +kubebuilder:printcolumn:name="age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // SFService is the Schema for the sfservices API
 type SFService struct {

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfplans.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfplans.yaml
@@ -8,6 +8,13 @@ metadata:
   creationTimestamp: null
   name: sfplans.osb.servicefabrik.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.name
+    name: display-name
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: osb.servicefabrik.io
   names:
     kind: SFPlan
@@ -15,6 +22,8 @@ spec:
     plural: sfplans
     singular: sfplan
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: SFPlan is the Schema for the sfplans API
@@ -34,6 +43,8 @@ spec:
         spec:
           description: SFPlanSpec defines the desired state of SFPlan
           properties:
+            autoUpdateInstances:
+              type: boolean
             bindable:
               type: boolean
             context:
@@ -132,6 +143,9 @@ spec:
           type: object
         status:
           description: SFPlanStatus defines the observed state of SFPlan
+          properties:
+            specHash:
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfservices.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfservices.yaml
@@ -8,6 +8,13 @@ metadata:
   creationTimestamp: null
   name: sfservices.osb.servicefabrik.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.name
+    name: display-name
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: osb.servicefabrik.io
   names:
     kind: SFService
@@ -15,6 +22,7 @@ spec:
     plural: sfservices
     singular: sfservice
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: SFService is the Schema for the sfservices API

--- a/interoperator/controllers/schedulers/setup_schedulers.go
+++ b/interoperator/controllers/schedulers/setup_schedulers.go
@@ -19,10 +19,12 @@ limitations under the License.
 package schedulers
 
 import (
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfdefaultscheduler"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sflabelselectorscheduler"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfserviceinstancecounter"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfserviceinstanceupdater"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -38,6 +40,11 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		setupLog.Error(err, "unable to create sfserviceinstance-counter", "scheduler-helper", "SFServiceInstanceCounter")
 		return err
 	}
+
+	_ = mgr.GetFieldIndexer().IndexField(&osbv1alpha1.SFServiceInstance{}, "spec.planId", func(o runtime.Object) []string {
+		planID := o.(*osbv1alpha1.SFServiceInstance).Spec.PlanID
+		return []string{planID}
+	})
 
 	if err = (&sfserviceinstanceupdater.SFServiceInstanceUpdater{
 		Client: mgr.GetClient(),

--- a/interoperator/controllers/schedulers/setup_schedulers.go
+++ b/interoperator/controllers/schedulers/setup_schedulers.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfdefaultscheduler"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sflabelselectorscheduler"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfserviceinstancecounter"
-
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfserviceinstanceupdater"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -36,6 +36,14 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		Log:    ctrl.Log.WithName("scheduler-helper").WithName("sfserviceinstance-counter"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create sfserviceinstance-counter", "scheduler-helper", "SFServiceInstanceCounter")
+		return err
+	}
+
+	if err = (&sfserviceinstanceupdater.SFServiceInstanceUpdater{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("scheduler-helper").WithName("sfserviceinstance-updater"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create sfserviceinstance-updater", "scheduler-helper", "SFServiceInstanceUpdater")
 		return err
 	}
 

--- a/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller.go
+++ b/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2018 The Service Fabrik Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfserviceinstanceupdater
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/json"
+
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/config"
+	"github.com/go-logr/logr"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// SFServiceInstanceUpdater reconciles a SFServiceInstance object
+type SFServiceInstanceUpdater struct {
+	client.Client
+	Log logr.Logger
+}
+
+// Reconcile schedules the SFServiceInstance to one SFCluster and sets the ClusterID in
+// SFServiceInstance.Spec.ClusterID. It chooses the destination cluster based on clusterSelector
+// template provided in the plan.
+func (r *SFServiceInstanceUpdater) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	log := r.Log.WithValues("sfserviceinstance-updater", req.NamespacedName)
+
+	plan := &osbv1alpha1.SFPlan{}
+	err := r.Get(ctx, req.NamespacedName, plan)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if plan.Spec.AutoUpdateInstances == true {
+		currentSpecHash := calculateHash(plan.Spec)
+		if plan.Status.SpecHash == "" {
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				err1 := r.Get(ctx, req.NamespacedName, plan)
+				if err1 != nil {
+					return err1
+				}
+				currentSpecHash := calculateHash(plan.Spec)
+				plan.Status.SpecHash = currentSpecHash
+				return r.Status().Update(ctx, plan)
+			})
+			if err != nil {
+				log.Error(err, "Error occured while updating the sfplan spec-hash", "cluster-name", plan.GetName(), "current-hash", currentSpecHash)
+				return ctrl.Result{}, err
+			}
+		} else if plan.Status.SpecHash != currentSpecHash {
+			var instances osbv1alpha1.SFServiceInstanceList
+			err = r.List(context.Background(), &instances, client.MatchingField("spec.planId", plan.ObjectMeta.Name))
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			for _, instance := range instances.Items {
+				log.Info("Update required for : Instance with plan ID", "plan ID", plan.ObjectMeta.Name, "SFServiceInstance ID", instance.Name)
+				//Set state as update for instances
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					err1 := r.Get(ctx, types.NamespacedName{
+						Name:      instance.GetName(),
+						Namespace: instance.GetNamespace(),
+					}, &instance)
+					if err1 != nil {
+						return err1
+					}
+					instance.Status.State = "update"
+					return r.Update(ctx, &instance)
+				})
+				if err != nil {
+					log.Error(err, "Error occured while updating the instance", "instance-name", instance.GetName())
+					return ctrl.Result{}, err
+				}
+			}
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				err1 := r.Get(ctx, req.NamespacedName, plan)
+				if err1 != nil {
+					return err1
+				}
+				plan.Status.SpecHash = calculateHash(plan.Spec)
+				return r.Status().Update(ctx, plan)
+			})
+			if err != nil {
+				log.Error(err, "Error occured while updating the sfplan spec-hash", "cluster-name", plan.GetName(), "current-hash", currentSpecHash)
+				return ctrl.Result{}, err
+			}
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func calculateHash(v interface{}) string {
+	arrBytes := []byte{}
+	jsonBytes, _ := json.Marshal(v)
+	arrBytes = append(arrBytes, jsonBytes...)
+	hash := md5.Sum(arrBytes)
+	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+//SetupWithManager should be called if the controller is to be initialized.
+func (r *SFServiceInstanceUpdater) SetupWithManager(mgr ctrl.Manager) error {
+	cfgManager, err := config.New(mgr.GetConfig(), mgr.GetScheme(), mgr.GetRESTMapper())
+	if err != nil {
+		return err
+	}
+	interoperatorCfg := cfgManager.GetConfig()
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("scheduler_helper_sfserviceinstance_updater").
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: interoperatorCfg.InstanceWorkerCount,
+		}).
+		For(&osbv1alpha1.SFPlan{}).
+		Complete(r)
+}

--- a/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller_suit_test.go
+++ b/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller_suit_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Service Fabrik Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfserviceinstanceupdater
+
+import (
+	stdlog "log"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testLog logr.Logger
+
+func TestMain(m *testing.M) {
+	var err error
+	logf.SetLogger(zap.LoggerTo(ginkgo.GinkgoWriter, true))
+	testLog = ctrl.Log.WithName("test").WithName("sflabelselectorscheduler")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+	}
+
+	err = osbv1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	err = resourcev1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	if cfg, err = testEnv.Start(); err != nil {
+		stdlog.Fatal(err)
+	}
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	code := m.Run()
+	testEnv.Stop()
+	os.Exit(code)
+}
+
+// StartTestManager adds recFn
+func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}, *sync.WaitGroup) {
+	stop := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		g.Expect(mgr.Start(stop)).NotTo(gomega.HaveOccurred())
+	}()
+	return stop, wg
+}

--- a/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller_test.go
+++ b/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2018 The Service Fabrik Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfserviceinstanceupdater
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/schedulers/sfdefaultscheduler"
+
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/golang/mock/gomock"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlrun "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var c client.Client
+
+const timeout = time.Second * 5
+
+func TestReconcile(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	configMap := _getDummyConfigMap()
+
+	mgr, err := manager.New(cfg, manager.Options{
+		MetricsBindAddress: "0",
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	c, err = client.New(cfg, client.Options{
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	g.Expect(c.Create(context.TODO(), configMap)).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), configMap)
+
+	_ = mgr.GetFieldIndexer().IndexField(&osbv1alpha1.SFServiceInstance{}, "spec.planId", func(o runtime.Object) []string {
+		planID := o.(*osbv1alpha1.SFServiceInstance).Spec.PlanID
+		return []string{planID}
+	})
+
+	SFServiceInstanceUpdater := &SFServiceInstanceUpdater{
+		Client: mgr.GetClient(),
+		Log:    ctrlrun.Log.WithName("scheduler-helper").WithName("sfserviceinstance-updater"),
+	}
+	g.Expect(SFServiceInstanceUpdater.SetupWithManager(mgr)).NotTo(gomega.HaveOccurred())
+
+	g.Expect((&sfdefaultscheduler.SFDefaultScheduler{
+		Client: mgr.GetClient(),
+		Log:    ctrlrun.Log.WithName("schedulers").WithName("default"),
+	}).SetupWithManager(mgr)).NotTo(gomega.HaveOccurred())
+
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	plan1 := _getDummyPlan("provisioncontent")
+	g.Expect(c.Create(context.TODO(), plan1)).NotTo(gomega.HaveOccurred())
+
+	instance1 := _getDummySFServiceInstance("foo1", "plan-id")
+	g.Expect(c.Create(context.TODO(), instance1)).NotTo(gomega.HaveOccurred())
+
+	instance2 := _getDummySFServiceInstance("foo2", "plan-id")
+	g.Expect(c.Create(context.TODO(), instance2)).NotTo(gomega.HaveOccurred())
+
+	plan2 := &osbv1alpha1.SFPlan{}
+	g.Eventually(func() error {
+		err := c.Get(context.TODO(), types.NamespacedName{
+			Name:      "plan-id",
+			Namespace: "default",
+		}, plan2)
+		if err != nil {
+			return err
+		}
+		if plan2.Status.SpecHash == "" {
+			return errors.New("service plan specHash not updated")
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+
+	plan2.Spec.Templates[0].Content = "modifiedContent"
+	g.Expect(c.Update(context.TODO(), plan2)).NotTo(gomega.HaveOccurred())
+
+	plan3 := &osbv1alpha1.SFPlan{}
+	g.Eventually(func() error {
+		err := c.Get(context.TODO(), types.NamespacedName{
+			Name:      "plan-id",
+			Namespace: "default",
+		}, plan3)
+		if err != nil {
+			return err
+		}
+		previousResourceVersion, _ := strconv.Atoi(plan2.ResourceVersion)
+		currentResourceVersion, _ := strconv.Atoi(plan3.ResourceVersion)
+		if currentResourceVersion == (previousResourceVersion + 1) {
+			return errors.New("resource version is not updated")
+		}
+
+		err = c.Get(context.TODO(), types.NamespacedName{
+			Name:      "foo1",
+			Namespace: "default",
+		}, instance1)
+		if err != nil {
+			return err
+		}
+		instance1State := instance1.Status.State
+		if instance1State != "update" {
+			return errors.New("service intance 1 state is not update")
+		}
+		err = c.Get(context.TODO(), types.NamespacedName{
+			Name:      "foo2",
+			Namespace: "default",
+		}, instance2)
+		if err != nil {
+			return err
+		}
+		instance2State := instance2.Status.State
+		if instance2State != "update" {
+			return errors.New("service intance 2 state is not update")
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+	g.Expect(instance1.Status.State).To(gomega.Equal("update"))
+
+	g.Expect(c.Delete(context.TODO(), instance1)).NotTo(gomega.HaveOccurred())
+	g.Expect(c.Delete(context.TODO(), instance2)).NotTo(gomega.HaveOccurred())
+
+}
+
+func _getDummyConfigMap() *corev1.ConfigMap {
+	data := make(map[string]string)
+	config := "schedulerType: default"
+	data[constants.ConfigMapKey] = config
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.ConfigMapName,
+			Namespace: constants.DefaultServiceFabrikNamespace,
+		},
+		Data: data,
+	}
+}
+
+func _getDummySFServiceInstance(name string, planID string) *osbv1alpha1.SFServiceInstance {
+	return &osbv1alpha1.SFServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				"state": "in_queue",
+			},
+		},
+		Spec: osbv1alpha1.SFServiceInstanceSpec{
+			ServiceID:        "service-id",
+			PlanID:           planID,
+			RawContext:       nil,
+			OrganizationGUID: "organization-guid",
+			SpaceGUID:        "space-guid",
+			RawParameters:    nil,
+			PreviousValues:   nil,
+			//			ClusterID:        "1",
+		},
+		Status: osbv1alpha1.SFServiceInstanceStatus{
+			State: "in_queue",
+		},
+	}
+}
+
+func _getDummyPlan(provisionContent string) *osbv1alpha1.SFPlan {
+	templateSpec := []osbv1alpha1.TemplateSpec{
+		osbv1alpha1.TemplateSpec{
+			Action:  "provision",
+			Type:    "gotemplate",
+			Content: provisionContent,
+		},
+		osbv1alpha1.TemplateSpec{
+			Action:  "bind",
+			Type:    "gotemplate",
+			Content: "bindcontent",
+		},
+		osbv1alpha1.TemplateSpec{
+			Action:  "status",
+			Type:    "gotemplate",
+			Content: "statuscontent",
+		},
+		osbv1alpha1.TemplateSpec{
+			Action: "sources",
+			Type:   "gotemplate",
+			Content: `secret:
+  apiVersion: v1
+  kind: Secret
+  name: name
+  namespace: namespace`,
+		},
+	}
+	return &osbv1alpha1.SFPlan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "plan-id",
+			Namespace:  "default",
+			Labels:     map[string]string{"serviceId": "service-id", "planId": "plan-id"},
+			Finalizers: []string{"abc"},
+		},
+		Spec: osbv1alpha1.SFPlanSpec{
+			Name:                "plan-name",
+			ID:                  "plan-id",
+			Description:         "description",
+			Metadata:            nil,
+			Free:                false,
+			Bindable:            true,
+			PlanUpdatable:       true,
+			AutoUpdateInstances: true,
+			Schemas:             nil,
+			Templates:           templateSpec,
+			ServiceID:           "service-id",
+			RawContext:          nil,
+			Manager:             nil,
+		},
+	}
+}
+
+func _getSFClusterList(clusters ...resourcev1alpha1.SFCluster) *resourcev1alpha1.SFClusterList {
+	return &resourcev1alpha1.SFClusterList{
+		Items: clusters,
+	}
+}
+
+func _getKey(obj metav1.Object) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+}

--- a/interoperator/go.sum
+++ b/interoperator/go.sum
@@ -561,6 +561,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65/go.mod h1:5BIN
 k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655/go.mod h1:nL6pwRT8NgfF8TT68DBI8uEePRt89cSvoXUVqbkWHq4=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8 h1:Iieh/ZEgT3BWwbLD5qEKcY06jKuPEl6zC7gPSehoLw4=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
+k8s.io/apimachinery v0.17.1 h1:zUjS3szTxoUjTDYNvdFkYt2uMEXLcthcbp+7uZvWhYM=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20191016112112-5190913f932d/go.mod h1:7OqfAolfWxUM/jJ/HBLyE+cdaWFBUoo5Q5pHgJVj2ws=
 k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5 h1:8ZfMjkMBzcXEawLsYHg9lDM7aLEVso3NiVKfUTnN56A=
@@ -568,6 +569,7 @@ k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5/go.mod h1:sDl6WKSQkDM6zS1u
 k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90/go.mod h1:J69/JveO6XESwVgG53q3Uz5OSfgsv4uxpScmmyYOOlk=
 k8s.io/client-go v0.0.0-20191016111102-bec269661e48 h1:C2XVy2z0dV94q9hSSoCuTPp1KOG7IegvbdXuz9VGxoU=
 k8s.io/client-go v0.0.0-20191016111102-bec269661e48/go.mod h1:hrwktSwYGI4JK+TJA3dMaFyyvHVi/aLarVHpbs8bgCU=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269/go.mod h1:V5BD6M4CyaN5m+VthcclXWsVcT1Hu+glwa1bi3MIsyE=
 k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894 h1:NMYlxaF7rYQJk2E2IyrUhaX81zX24+dmoZdkPw0gJqI=
 k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894/go.mod h1:mJUgkl06XV4kstAnLHAIzJPVCOzVR+ZcfPIv4fUsFCY=

--- a/interoperator/main.go
+++ b/interoperator/main.go
@@ -76,6 +76,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	_ = mgr.GetFieldIndexer().IndexField(&osbv1alpha1.SFServiceInstance{}, "spec.planId", func(o runtime.Object) []string {
+		planID := o.(*osbv1alpha1.SFServiceInstance).Spec.PlanID
+		return []string{planID}
+	})
+
 	if err = provisioners.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create provisioners")
 		os.Exit(1)

--- a/interoperator/main.go
+++ b/interoperator/main.go
@@ -76,11 +76,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	_ = mgr.GetFieldIndexer().IndexField(&osbv1alpha1.SFServiceInstance{}, "spec.planId", func(o runtime.Object) []string {
-		planID := o.(*osbv1alpha1.SFServiceInstance).Spec.PlanID
-		return []string{planID}
-	})
-
 	if err = provisioners.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create provisioners")
 		os.Exit(1)


### PR DESCRIPTION
* Added a flag in SFPlan for setting autoUpdatable as true if one wants to mass update serviceinstances when sfplan changes.

* Added a property called specHash in SFPlan to check if the spec change is addressed by the sfserviceinstanceupdater controller.

* Added a field indexer in the main.go to index sfserviceinstances based on spec.planID field.

* Added SFServiceInstanceUpdater controller as part of scheduler. This controller watches on the SFPlans and for any change in spec, it sets the status of all the sfserviceinstances to "update", if the autoUpdateable feature of that plan is turned on.

* Added display-name as additional printer column for SFPlan and SFService.