### PR TITLE
Making namespace based separation configurable

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -161,7 +161,7 @@ defaults: &defaults
   ##############################
   apiserver:
     # isServiceDefinitionAvailableOnApiserver: false
-    # enable_namespace: false
+    # enable_namespaced_separation: false
     ip: '10.244.14.252'
     port: 8443
     encryption:

--- a/helm-charts/interoperator/conf/settings.yaml
+++ b/helm-charts/interoperator/conf/settings.yaml
@@ -44,7 +44,8 @@ defaults: &defaults
   apiserver:
     getConfigInCluster: true
     isServiceDefinitionAvailableOnApiserver: true
-    enable_namespace: true
+    enable_namespaced_separation: {{ .Values.broker.enable_namespaced_separation }}
+    services_namespace: {{ .Values.broker.services_namespace }}
     crds:
       "osb.servicefabrik.io_v1alpha1_sfserviceinstances.yaml": {{ (.Files.Get "conf/sfserviceinstance.yaml") | b64enc }}
       "osb.servicefabrik.io_v1alpha1_sfservicebindings.yaml": {{ (.Files.Get "conf/sfservicebinding.yaml") | b64enc }}

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -13,6 +13,8 @@ broker:
   port: 9293
   username: broker
   password: secret
+  enable_namespaced_separation: true
+  services_namespace: "services"
   quota:
     enabled: false
     oauthDomain: https://myauth-domain.com


### PR DESCRIPTION
SF/Interoperator currently creates CRs either all in default namespaces, or creates namespaces for each service instance and puts the CRs there. With this change, we also enable a configurable namespace instead of default namespace.

* If the broker has `apiserver. enable_namespaced_separation` flag as true, it creates separate namespace, else if it has `apiserver.services_namespace` set, it takes that as the namespace name. otherwise, it goes to the default namespace(BOSH based usecase).

* Helm chart now supports both these values, `enable_namespaced_separation` which is by default true and `services_namespace` which is not used by default.