### PR TITLE
Ensure Interoperator pod gets re-created during helm upgrade

### DIFF
--- a/helm-charts/interoperator/templates/broker.yaml
+++ b/helm-charts/interoperator/templates/broker.yaml
@@ -58,6 +58,8 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-broker
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/helm-charts/interoperator/templates/multiclusterdeployer.yaml
+++ b/helm-charts/interoperator/templates/multiclusterdeployer.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-controller-manager
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
       - args:

--- a/helm-charts/interoperator/templates/scheduler.yaml
+++ b/helm-charts/interoperator/templates/scheduler.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-controller-manager
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
       - args:


### PR DESCRIPTION
### Context

When Helm deploys interoperator, provisioner replica set is set to zero. Then the scheduler schedules the provisioner based on the SFClusters. If the same cluster is added as the SFCluster, then provisioner is scheduled with replica set as 1 in the same cluster.

        While the provisioner is running, if another helm upgrade is done which does not have any delta change, provisioner replicaset will be 0 again and since scheduler is not restarted, it will not bring up the replicaset count. 

          With helm2, it was possible to use an option **--recreate-pods** to re-create pods forcefully. **The --recreate-pods flag doesn’t exist anymore in Helm3**. This was marked as [deprecated](https://github.com/helm/helm-www/pull/286) in Helm 2 and the documentation has been updated to show how to do this properly with Helm 3.

h3. Solution

If it is needed to always roll the deployment, one can use a similar annotation step as above, instead replacing with a random string so it always changes and causes the deployment to roll:

```
kind: Deployment
spec:
  template:
    metadata:
      annotations:
        rollme: {{ randAlphaNum 5 | quote }}
```