### PR TITLE
Converting logger statement level to debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,43 +5,26 @@
 **/package-lock.json
 **/node_modules
 **/coverage
-
-**/node_modules
-**/coverage
-**/package-lock.json
 **/.env
-**/lerna-debug.log
 **/npm-debug.log
 **/.idea
+**/vendor
+**/logs
 **/store/sessions
 **/config/**/settings.*.yml
-
 # Ignore documentation
 **/jsdoc
-
 # Ignore all logfiles and tempfiles.
 **/*.log
 /tmp
-**/store/sessions
 */*/kubeconfig.yaml
-
-# Ignore developer's settings files
-broker/config/settings.*.yml
-
 # Ignore all files starting with "my"
 my*
-
 # Ignore coverage results
 broker/coverage
 .vscode/
-
-
 #ingoring files created during unit tests
 broker/lib/fabrik/actions/js/ReserveIps.js
 broker/lib/fabrik/actions/sh/
 broker/applications/deployment_hooks/lib/actions/js/ReserveIps.js
 broker/applications/deployment_hooks/lib/actions/sh/
-
-interoperator/vendor
-webhooks/vendor
-webhooks/logs

--- a/broker/applications/operators/bosh-operator/DirectorService.js
+++ b/broker/applications/operators/bosh-operator/DirectorService.js
@@ -519,7 +519,7 @@ class DirectorService extends BaseDirectorService {
       })
       .then(() => this.executeActions(serviceLifeCycle, actionContext))
       .then(preDeployResponse => this.generateManifest(deploymentName, opts, preDeployResponse, preUpdateAgentResponse))
-      .tap(manifest => logger.info('+-> Deployment manifest:\n', manifest))
+      .tap(manifest => logger.debug('+-> Deployment manifest:\n', manifest))
       .then(manifest => this.director.createOrUpdateDeployment(action, manifest, args, scheduled))
       .tap(taskId => logger.info(`+-> Scheduled ${action} deployment task '${taskId}'`))
       .catch(err => {

--- a/broker/core/utils/src/HttpClient.js
+++ b/broker/core/utils/src/HttpClient.js
@@ -144,35 +144,30 @@ class HttpClient {
         switch (res.statusCode) {
           case CONST.HTTP_STATUS_CODE.BAD_REQUEST:
             logger.warn(message, {
-              request: options,
               response: result
             });
             err = new BadRequest(message);
             break;
           case CONST.HTTP_STATUS_CODE.NOT_FOUND:
             logger.info(message, {
-              request: options,
               response: result
             });
             err = new NotFound(message);
             break;
           case CONST.HTTP_STATUS_CODE.CONFLICT:
             logger.info(message, {
-              request: options,
               response: result
             });
             err = new Conflict(message);
             break;
           case CONST.HTTP_STATUS_CODE.UNPROCESSABLE_ENTITY:
             logger.info(message, {
-              request: options,
               response: result
             });
             err = new UnprocessableEntity(message);
             break;
           default:
             logger.error(message, {
-              request: options,
               response: result
             });
             err = new InternalServerError(message);


### PR DESCRIPTION
 1. Currently the service fabrik logs on the info level the generated manifest file, which contains passwords into a log entry. This is problematic.

1. In case of logging of an error requests, if a http request fails the service fabrik currently logs the whole error object, which contains the request including authentication. This should be avoided/filtered.