### PR TITLE
Support multiple Interoperator Per Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,23 @@ Please create sfcluster CRs and add reference to kubeconfig. In the example belo
 
 For multi-cluster support, all corresponding sfcluster CRs need to be created and their kubeconfig needs to be supplied in the corresponding secret.
 
-Please note that sfservice and sfplans need to be deployed in the same namespace where SF is deployed (default is `interoperator`).
+Please note that `sfservice`, `sfplans` and `sfcluster` (along with the `secret` it refers to) need to be deployed in the same namespace where SF is deployed (default is `interoperator`).
 
 To understand the CRs and their structures, please check the Architecture. The different templates are described in [interoperator-templates](https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/master/docs/Interoperator-templates.md)
 
+### Deploying multiple interoperator in the same cluster
+
+Multiple instances of interoperator can be deployed on a single cluster. But each instance must be deployed in a separate namespace. Only one instance of interoperator can be deployed in one namespace. The the custom resources like `sfservice`, `sfplans` and `sfcluster` (along with the `secret` it refers to) related on deployment of interoperator must be created in the namespace where interoperator is deployed. 
+
+Deploy the first instance of interoperator on a cluster 
+```shell
+helm install --set cluster.host=sf.ingress.< clusterdomain > --set installCRDS=true --name interoperator --namespace interoperator [--version <helm chart version>] sf-charts/interoperator
+```
+
+All the subsequent installations must use `installCRDS=false` flag during the installation
+```shell
+helm install --set cluster.host=sf.ingress.< clusterdomain > --set installCRDS=false --name interoperator --namespace interoperator [--version <helm chart version>] sf-charts/interoperator
+```
 
 ### Register with the platform
 

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -106,6 +106,11 @@ class ServiceBrokerApiController extends FabrikBaseController {
       res.status(CONST.HTTP_STATUS_CODE.CONFLICT).send({});
     }
 
+    let namespaceLabel = {};
+    if (_.get(config, 'sf_namespace')) {
+      namespaceLabel[CONST.APISERVER.NAMESPACE_LABEL_KEY] = _.get(config, 'sf_namespace');
+    }
+
     req.operation_type = CONST.OPERATION_TYPE.CREATE;
     return Promise.try(() => eventmesh.apiServerClient.createNamespace(eventmesh.apiServerClient.getNamespaceId(req.params.instance_id)))
       .then(() => eventmesh.apiServerClient.createOSBResource({
@@ -118,7 +123,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         labels: _.merge({
           plan_id: planId,
           service_id: serviceId
-        }, contextLabels),
+        }, contextLabels, namespaceLabel),
         spec: params,
         status: {
           state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE
@@ -375,6 +380,11 @@ class ServiceBrokerApiController extends FabrikBaseController {
       res.status(CONST.HTTP_STATUS_CODE.CONFLICT).send({});
     }
 
+    let namespaceLabel = {};
+    if (_.get(config, 'sf_namespace')) {
+      namespaceLabel[CONST.APISERVER.NAMESPACE_LABEL_KEY] = _.get(config, 'sf_namespace');
+    }
+
     return Promise
       .try(() => {
         return eventmesh.apiServerClient.createOSBResource({
@@ -384,9 +394,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
           metadata: {
             finalizers: [`${CONST.APISERVER.FINALIZERS.BROKER}`]
           },
-          labels: {
+          labels: _.merge({
             instance_guid: req.params.instance_id
-          },
+          }, namespaceLabel),
           spec: params,
           status: {
             state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE

--- a/broker/core/app-config/src/index.js
+++ b/broker/core/app-config/src/index.js
@@ -62,6 +62,10 @@ if (process.env.BROKER_USERNAME) {
 if (process.env.BROKER_PASSWORD) {
   config.password = process.env.BROKER_PASSWORD;
 }
+if (process.env.POD_NAMESPACE) {
+  // Not set when it is Broker Bosh Deployment
+  config.sf_namespace = process.env.POD_NAMESPACE;
+}
 
 function updateLogFileConfig(logPath) {
   const logSuffix = `-worker-${process.env.worker}.log`;

--- a/broker/core/utils/src/commonVariables.js
+++ b/broker/core/utils/src/commonVariables.js
@@ -324,6 +324,7 @@ module.exports = Object.freeze({
     POLLER_WATCHER_REFRESH_INTERVAL: 120000, // // in ms should be greater than DIRECTOR_RESOURCE_POLLER_INTERVAL
     WATCH_TIMEOUT: 600, // in sec (10 minutes)
     VERSION: '1.10',
+    NAMESPACE_LABEL_KEY: 'OWNER_INTEROPERATOR_NAMESPACE',
     DEFAULT_NAMESPACE: 'default',
     NAMESPACE_OBJECT: 'Namespace',
     NAMESPACE_API_VERSION: 'v1',

--- a/broker/data-access-layer/eventmesh/src/utils/index.js
+++ b/broker/data-access-layer/eventmesh/src/utils/index.js
@@ -14,11 +14,16 @@ const {
 } = require('@sf/common-utils');
 
 function getAllServices() {
-  return apiServerClient.getResources({
+  let namespaceOpts = {};
+  if (_.get(config, 'sf_namespace')) {
+    namespaceOpts.namespaceId = _.get(config, 'sf_namespace');
+  } else {
+    namespaceOpts.allNamespaces = true;
+  }
+  return apiServerClient.getResources(_.merge({
     resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
-    resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES,
-    allNamespaces: true
-  })
+    resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES
+  },namespaceOpts))
     .then(serviceList => {
       let services = [];
       _.forEach(serviceList, service => {
@@ -29,14 +34,19 @@ function getAllServices() {
 }
 
 function getAllPlansForService(serviceId) {
-  return apiServerClient.getResources({
+  let namespaceOpts = {};
+  if (_.get(config, 'sf_namespace')) {
+    namespaceOpts.namespaceId = _.get(config, 'sf_namespace');
+  } else {
+    namespaceOpts.allNamespaces = true;
+  }
+  return apiServerClient.getResources(_.merge({
     resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
     resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS,
     query: {
       labelSelector: `serviceId=${serviceId}`
-    },
-    allNamespaces: true
-  })
+    }
+  }, namespaceOpts))
     .then(planList => {
       let plans = [];
       _.forEach(planList, plan => {

--- a/broker/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
+++ b/broker/test/test_broker/acceptance/service-broker-api.instances.docker.spec.js
@@ -661,7 +661,7 @@ describe('service-broker-api', function () {
 
           mocks.apiServerEventMesh.nockCreateResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, testPayload, 1);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
-          mocks.apiServerEventMesh.nockGetSecret(binding_id, CONST.APISERVER.DEFAULT_NAMESPACE, {
+          mocks.apiServerEventMesh.nockGetSecret(binding_id, _.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE), {
             data: {
               response: encodeBase64({ credentials: secretData })
             }

--- a/broker/test/test_broker/eventmesh.ApiServerClient.spec.js
+++ b/broker/test/test_broker/eventmesh.ApiServerClient.spec.js
@@ -121,19 +121,19 @@ function nockGetResource(resourceGroup, resourceType, id, namespaceId, response,
 
 function nockCreateConfigMap(response, expectedStatusCode, payload) {
   nock(apiServerHost)
-    .post(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.DEFAULT_NAMESPACE}/configmaps`, JSON.stringify(payload))
+    .post(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${_.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE)}/configmaps`, JSON.stringify(payload))
     .reply(expectedStatusCode || 200, response);
 }
 
 function nockGetConfigMap(response, expectedStatusCode) {
   nock(apiServerHost)
-    .get(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.DEFAULT_NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`)
+    .get(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${_.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE)}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`)
     .reply(expectedStatusCode || 200, response);
 }
 
 function nockUpdateConfigMap(response, expectedStatusCode, payload) {
   nock(apiServerHost)
-    .patch(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.DEFAULT_NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`, JSON.stringify(payload))
+    .patch(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${_.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE)}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`, JSON.stringify(payload))
     .reply(expectedStatusCode || 200, response);
 }
 
@@ -972,7 +972,7 @@ describe('eventmesh', () => {
             });
             expect(res.body.kind).to.eql(CONST.APISERVER.CONFIG_MAP.RESOURCE_KIND);
             expect(res.body.metadata.resourceVersion).to.eql('370255');
-            expect(res.body.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.DEFAULT_NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
+            expect(res.body.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${_.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE)}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
             verify();
           });
       });
@@ -1011,7 +1011,7 @@ describe('eventmesh', () => {
             });
             expect(res.kind).to.eql(CONST.APISERVER.CONFIG_MAP.RESOURCE_KIND);
             expect(res.metadata.resourceVersion).to.eql('370255');
-            expect(res.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.DEFAULT_NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
+            expect(res.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${_.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE)}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
             verify();
           });
       });
@@ -1070,7 +1070,7 @@ describe('eventmesh', () => {
             });
             expect(res.body.kind).to.eql(CONST.APISERVER.CONFIG_MAP.RESOURCE_KIND);
             expect(res.body.metadata.resourceVersion).to.eql('370255');
-            expect(res.body.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.DEFAULT_NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
+            expect(res.body.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${_.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE)}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
             verify();
           });
       });
@@ -1100,7 +1100,7 @@ describe('eventmesh', () => {
             });
             expect(res.body.kind).to.eql(CONST.APISERVER.CONFIG_MAP.RESOURCE_KIND);
             expect(res.body.metadata.resourceVersion).to.eql('370255');
-            expect(res.body.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.DEFAULT_NAMESPACE}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
+            expect(res.body.metadata.selfLink).to.eql(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${_.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE)}/configmaps/${CONST.CONFIG.RESOURCE_NAME}`);
             verify();
           });
       });

--- a/broker/test/test_broker/mocks/apiServerEventMesh.js
+++ b/broker/test/test_broker/mocks/apiServerEventMesh.js
@@ -109,7 +109,7 @@ function nockCreateResource(resourceGroup, resourceType, response, times, verifi
 
 function nockGetConfigMap(expectedStatusCode, enabled) {
   nock(apiServerHost)
-    .get(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${CONST.APISERVER.DEFAULT_NAMESPACE}/configmaps`)
+    .get(`/api/${CONST.APISERVER.CONFIG_MAP.API_VERSION}/namespaces/${_.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE)}/configmaps`)
     .reply(expectedStatusCode || 200, enabled ? expectedGetConfigMapResponseEnabled : expectedGetConfigMapResponseDisabled);
 }
 

--- a/helm-charts/interoperator/templates/provisioner.yaml
+++ b/helm-charts/interoperator/templates/provisioner.yaml
@@ -91,7 +91,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: provisioner-clusterrolebinding
+  name: {{ .Release.Name }}-provisioner-clusterrolebinding
 subjects:
   - kind: ServiceAccount
     # Reference to upper's `metadata.name`

--- a/helm-charts/interoperator/templates/sfcluster.yaml
+++ b/helm-charts/interoperator/templates/sfcluster.yaml
@@ -1,3 +1,4 @@
-
 ---
+{{- if .Values.installCRDS }}
 {{- .Files.Get "conf/sfcluster.yaml" }}
+{{- end }}

--- a/helm-charts/interoperator/templates/sfplan.yaml
+++ b/helm-charts/interoperator/templates/sfplan.yaml
@@ -1,3 +1,4 @@
-
 ---
+{{- if .Values.installCRDS }}
 {{- .Files.Get "conf/sfplan.yaml" }}
+{{- end }}

--- a/helm-charts/interoperator/templates/sfservice.yaml
+++ b/helm-charts/interoperator/templates/sfservice.yaml
@@ -1,3 +1,4 @@
-
 ---
+{{- if .Values.installCRDS }}
 {{- .Files.Get "conf/sfservice.yaml" }}
+{{- end }}

--- a/helm-charts/interoperator/templates/sfservicebinding.yaml
+++ b/helm-charts/interoperator/templates/sfservicebinding.yaml
@@ -1,3 +1,4 @@
-
 ---
+{{- if .Values.installCRDS }}
 {{- .Files.Get "conf/sfservicebinding.yaml" }}
+{{- end }}

--- a/helm-charts/interoperator/templates/sfserviceinstance.yaml
+++ b/helm-charts/interoperator/templates/sfserviceinstance.yaml
@@ -1,3 +1,4 @@
-
 ---
+{{- if .Values.installCRDS }}
 {{- .Files.Get "conf/sfserviceinstance.yaml" }}
+{{- end }}

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
+installCRDS: true
 
 cluster:
   host: sf.ingress.sf21-intop.interop.shoot.canary.k8s-hana.ondemand.com

--- a/interoperator/api/osb/v1alpha1/sfplan_types_test.go
+++ b/interoperator/api/osb/v1alpha1/sfplan_types_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -57,7 +58,7 @@ func TestStorageSfPlan(t *testing.T) {
 	}
 	key := types.NamespacedName{
 		Name:      "plan-id",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 	parameters := `{
 		"$schema": "http://json-schema.org/draft-06/schema#",
@@ -90,7 +91,7 @@ func TestStorageSfPlan(t *testing.T) {
 	created := &SFPlan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "plan-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: SFPlanSpec{
 			Name:          "plan-name",
@@ -135,7 +136,7 @@ func TestStorageSfPlan(t *testing.T) {
 	// Test listing
 	planList := &SFPlanList{}
 	options := &kubernetes.ListOptions{
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 	labels := make(kubernetes.MatchingLabels)
 	labels["hello"] = "world"

--- a/interoperator/api/osb/v1alpha1/sfservice_types_test.go
+++ b/interoperator/api/osb/v1alpha1/sfservice_types_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -30,7 +31,7 @@ import (
 func TestStorageSFService(t *testing.T) {
 	key := types.NamespacedName{
 		Name:      "foo",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 	parameters := `{
 		"foo": "bar",
@@ -44,7 +45,7 @@ func TestStorageSFService(t *testing.T) {
 	created := &SFService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: SFServiceSpec{
 			Name:                "service-name",
@@ -87,7 +88,7 @@ func TestStorageSFService(t *testing.T) {
 	// Test listing
 	serviceList := &SFServiceList{}
 	options := &kubernetes.ListOptions{
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 	labels := make(kubernetes.MatchingLabels)
 	labels["hello"] = "world"

--- a/interoperator/api/osb/v1alpha1/sfservicebinding_types_test.go
+++ b/interoperator/api/osb/v1alpha1/sfservicebinding_types_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -30,7 +31,7 @@ import (
 func TestStorageSFServiceBinding(t *testing.T) {
 	key := types.NamespacedName{
 		Name:      "foo",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 	parameters := `{
 		"foo": "bar",
@@ -44,7 +45,7 @@ func TestStorageSFServiceBinding(t *testing.T) {
 	created := &SFServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: SFServiceBindingSpec{
 			ID:                "binding-id",
@@ -92,7 +93,7 @@ func TestStorageSFServiceBinding(t *testing.T) {
 	// Test listing
 	bindingList := &SFServiceBindingList{}
 	options := &kubernetes.ListOptions{
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 	labels := make(kubernetes.MatchingLabels)
 	labels["hello"] = "world"

--- a/interoperator/api/osb/v1alpha1/sfserviceinstance_types_test.go
+++ b/interoperator/api/osb/v1alpha1/sfserviceinstance_types_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -30,7 +31,7 @@ import (
 func TestStorageServiceInstance(t *testing.T) {
 	key := types.NamespacedName{
 		Name:      "foo",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 	parameters := `{
 		"foo": "bar",
@@ -53,7 +54,7 @@ func TestStorageServiceInstance(t *testing.T) {
 	created := &SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: spec,
 		Status: SFServiceInstanceStatus{
@@ -67,7 +68,7 @@ func TestStorageServiceInstance(t *testing.T) {
 					APIVersion: "v1alpha1",
 					Kind:       "Director",
 					Name:       "dddd",
-					Namespace:  "default",
+					Namespace:  constants.InteroperatorNamespace,
 				},
 			},
 		},
@@ -95,7 +96,7 @@ func TestStorageServiceInstance(t *testing.T) {
 	// Test listing
 	instanceList := &SFServiceInstanceList{}
 	options := &kubernetes.ListOptions{
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 	labels := make(kubernetes.MatchingLabels)
 	labels["hello"] = "world"

--- a/interoperator/api/resource/v1alpha1/sfcluster_types_test.go
+++ b/interoperator/api/resource/v1alpha1/sfcluster_types_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,12 +33,12 @@ import (
 func TestStorageSFCluster(t *testing.T) {
 	key := types.NamespacedName{
 		Name:      "foo",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 	created := &SFCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		}}
 	g := gomega.NewGomegaWithT(t)
 
@@ -147,7 +148,7 @@ func _getDummyCluster() *SFCluster {
 	return &SFCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: SFClusterSpec{
 			SecretRef: "cluster-id-secret",

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/provisioner"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -493,7 +494,8 @@ func (r *ReconcileProvisioner) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: interoperatorCfg.ProvisionerWorkerCount,
 		}).
-		For(&resourcev1alpha1.SFCluster{})
+		For(&resourcev1alpha1.SFCluster{}).
+		WithEventFilter(watches.NamespaceFilter())
 
 	return builder.Complete(r)
 }

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller_test.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller_test.go
@@ -25,6 +25,7 @@ import (
 	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/provisioner/mock_provisioner"
 	mock_clusterRegistry "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry/mock_registry"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 
 	"github.com/golang/mock/gomock"
 	"github.com/onsi/gomega"
@@ -42,7 +43,7 @@ import (
 
 var c client.Client
 
-var expectedRequest = ctrlrun.Request{NamespacedName: types.NamespacedName{Name: "1", Namespace: "default"}}
+var expectedRequest = ctrlrun.Request{NamespacedName: types.NamespacedName{Name: "1", Namespace: constants.InteroperatorNamespace}}
 
 const timeout = time.Second * 5
 
@@ -51,7 +52,7 @@ const timeout = time.Second * 5
 var clusterInstance = &resourcev1alpha1.SFCluster{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "2",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	},
 	Spec: resourcev1alpha1.SFClusterSpec{
 		SecretRef: "my-secret",
@@ -61,14 +62,14 @@ var clusterInstance = &resourcev1alpha1.SFCluster{
 var clusterSecret = &corev1.Secret{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "my-secret",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	},
 }
 
 var deploymentInstance = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "provisioner",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	},
 	Spec: appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{},
@@ -390,7 +391,7 @@ func TestReconcileProvisioner_reconcileSfClusterCrd(t *testing.T) {
 
 	// Delete sfcluster from target cluster
 	sfTargetCluster := &resourcev1alpha1.SFCluster{}
-	err = c2.Get(context.TODO(), types.NamespacedName{Name: "2", Namespace: "default"}, sfTargetCluster)
+	err = c2.Get(context.TODO(), types.NamespacedName{Name: "2", Namespace: constants.InteroperatorNamespace}, sfTargetCluster)
 	if err == nil {
 		c2.Delete(context.TODO(), sfTargetCluster)
 	}
@@ -443,7 +444,7 @@ func TestReconcileProvisioner_reconcileSfClusterCrd(t *testing.T) {
 		})
 		sfTargetCluster := &resourcev1alpha1.SFCluster{}
 		g.Eventually(func() error {
-			return c2.Get(context.TODO(), types.NamespacedName{Name: "2", Namespace: "default"}, sfTargetCluster)
+			return c2.Get(context.TODO(), types.NamespacedName{Name: "2", Namespace: constants.InteroperatorNamespace}, sfTargetCluster)
 		}, timeout).Should(gomega.Succeed())
 	}
 }
@@ -470,7 +471,7 @@ func TestReconcileProvisioner_reconcileSfClusterSecret(t *testing.T) {
 
 	// Delete sfcluster from target cluster
 	clusterInstanceSecret := &corev1.Secret{}
-	err = c2.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, clusterInstanceSecret)
+	err = c2.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: constants.InteroperatorNamespace}, clusterInstanceSecret)
 	if err == nil {
 		c2.Delete(context.TODO(), clusterInstanceSecret)
 	}
@@ -504,7 +505,7 @@ func TestReconcileProvisioner_reconcileSfClusterSecret(t *testing.T) {
 		{
 			name: "Create if Secret not found",
 			args: args{
-				namespace:    "default",
+				namespace:    constants.InteroperatorNamespace,
 				secretName:   "my-secret",
 				clusterID:    "2",
 				targetClient: c2,
@@ -514,7 +515,7 @@ func TestReconcileProvisioner_reconcileSfClusterSecret(t *testing.T) {
 		{
 			name: "Update if secret already exists",
 			args: args{
-				namespace:    "default",
+				namespace:    constants.InteroperatorNamespace,
 				secretName:   "my-secret",
 				clusterID:    "2",
 				targetClient: c2,
@@ -530,7 +531,7 @@ func TestReconcileProvisioner_reconcileSfClusterSecret(t *testing.T) {
 		})
 		clusterInstanceSecret := &corev1.Secret{}
 		g.Eventually(func() error {
-			return c2.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, clusterInstanceSecret)
+			return c2.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: constants.InteroperatorNamespace}, clusterInstanceSecret)
 		}, timeout).Should(gomega.Succeed())
 	}
 }
@@ -558,7 +559,7 @@ func TestReconcileProvisioner_reconcileDeployment(t *testing.T) {
 	// Delete provisioner deployment in target cluster if present
 
 	targetProvisionerInstance := &appsv1.Deployment{}
-	err = c2.Get(context.TODO(), types.NamespacedName{Name: "provisioner", Namespace: "default"}, targetProvisionerInstance)
+	err = c2.Get(context.TODO(), types.NamespacedName{Name: "provisioner", Namespace: constants.InteroperatorNamespace}, targetProvisionerInstance)
 	if err == nil {
 		c2.Delete(context.TODO(), targetProvisionerInstance)
 	}
@@ -619,7 +620,7 @@ func TestReconcileProvisioner_reconcileDeployment(t *testing.T) {
 		})
 		targetProvisionerInstance := &appsv1.Deployment{}
 		g.Eventually(func() error {
-			return c2.Get(context.TODO(), types.NamespacedName{Name: "provisioner", Namespace: "default"}, targetProvisionerInstance)
+			return c2.Get(context.TODO(), types.NamespacedName{Name: "provisioner", Namespace: constants.InteroperatorNamespace}, targetProvisionerInstance)
 		}, timeout).Should(gomega.Succeed())
 	}
 }
@@ -647,7 +648,7 @@ func TestReconcileProvisioner_reconcileClusterRoleBinding(t *testing.T) {
 	// Delete clusterrolebinding in target cluster if present
 
 	targetClusterRoleBinding := &v1.ClusterRoleBinding{}
-	err = c2.Get(context.TODO(), types.NamespacedName{Name: "provisioner-clusterrolebinding", Namespace: "default"}, targetClusterRoleBinding)
+	err = c2.Get(context.TODO(), types.NamespacedName{Name: "provisioner-clusterrolebinding", Namespace: constants.InteroperatorNamespace}, targetClusterRoleBinding)
 	if err == nil {
 		c2.Delete(context.TODO(), targetClusterRoleBinding)
 	}
@@ -676,7 +677,7 @@ func TestReconcileProvisioner_reconcileClusterRoleBinding(t *testing.T) {
 		{
 			name: "Create if clusterrolebinding does not exists",
 			args: args{
-				namespace:    "default",
+				namespace:    constants.InteroperatorNamespace,
 				clusterID:    "2",
 				targetClient: c2,
 			},
@@ -685,7 +686,7 @@ func TestReconcileProvisioner_reconcileClusterRoleBinding(t *testing.T) {
 		{
 			name: "Update if clusterrolebinding already exists",
 			args: args{
-				namespace:    "default",
+				namespace:    constants.InteroperatorNamespace,
 				clusterID:    "2",
 				targetClient: c2,
 			},
@@ -700,7 +701,7 @@ func TestReconcileProvisioner_reconcileClusterRoleBinding(t *testing.T) {
 		})
 		targetClusterRoleBinding := &v1.ClusterRoleBinding{}
 		g.Eventually(func() error {
-			return c2.Get(context.TODO(), types.NamespacedName{Name: "provisioner-clusterrolebinding", Namespace: "default"}, targetClusterRoleBinding)
+			return c2.Get(context.TODO(), types.NamespacedName{Name: "provisioner-clusterrolebinding", Namespace: constants.InteroperatorNamespace}, targetClusterRoleBinding)
 		}, timeout).Should(gomega.Succeed())
 	}
 }

--- a/interoperator/controllers/multiclusterdeploy/sfservicebindingreplicator/sfservicebindingreplicator_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/sfservicebindingreplicator/sfservicebindingreplicator_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/multiclusterdeploy/watchmanager"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/utils"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"github.com/go-logr/logr"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -231,7 +231,7 @@ func (r *BindingReplicator) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 				for k, v := range replicaSecret.Data {
 					bindingSecret.Data[k] = v
 				}
-				if err = controllerutil.SetControllerReference(binding, bindingSecret, r.scheme); err != nil {
+				if err = utils.SetOwnerReference(binding, bindingSecret, r.scheme); err != nil {
 					log.Error(err, "failed to set owner reference for secret", "binding", bindingID)
 					return ctrl.Result{}, err
 				}

--- a/interoperator/controllers/multiclusterdeploy/sfservicebindingreplicator/sfservicebindingreplicator_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/sfservicebindingreplicator/sfservicebindingreplicator_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/multiclusterdeploy/watchmanager"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -76,7 +77,7 @@ func (r *BindingReplicator) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
-	if clusterID == constants.DefaultMasterClusterID {
+	if clusterID == constants.OwnClusterID {
 		// Target cluster is mastercluster itself
 		// Replication not needed
 		log.Info("Target cluster is master cluster itself, replication not needed..")
@@ -344,7 +345,8 @@ func (r *BindingReplicator) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		Named("mcd_replicator_binding").
 		For(&osbv1alpha1.SFServiceBinding{}).
-		Watches(&source.Channel{Source: watchEvents}, &handler.EnqueueRequestForObject{})
+		Watches(&source.Channel{Source: watchEvents}, &handler.EnqueueRequestForObject{}).
+		WithEventFilter(watches.NamespaceLabelFilter())
 
 	return builder.Complete(r)
 }

--- a/interoperator/controllers/multiclusterdeploy/sfservicebindingreplicator/sfservicebindingreplicator_controller_test.go
+++ b/interoperator/controllers/multiclusterdeploy/sfservicebindingreplicator/sfservicebindingreplicator_controller_test.go
@@ -42,9 +42,9 @@ import (
 var c, c2 client.Client
 var secretID = "sf-binding-id"
 var bindingID = "binding-id"
-var namespace = "default"
-var bindingKey = types.NamespacedName{Name: bindingID, Namespace: "default"}
-var secretKey = types.NamespacedName{Name: secretID, Namespace: "default"}
+var namespace = constants.InteroperatorNamespace
+var bindingKey = types.NamespacedName{Name: bindingID, Namespace: constants.InteroperatorNamespace}
+var secretKey = types.NamespacedName{Name: secretID, Namespace: constants.InteroperatorNamespace}
 var serviceInstance *osbv1alpha1.SFServiceInstance
 var binding, replicaBinding *osbv1alpha1.SFServiceBinding
 
@@ -52,7 +52,7 @@ const timeout = time.Second * 5
 
 var objectMetaInstance = metav1.ObjectMeta{
 	Name:      "instance-id",
-	Namespace: "default",
+	Namespace: constants.InteroperatorNamespace,
 	Labels: map[string]string{
 		"state": "in_queue",
 	},
@@ -71,7 +71,7 @@ var specInstance = osbv1alpha1.SFServiceInstanceSpec{
 
 var objectMetaBinding = metav1.ObjectMeta{
 	Name:      "binding-id",
-	Namespace: "default",
+	Namespace: constants.InteroperatorNamespace,
 	Labels: map[string]string{
 		"state": "in_queue",
 	},
@@ -272,7 +272,7 @@ func TestReconcileMultiClusterBind(t *testing.T) {
 
 	replicaSecret := &corev1.Secret{}
 	replicaSecret.SetName(secretID)
-	replicaSecret.SetNamespace("default")
+	replicaSecret.SetNamespace(constants.InteroperatorNamespace)
 	err = c2.Create(context.TODO(), replicaSecret)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -350,7 +350,7 @@ func TestReconcileMultiClusterUnbind(t *testing.T) {
 
 	bindingSecret := &corev1.Secret{}
 	bindingSecret.SetName(secretID)
-	bindingSecret.SetNamespace("default")
+	bindingSecret.SetNamespace(constants.InteroperatorNamespace)
 	g.Expect(c.Create(context.TODO(), bindingSecret)).NotTo(gomega.HaveOccurred())
 
 	mockClusterRegistry.EXPECT().GetClient("2").Return(c2, nil).AnyTimes()

--- a/interoperator/controllers/multiclusterdeploy/sfserviceinstancereplicator/sfserviceinstancereplicator_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/sfserviceinstancereplicator/sfserviceinstancereplicator_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/multiclusterdeploy/watchmanager"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -74,7 +75,7 @@ func (r *InstanceReplicator) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
-	if clusterID == constants.DefaultMasterClusterID {
+	if clusterID == constants.OwnClusterID {
 		// Target cluster is mastercluster itself
 		// Replication not needed
 		return ctrl.Result{}, nil
@@ -302,7 +303,8 @@ func (r *InstanceReplicator) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		Named("mcd_replicator_instance").
 		For(&osbv1alpha1.SFServiceInstance{}).
-		Watches(&source.Channel{Source: watchEvents}, &handler.EnqueueRequestForObject{})
+		Watches(&source.Channel{Source: watchEvents}, &handler.EnqueueRequestForObject{}).
+		WithEventFilter(watches.NamespaceLabelFilter())
 
 	return builder.Complete(r)
 }

--- a/interoperator/controllers/multiclusterdeploy/sfserviceinstancereplicator/sfserviceinstancereplicator_controller_test.go
+++ b/interoperator/controllers/multiclusterdeploy/sfserviceinstancereplicator/sfserviceinstancereplicator_controller_test.go
@@ -41,7 +41,7 @@ import (
 
 var c, c2 client.Client
 
-var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
+var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: constants.InteroperatorNamespace}}
 var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: "sf-instance-id"}
 
 const timeout = time.Second * 5
@@ -133,13 +133,13 @@ func TestReconcile(t *testing.T) {
 	instance.SetNamespace("sf-instance-id")
 	g.Expect(c.Create(context.TODO(), instance)).NotTo(gomega.HaveOccurred())
 
-	// Set clusterID as DefaultMasterClusterID
+	// Set clusterID as OwnClusterID
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		err = c.Get(context.TODO(), instanceKey, instance)
 		if err != nil {
 			return err
 		}
-		instance.Spec.ClusterID = constants.DefaultMasterClusterID
+		instance.Spec.ClusterID = constants.OwnClusterID
 		return c.Update(context.TODO(), instance)
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -314,7 +314,7 @@ func TestInstanceReplicator_setInProgress(t *testing.T) {
 	var instance = &osbv1alpha1.SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "instance-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: osbv1alpha1.SFServiceInstanceSpec{
 			ServiceID:        "service-id",
@@ -329,7 +329,7 @@ func TestInstanceReplicator_setInProgress(t *testing.T) {
 			State: "in_queue",
 		},
 	}
-	var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: "default"}
+	var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: constants.InteroperatorNamespace}
 
 	mgr, err := manager.New(cfg, manager.Options{})
 	g.Expect(err).NotTo(gomega.HaveOccurred())

--- a/interoperator/controllers/multiclusterdeploy/sfservicesreplicator/sfservices_mcd_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/sfservicesreplicator/sfservices_mcd_controller.go
@@ -22,6 +22,7 @@ import (
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"github.com/go-logr/logr"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -246,7 +247,8 @@ func (r *ReconcileSFServices) SetupWithManager(mgr ctrl.Manager) error {
 		}).
 		Watches(&source.Kind{Type: &osbv1alpha1.SFPlan{}}, &handler.EnqueueRequestsFromMapFunc{
 			ToRequests: mapFn,
-		})
+		}).
+		WithEventFilter(watches.NamespaceFilter())
 
 	return builder.Complete(r)
 }

--- a/interoperator/controllers/multiclusterdeploy/sfservicesreplicator/sfservices_mcd_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/sfservicesreplicator/sfservices_mcd_controller.go
@@ -22,6 +22,7 @@ import (
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/utils"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"github.com/go-logr/logr"
@@ -31,7 +32,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	kubernetes "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -157,7 +157,7 @@ func (r *ReconcileSFServices) handleServicePlans(service *osbv1alpha1.SFService,
 		if err != nil {
 			if apiErrors.IsNotFound(err) {
 				replicateSFPlanResourceData(&obj, plan)
-				err = controllerutil.SetControllerReference(service, plan, r.scheme)
+				err = utils.SetOwnerReference(service, plan, r.scheme)
 				if err != nil {
 					return err
 				}
@@ -170,7 +170,7 @@ func (r *ReconcileSFServices) handleServicePlans(service *osbv1alpha1.SFService,
 			}
 		} else {
 			replicateSFPlanResourceData(&obj, plan)
-			err = controllerutil.SetControllerReference(service, plan, r.scheme)
+			err = utils.SetOwnerReference(service, plan, r.scheme)
 			if err != nil {
 				return err
 			}

--- a/interoperator/controllers/multiclusterdeploy/sfservicesreplicator/sfservices_mcd_controller_test.go
+++ b/interoperator/controllers/multiclusterdeploy/sfservicesreplicator/sfservices_mcd_controller_test.go
@@ -40,7 +40,7 @@ import (
 
 var c, c2 client.Client
 
-var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
+var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: constants.InteroperatorNamespace}}
 
 const timeout = time.Second * 5
 
@@ -62,7 +62,7 @@ func createAndTestSFServiceAndPlans(serviceName string, planName string, service
 	g.Eventually(func() error {
 		err := c2.Get(context.TODO(), types.NamespacedName{
 			Name:      serviceName,
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		}, service)
 		if err != nil {
 			return err
@@ -71,13 +71,13 @@ func createAndTestSFServiceAndPlans(serviceName string, planName string, service
 	}, timeout).Should(gomega.Succeed())
 	g.Expect(service.GetName()).To(gomega.Equal(serviceName))
 
-	err = c.Get(context.TODO(), types.NamespacedName{Name: planName, Namespace: "default"}, plan)
+	err = c.Get(context.TODO(), types.NamespacedName{Name: planName, Namespace: constants.InteroperatorNamespace}, plan)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	g.Eventually(func() error {
 		err := c2.Get(context.TODO(), types.NamespacedName{
 			Name:      planName,
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		}, plan)
 		if err != nil {
 			return err
@@ -125,7 +125,7 @@ func TestReconcile(t *testing.T) {
 	service1 := &osbv1alpha1.SFService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: osbv1alpha1.SFServiceSpec{
 			ID: "foo",
@@ -156,7 +156,7 @@ func TestReconcile(t *testing.T) {
 	plan1 := &osbv1alpha1.SFPlan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: osbv1alpha1.SFPlanSpec{
 			Name:          "plan-name",
@@ -197,14 +197,14 @@ func TestReconcile(t *testing.T) {
 	sfcluster1 := &resourcev1alpha1.SFCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "1",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 	}
 
 	sfcluster2 := &resourcev1alpha1.SFCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "2",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 	}
 

--- a/interoperator/controllers/multiclusterdeploy/watchmanager/watchmanager_suite_test.go
+++ b/interoperator/controllers/multiclusterdeploy/watchmanager/watchmanager_suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -97,7 +98,7 @@ func _getDummyInstance() *osbv1alpha1.SFServiceInstance {
 	return &osbv1alpha1.SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "instance-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: osbv1alpha1.SFServiceInstanceSpec{
 			ServiceID: "service-id",
@@ -110,7 +111,7 @@ func _getDummyBinding() *osbv1alpha1.SFServiceBinding {
 	return &osbv1alpha1.SFServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "binding-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: osbv1alpha1.SFServiceBindingSpec{
 			ServiceID:  "service-id",

--- a/interoperator/controllers/provisioners/sfplan/sfplan_controller.go
+++ b/interoperator/controllers/provisioners/sfplan/sfplan_controller.go
@@ -24,6 +24,7 @@ import (
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/utils"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"github.com/go-logr/logr"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -149,7 +149,7 @@ func (r *ReconcileSFPlan) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		existingRefs[i] = *ownerRefs[i].DeepCopy()
 	}
 
-	err = controllerutil.SetControllerReference(service, instance, r.scheme)
+	err = utils.SetOwnerReference(service, instance, r.scheme)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/interoperator/controllers/provisioners/sfplan/sfplan_controller.go
+++ b/interoperator/controllers/provisioners/sfplan/sfplan_controller.go
@@ -207,5 +207,6 @@ func (r *ReconcileSFPlan) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("plan").
 		For(&osbv1alpha1.SFPlan{}).
+		WithEventFilter(watches.NamespaceFilter()).
 		Complete(r)
 }

--- a/interoperator/controllers/provisioners/sfplan/sfplan_controller_test.go
+++ b/interoperator/controllers/provisioners/sfplan/sfplan_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 
 	"github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +37,7 @@ import (
 
 var c client.Client
 
-var planKey = types.NamespacedName{Name: "foo", Namespace: "default"}
+var planKey = types.NamespacedName{Name: "foo", Namespace: constants.InteroperatorNamespace}
 var expectedRequest = reconcile.Request{NamespacedName: planKey}
 
 const timeout = time.Second * 5
@@ -69,7 +70,7 @@ func TestReconcile(t *testing.T) {
 	service := &osbv1alpha1.SFService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "service-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels:    map[string]string{"serviceId": "service-id"},
 		},
 		Spec: osbv1alpha1.SFServiceSpec{
@@ -95,7 +96,7 @@ func TestReconcile(t *testing.T) {
 	instance := &osbv1alpha1.SFPlan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: osbv1alpha1.SFPlanSpec{
 			Name:          "plan-name",

--- a/interoperator/controllers/provisioners/sfservice/sfservice_controller.go
+++ b/interoperator/controllers/provisioners/sfservice/sfservice_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -79,5 +80,6 @@ func (r *ReconcileSFService) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("service").
 		For(&osbv1alpha1.SFService{}).
+		WithEventFilter(watches.NamespaceFilter()).
 		Complete(r)
 }

--- a/interoperator/controllers/provisioners/sfservice/sfservice_controller_test.go
+++ b/interoperator/controllers/provisioners/sfservice/sfservice_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 
 	"github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +37,7 @@ import (
 
 var c client.Client
 
-var serviceKey = types.NamespacedName{Name: "service-id", Namespace: "default"}
+var serviceKey = types.NamespacedName{Name: "service-id", Namespace: constants.InteroperatorNamespace}
 var expectedRequest = reconcile.Request{NamespacedName: serviceKey}
 
 const timeout = time.Second * 5
@@ -44,7 +45,7 @@ const timeout = time.Second * 5
 func TestReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	instance := &osbv1alpha1.SFService{
-		ObjectMeta: metav1.ObjectMeta{Name: "service-id", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "service-id", Namespace: constants.InteroperatorNamespace},
 		Spec: osbv1alpha1.SFServiceSpec{
 			Name:                "service-name",
 			ID:                  "service-id",

--- a/interoperator/controllers/provisioners/sfservicebinding/sfservicebinding_controller.go
+++ b/interoperator/controllers/provisioners/sfservicebinding/sfservicebinding_controller.go
@@ -42,7 +42,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -416,7 +415,7 @@ func (r *ReconcileSFServiceBinding) updateBindStatus(binding *osbv1alpha1.SFServ
 			StringData: data,
 		}
 
-		if err := controllerutil.SetControllerReference(binding, secret, r.scheme); err != nil {
+		if err := utils.SetOwnerReference(binding, secret, r.scheme); err != nil {
 			log.Error(err, "failed to set owner reference for secret", "binding", bindingID)
 			return err
 		}

--- a/interoperator/controllers/provisioners/sfservicebindingcleaner/sfservicebindingcleaner_controller.go
+++ b/interoperator/controllers/provisioners/sfservicebindingcleaner/sfservicebindingcleaner_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 )
 
 // ReconcileSFServiceBindingCleaner reconciles a SfServiceBindingCleaner object
@@ -91,5 +92,6 @@ func (r *ReconcileSFServiceBindingCleaner) Reconcile(req ctrl.Request) (ctrl.Res
 func (r *ReconcileSFServiceBindingCleaner) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&osbv1alpha1.SFServiceBinding{}).
+		WithEventFilter(watches.NamespaceLabelFilter()).
 		Complete(r)
 }

--- a/interoperator/controllers/provisioners/sfservicebindingcleaner/sfservicebindingcleaner_controller.go
+++ b/interoperator/controllers/provisioners/sfservicebindingcleaner/sfservicebindingcleaner_controller.go
@@ -91,6 +91,7 @@ func (r *ReconcileSFServiceBindingCleaner) Reconcile(req ctrl.Request) (ctrl.Res
 
 func (r *ReconcileSFServiceBindingCleaner) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("binding_cleaner").
 		For(&osbv1alpha1.SFServiceBinding{}).
 		WithEventFilter(watches.NamespaceLabelFilter()).
 		Complete(r)

--- a/interoperator/controllers/provisioners/sfservicebindingcleaner/sfservicebindingcleaner_controller_test.go
+++ b/interoperator/controllers/provisioners/sfservicebindingcleaner/sfservicebindingcleaner_controller_test.go
@@ -32,7 +32,7 @@ var c client.Client
 var binding = &osbv1alpha1.SFServiceBinding{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "binding-id",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 		Labels: map[string]string{
 			"state": "in_queue",
 		},
@@ -66,7 +66,7 @@ func setupInteroperatorConfig() {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.ConfigMapName,
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Data: data,
 	}
@@ -103,7 +103,7 @@ var _ = Describe("SFServiceBindingCleaner controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			binding := &osbv1alpha1.SFServiceBinding{}
-			bindingKey := types.NamespacedName{Name: "binding-id", Namespace: "default"}
+			bindingKey := types.NamespacedName{Name: "binding-id", Namespace: constants.InteroperatorNamespace}
 			err = c.Get(context.TODO(), bindingKey, binding)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(binding.Status.State).Should(Equal("in_queue"))

--- a/interoperator/controllers/provisioners/sfserviceinstance/sfserviceinstance_controller_test.go
+++ b/interoperator/controllers/provisioners/sfserviceinstance/sfserviceinstance_controller_test.go
@@ -74,7 +74,7 @@ var templateSpec = []osbv1alpha1.TemplateSpec{
 var service = &osbv1alpha1.SFService{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "service-id",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 		Labels:    map[string]string{"serviceId": "service-id"},
 	},
 	Spec: osbv1alpha1.SFServiceSpec{
@@ -100,7 +100,7 @@ var service = &osbv1alpha1.SFService{
 var plan = &osbv1alpha1.SFPlan{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "plan-id",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 		Labels: map[string]string{
 			"serviceId": "service-id",
 			"planId":    "plan-id",
@@ -125,7 +125,7 @@ var plan = &osbv1alpha1.SFPlan{
 var instance = &osbv1alpha1.SFServiceInstance{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "instance-id",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 		Labels: map[string]string{
 			"state": "in_queue",
 		},
@@ -145,7 +145,7 @@ var instance = &osbv1alpha1.SFServiceInstance{
 	},
 }
 
-var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: "default"}
+var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: constants.InteroperatorNamespace}
 var expectedRequest = reconcile.Request{NamespacedName: instanceKey}
 
 func setupInteroperatorConfig(g *gomega.GomegaWithT) {
@@ -164,7 +164,7 @@ func setupInteroperatorConfig(g *gomega.GomegaWithT) {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.ConfigMapName,
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Data: data,
 	}
@@ -206,12 +206,12 @@ func TestReconcile(t *testing.T) {
 		clusterRegistry: mockClusterRegistry,
 	}
 
-	mockResourceManager.EXPECT().ComputeExpectedResources(gomock.Any(), "instance-id", "", "service-id", "plan-id", osbv1alpha1.ProvisionAction, "default").Return(expectedResources, nil).AnyTimes()
+	mockResourceManager.EXPECT().ComputeExpectedResources(gomock.Any(), "instance-id", "", "service-id", "plan-id", osbv1alpha1.ProvisionAction, constants.InteroperatorNamespace).Return(expectedResources, nil).AnyTimes()
 	mockResourceManager.EXPECT().SetOwnerReference(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockClusterRegistry.EXPECT().GetClient("1").Return(controller, nil).AnyTimes()
 	mockResourceManager.EXPECT().ReconcileResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(appliedResources, err1).Times(1)
 	mockResourceManager.EXPECT().ReconcileResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(appliedResources, nil).AnyTimes()
-	mockResourceManager.EXPECT().ComputeStatus(gomock.Any(), "instance-id", "", "service-id", "plan-id", osbv1alpha1.ProvisionAction, "default").Return(&properties.Status{
+	mockResourceManager.EXPECT().ComputeStatus(gomock.Any(), "instance-id", "", "service-id", "plan-id", osbv1alpha1.ProvisionAction, constants.InteroperatorNamespace).Return(&properties.Status{
 		Provision: properties.InstanceStatus{
 			State: "succeeded",
 		},
@@ -307,7 +307,7 @@ func TestReconcileSFServiceInstance_handleError(t *testing.T) {
 	instance := &osbv1alpha1.SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "instance-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels: map[string]string{
 				"state":                 "in_queue",
 				constants.ErrorCountKey: "10",

--- a/interoperator/controllers/schedulers/sfdefaultscheduler/sfdefaultscheduler_controller.go
+++ b/interoperator/controllers/schedulers/sfdefaultscheduler/sfdefaultscheduler_controller.go
@@ -22,6 +22,7 @@ import (
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/config"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -56,7 +57,7 @@ func (r *SFDefaultScheduler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 	if instance.Spec.ClusterID == "" {
-		instance.Spec.ClusterID = constants.DefaultMasterClusterID
+		instance.Spec.ClusterID = constants.OwnClusterID
 		if err := r.Update(context.Background(), instance); err != nil {
 			log.Error(err, "failed to set cluster id")
 			return ctrl.Result{}, err
@@ -83,5 +84,6 @@ func (r *SFDefaultScheduler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("scheduler_default").
 		For(&osbv1alpha1.SFServiceInstance{}).
+		WithEventFilter(watches.NamespaceLabelFilter()).
 		Complete(r)
 }

--- a/interoperator/controllers/schedulers/sfdefaultscheduler/sfdefaultscheduler_controller_test.go
+++ b/interoperator/controllers/schedulers/sfdefaultscheduler/sfdefaultscheduler_controller_test.go
@@ -37,13 +37,13 @@ import (
 
 var c client.Client
 
-var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
+var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: constants.InteroperatorNamespace}}
 
 const timeout = time.Second * 5
 
 func TestReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	instance := &osbv1alpha1.SFServiceInstance{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	instance := &osbv1alpha1.SFServiceInstance{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: constants.InteroperatorNamespace}}
 
 	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
 	// channel when it is finished.
@@ -56,14 +56,14 @@ func TestReconcile(t *testing.T) {
 	sfcluster1 := &resourcev1alpha1.SFCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "1",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 	}
 
 	sfcluster2 := &resourcev1alpha1.SFCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "2",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 	}
 
@@ -92,7 +92,7 @@ func TestReconcile(t *testing.T) {
 	}
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Eventually(func() error {
-		err := c.Get(context.TODO(), types.NamespacedName{Name: "foo", Namespace: "default"}, instance)
+		err := c.Get(context.TODO(), types.NamespacedName{Name: "foo", Namespace: constants.InteroperatorNamespace}, instance)
 		if err != nil {
 			return err
 		}

--- a/interoperator/controllers/schedulers/sflabelselectorscheduler/sflabelselectorscheduler_controller.go
+++ b/interoperator/controllers/schedulers/sflabelselectorscheduler/sflabelselectorscheduler_controller.go
@@ -19,7 +19,6 @@ package sflabelselectorscheduler
 import (
 	"context"
 	"math"
-	"os"
 	"strings"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
@@ -30,6 +29,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/errors"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 
@@ -109,10 +109,7 @@ func getLabelSelectorString(sfServiceInstance *osbv1alpha1.SFServiceInstance, r 
 	log := r.Log.WithValues("instance", sfServiceInstance.GetName())
 	ctx := context.Background()
 
-	sfNamespace := os.Getenv(constants.NamespaceEnvKey)
-	if sfNamespace == "" {
-		sfNamespace = constants.DefaultServiceFabrikNamespace
-	}
+	sfNamespace := constants.InteroperatorNamespace
 	plan := &osbv1alpha1.SFPlan{}
 	namespacedName := types.NamespacedName{
 		Name:      sfServiceInstance.Spec.PlanID,
@@ -242,5 +239,6 @@ func (r *SFLabelSelectorScheduler) SetupWithManager(mgr ctrl.Manager) error {
 			MaxConcurrentReconciles: interoperatorCfg.InstanceWorkerCount,
 		}).
 		For(&osbv1alpha1.SFServiceInstance{}).
+		WithEventFilter(watches.NamespaceLabelFilter()).
 		Complete(r)
 }

--- a/interoperator/controllers/schedulers/sflabelselectorscheduler/sflabelselectorscheduler_controller_test.go
+++ b/interoperator/controllers/schedulers/sflabelselectorscheduler/sflabelselectorscheduler_controller_test.go
@@ -143,7 +143,7 @@ func TestReconcile(t *testing.T) {
 		}
 		err = c.Get(context.TODO(), types.NamespacedName{
 			Name:      "1",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		}, sfcluster1)
 		if err != nil {
 			return err
@@ -154,7 +154,7 @@ func TestReconcile(t *testing.T) {
 		}
 		err = c.Get(context.TODO(), types.NamespacedName{
 			Name:      "3",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		}, sfcluster3)
 		if err != nil {
 			return err
@@ -187,7 +187,7 @@ func TestReconcile(t *testing.T) {
 		}
 		err = c.Get(context.TODO(), types.NamespacedName{
 			Name:      "2",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		}, sfcluster2)
 		if err != nil {
 			return err
@@ -229,7 +229,7 @@ func _getDummyConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.ConfigMapName,
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Data: data,
 	}
@@ -246,7 +246,7 @@ func _getDummySFPlan(name string, clusterSelector string) *osbv1alpha1.SFPlan {
 	return &osbv1alpha1.SFPlan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: osbv1alpha1.SFPlanSpec{
 			Name:      "plan-name",
@@ -260,7 +260,7 @@ func _getDummySFService(name string) *osbv1alpha1.SFService {
 	return &osbv1alpha1.SFService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "service-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels:    map[string]string{"serviceId": "service-id"},
 		},
 		Spec: osbv1alpha1.SFServiceSpec{
@@ -288,7 +288,7 @@ func _getDummySFServiceInstance(name string, planID string) *osbv1alpha1.SFServi
 	return &osbv1alpha1.SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels: map[string]string{
 				"state": "in_queue",
 			},
@@ -313,7 +313,7 @@ func _getDummySFCLuster(name string, labels map[string]string) *resourcev1alpha1
 	return &resourcev1alpha1.SFCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 			Labels:    labels,
 		},
 	}

--- a/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller.go
+++ b/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller.go
@@ -18,7 +18,6 @@ package sfserviceinstancecounter
 
 import (
 	"context"
-	"os"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
@@ -26,6 +25,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/utils"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 	"github.com/go-logr/logr"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,10 +78,7 @@ func (r *SFServiceInstanceCounter) Reconcile(req ctrl.Request) (ctrl.Result, err
 					return ctrl.Result{}, err
 				}
 
-				sfNamespace := os.Getenv(constants.NamespaceEnvKey)
-				if sfNamespace == "" {
-					sfNamespace = constants.DefaultServiceFabrikNamespace
-				}
+				sfNamespace := constants.InteroperatorNamespace
 				sfCluster := &resourcev1alpha1.SFCluster{}
 				namespacedName := types.NamespacedName{
 					Name:      instance.Spec.ClusterID,
@@ -117,10 +114,7 @@ func (r *SFServiceInstanceCounter) Reconcile(req ctrl.Request) (ctrl.Result, err
 					return ctrl.Result{}, err
 				}
 
-				sfNamespace := os.Getenv(constants.NamespaceEnvKey)
-				if sfNamespace == "" {
-					sfNamespace = constants.DefaultServiceFabrikNamespace
-				}
+				sfNamespace := constants.InteroperatorNamespace
 				sfCluster := &resourcev1alpha1.SFCluster{}
 				namespacedName := types.NamespacedName{
 					Name:      instance.Spec.ClusterID,
@@ -168,5 +162,6 @@ func (r *SFServiceInstanceCounter) SetupWithManager(mgr ctrl.Manager) error {
 			MaxConcurrentReconciles: interoperatorCfg.InstanceWorkerCount,
 		}).
 		For(&osbv1alpha1.SFServiceInstance{}).
+		WithEventFilter(watches.NamespaceLabelFilter()).
 		Complete(r)
 }

--- a/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller_test.go
+++ b/interoperator/controllers/schedulers/sfserviceinstancecounter/sfserviceinstancecounter_controller_test.go
@@ -86,7 +86,7 @@ func TestReconcile(t *testing.T) {
 	sfcluster1 := &resourcev1alpha1.SFCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "1",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 	}
 	g.Expect(c.Create(context.TODO(), sfcluster1)).NotTo(gomega.HaveOccurred())
@@ -99,7 +99,7 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(func() error {
 		err := c.Get(context.TODO(), types.NamespacedName{
 			Name:      "1",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		}, sfCluster)
 		if err != nil {
 			return err
@@ -118,7 +118,7 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(func() error {
 		err := c.Get(context.TODO(), types.NamespacedName{
 			Name:      "1",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		}, sfCluster)
 		if err != nil {
 			return err
@@ -139,7 +139,7 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(func() error {
 		err := c.Get(context.TODO(), types.NamespacedName{
 			Name:      "foo1",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		}, instance1)
 		if err == nil {
 			return errors.New("instance not deleted")
@@ -150,7 +150,7 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(func() error {
 		err := c.Get(context.TODO(), types.NamespacedName{
 			Name:      "foo2",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		}, instance2)
 		if err == nil {
 			return errors.New("instance not deleted")
@@ -161,7 +161,7 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(func() error {
 		err := c.Get(context.TODO(), types.NamespacedName{
 			Name:      "1",
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		}, sfcluster2)
 		if err != nil {
 			return err
@@ -181,7 +181,7 @@ func _getDummyConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.ConfigMapName,
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Data: data,
 	}
@@ -191,7 +191,7 @@ func _getDummySFServiceInstance(name string, planID string) *osbv1alpha1.SFServi
 	return &osbv1alpha1.SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels: map[string]string{
 				"state": "in_queue",
 			},

--- a/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller.go
+++ b/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller.go
@@ -24,6 +24,7 @@ import (
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/config"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
 	"github.com/go-logr/logr"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -136,5 +137,6 @@ func (r *SFServiceInstanceUpdater) SetupWithManager(mgr ctrl.Manager) error {
 			MaxConcurrentReconciles: interoperatorCfg.InstanceWorkerCount,
 		}).
 		For(&osbv1alpha1.SFPlan{}).
+		WithEventFilter(watches.NamespaceFilter()).
 		Complete(r)
 }

--- a/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller_test.go
+++ b/interoperator/controllers/schedulers/sfserviceinstanceupdater/sfserviceinstanceupdater_controller_test.go
@@ -99,7 +99,7 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(func() error {
 		err := c.Get(context.TODO(), types.NamespacedName{
 			Name:      "plan-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		}, plan2)
 		if err != nil {
 			return err
@@ -117,7 +117,7 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(func() error {
 		err := c.Get(context.TODO(), types.NamespacedName{
 			Name:      "plan-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		}, plan3)
 		if err != nil {
 			return err
@@ -130,7 +130,7 @@ func TestReconcile(t *testing.T) {
 
 		err = c.Get(context.TODO(), types.NamespacedName{
 			Name:      "foo1",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		}, instance1)
 		if err != nil {
 			return err
@@ -141,7 +141,7 @@ func TestReconcile(t *testing.T) {
 		}
 		err = c.Get(context.TODO(), types.NamespacedName{
 			Name:      "foo2",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		}, instance2)
 		if err != nil {
 			return err
@@ -166,7 +166,7 @@ func _getDummyConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.ConfigMapName,
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Data: data,
 	}
@@ -176,7 +176,7 @@ func _getDummySFServiceInstance(name string, planID string) *osbv1alpha1.SFServi
 	return &osbv1alpha1.SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels: map[string]string{
 				"state": "in_queue",
 			},
@@ -227,7 +227,7 @@ func _getDummyPlan(provisionContent string) *osbv1alpha1.SFPlan {
 	return &osbv1alpha1.SFPlan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "plan-id",
-			Namespace:  "default",
+			Namespace:  constants.InteroperatorNamespace,
 			Labels:     map[string]string{"serviceId": "service-id", "planId": "plan-id"},
 			Finalizers: []string{"abc"},
 		},

--- a/interoperator/internal/config/config.go
+++ b/interoperator/internal/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
@@ -84,10 +83,7 @@ func New(kubeConfig *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper
 	if err != nil {
 		return nil, err
 	}
-	configMapNamespace := os.Getenv(constants.NamespaceEnvKey)
-	if configMapNamespace == "" {
-		configMapNamespace = constants.DefaultServiceFabrikNamespace
-	}
+	configMapNamespace := constants.InteroperatorNamespace
 
 	return &config{
 		c:         c,

--- a/interoperator/internal/config/config_test.go
+++ b/interoperator/internal/config/config_test.go
@@ -134,13 +134,13 @@ instanceContollerWatchList:
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.ConfigMapName,
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Data: data,
 	}
 	configMapKey := types.NamespacedName{
 		Name:      constants.ConfigMapName,
-		Namespace: constants.DefaultServiceFabrikNamespace,
+		Namespace: constants.InteroperatorNamespace,
 	}
 	interoperatorConfig := &InteroperatorConfig{
 		BindingWorkerCount:     constants.DefaultBindingWorkerCount,
@@ -239,7 +239,7 @@ func Test_config_UpdateConfig(t *testing.T) {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.ConfigMapName,
-			Namespace: constants.DefaultServiceFabrikNamespace,
+			Namespace: constants.InteroperatorNamespace,
 		},
 	}
 	interoperatorConfig := &InteroperatorConfig{

--- a/interoperator/internal/provisioner/provisioner.go
+++ b/interoperator/internal/provisioner/provisioner.go
@@ -2,7 +2,6 @@ package provisioner
 
 import (
 	"context"
-	"os"
 
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/errors"
@@ -47,10 +46,7 @@ func New(kubeConfig *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper
 	if err != nil {
 		return nil, err
 	}
-	provisionerNamespace := os.Getenv(constants.NamespaceEnvKey)
-	if provisionerNamespace == "" {
-		provisionerNamespace = constants.DefaultServiceFabrikNamespace
-	}
+	provisionerNamespace := constants.InteroperatorNamespace
 
 	return &provisioner{
 		c:         c,

--- a/interoperator/internal/provisioner/provisioner_test.go
+++ b/interoperator/internal/provisioner/provisioner_test.go
@@ -86,7 +86,7 @@ func Test_provisioner_Fetch(t *testing.T) {
 			name: "should fail if deployment not found",
 			fields: fields{
 				c:         c,
-				namespace: "default",
+				namespace: constants.InteroperatorNamespace,
 			},
 			wantErr: true,
 		},
@@ -94,7 +94,7 @@ func Test_provisioner_Fetch(t *testing.T) {
 			name: "should fetch deployment",
 			fields: fields{
 				c:         c,
-				namespace: "default",
+				namespace: constants.InteroperatorNamespace,
 			},
 			wantErr: false,
 			setup: func(p *provisioner) {
@@ -165,7 +165,7 @@ func Test_provisioner_Get(t *testing.T) {
 			name: "should do nothing if deployment already fetched",
 			fields: fields{
 				c:          c,
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 				deployment: &appsv1.Deployment{},
 			},
 			want:    &appsv1.Deployment{},
@@ -175,7 +175,7 @@ func Test_provisioner_Get(t *testing.T) {
 			name: "should fail if deployment not found",
 			fields: fields{
 				c:         c,
-				namespace: "default",
+				namespace: constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			wantErr: true,

--- a/interoperator/internal/renderer/factory/factory_test.go
+++ b/interoperator/internal/renderer/factory/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/renderer"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/renderer/gotemplate"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/renderer/helm"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -99,7 +100,7 @@ func TestGetRendererInput(t *testing.T) {
 	plan := osbv1alpha1.SFPlan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "plan-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: osbv1alpha1.SFPlanSpec{
 			Name:          "plan-name",
@@ -121,20 +122,20 @@ func TestGetRendererInput(t *testing.T) {
 	service := osbv1alpha1.SFService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 	}
 
 	name := types.NamespacedName{
 		Name:      "foo",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 
 	spec := osbv1alpha1.SFServiceInstanceSpec{}
 	instance := osbv1alpha1.SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: spec,
 		Status: osbv1alpha1.SFServiceInstanceStatus{
@@ -148,7 +149,7 @@ func TestGetRendererInput(t *testing.T) {
 					APIVersion: "v1alpha1",
 					Kind:       "Director",
 					Name:       "dddd",
-					Namespace:  "default",
+					Namespace:  constants.InteroperatorNamespace,
 				},
 			},
 		},
@@ -157,7 +158,7 @@ func TestGetRendererInput(t *testing.T) {
 	binding := osbv1alpha1.SFServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 	}
 
@@ -287,7 +288,7 @@ func TestGetRendererInput(t *testing.T) {
 func TestGetRendererInputFromSources(t *testing.T) {
 	name := types.NamespacedName{
 		Name:      "foo",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}
 
 	invalidTemplate := osbv1alpha1.TemplateSpec{

--- a/interoperator/internal/resources/helper.go
+++ b/interoperator/internal/resources/helper.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"os"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/dynamic"
@@ -44,10 +43,7 @@ func fetchResources(client kubernetes.Client, instanceID, bindingID, serviceID, 
 	}
 
 	if serviceID != "" && planID != "" {
-		serviceNamespace := os.Getenv(constants.NamespaceEnvKey)
-		if serviceNamespace == "" {
-			serviceNamespace = constants.DefaultServiceFabrikNamespace
-		}
+		serviceNamespace := constants.InteroperatorNamespace
 		service, plan, err = services.FindServiceInfo(client, serviceID, planID, serviceNamespace)
 		if err != nil {
 			log.Error(err, "failed finding service and plan info", "serviceID", serviceID, "planID", planID)

--- a/interoperator/internal/resources/helper_test.go
+++ b/interoperator/internal/resources/helper_test.go
@@ -8,6 +8,7 @@ import (
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/dynamic"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/renderer"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -23,10 +24,10 @@ func Test_resourceManager_fetchResources(t *testing.T) {
 	instance := _getDummyInstance()
 	binding := _getDummyBinding()
 
-	var serviceKey = types.NamespacedName{Name: "service-id", Namespace: "default"}
-	var planKey = types.NamespacedName{Name: "plan-id", Namespace: "default"}
-	var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: "default"}
-	var bindingKey = types.NamespacedName{Name: "binding-id", Namespace: "default"}
+	var serviceKey = types.NamespacedName{Name: "service-id", Namespace: constants.InteroperatorNamespace}
+	var planKey = types.NamespacedName{Name: "plan-id", Namespace: constants.InteroperatorNamespace}
+	var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: constants.InteroperatorNamespace}
+	var bindingKey = types.NamespacedName{Name: "binding-id", Namespace: constants.InteroperatorNamespace}
 
 	g.Expect(c.Create(context.TODO(), service)).NotTo(gomega.HaveOccurred())
 	g.Expect(c.Create(context.TODO(), plan)).NotTo(gomega.HaveOccurred())
@@ -73,7 +74,7 @@ func Test_resourceManager_fetchResources(t *testing.T) {
 				bindingID:  "binding-id",
 				serviceID:  "service-id",
 				planID:     "plan-id",
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    instance,
 			want1:   binding,
@@ -90,7 +91,7 @@ func Test_resourceManager_fetchResources(t *testing.T) {
 				bindingID:  "binding-id",
 				serviceID:  "service-id",
 				planID:     "plan-id",
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			want1:   nil,
@@ -107,7 +108,7 @@ func Test_resourceManager_fetchResources(t *testing.T) {
 				bindingID:  "binding-id2",
 				serviceID:  "service-id",
 				planID:     "plan-id",
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			want1:   nil,
@@ -124,7 +125,7 @@ func Test_resourceManager_fetchResources(t *testing.T) {
 				bindingID:  "binding-id",
 				serviceID:  "service-id2",
 				planID:     "plan-id",
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			want1:   nil,
@@ -141,7 +142,7 @@ func Test_resourceManager_fetchResources(t *testing.T) {
 				bindingID:  "binding-id",
 				serviceID:  "service-id",
 				planID:     "plan-id2",
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			want1:   nil,
@@ -218,13 +219,13 @@ func Test_resourceManager_findUnstructuredObject(t *testing.T) {
 	resource := &unstructured.Unstructured{}
 	resource.SetAPIVersion("osb.servicefabrik.io/v1alpha1")
 	resource.SetKind("SFServiceInstance")
-	resource.SetNamespace("default")
+	resource.SetNamespace(constants.InteroperatorNamespace)
 	resource.SetName("instance-id")
 
 	resource2 := &unstructured.Unstructured{}
 	resource2.SetAPIVersion("osb.servicefabrik.io/v1alpha1")
 	resource2.SetKind("SFServiceInstance")
-	resource2.SetNamespace("default")
+	resource2.SetNamespace(constants.InteroperatorNamespace)
 	resource2.SetName("instance-id2")
 
 	tests := []struct {
@@ -269,7 +270,7 @@ func Test_deleteSubResource(t *testing.T) {
 	resource := &unstructured.Unstructured{}
 	resource.SetAPIVersion("v1")
 	resource.SetKind("ConfigMap")
-	resource.SetNamespace("default")
+	resource.SetNamespace(constants.InteroperatorNamespace)
 	resource.SetName("configmap")
 	tests := []struct {
 		name    string
@@ -316,7 +317,7 @@ func Test_computeInputObjects(t *testing.T) {
 	configResource := &unstructured.Unstructured{}
 	configResource.SetAPIVersion("v1")
 	configResource.SetKind("ConfigMap")
-	configResource.SetNamespace("default")
+	configResource.SetNamespace(constants.InteroperatorNamespace)
 	configResource.SetName("instance-id")
 	err := c.Create(context.TODO(), configResource)
 	if err != nil {
@@ -324,7 +325,7 @@ func Test_computeInputObjects(t *testing.T) {
 	}
 	err = c.Get(context.TODO(), types.NamespacedName{
 		Name:      "instance-id",
-		Namespace: "default",
+		Namespace: constants.InteroperatorNamespace,
 	}, configResource)
 	if err != nil {
 		t.Errorf("Failed to get configmap %v", err)
@@ -462,7 +463,8 @@ func Test_computeInputObjects(t *testing.T) {
 {{- $bindingID := "" }}
 {{- with .instance.metadata.name }} {{ $instanceID = . }} {{ end }}
 {{- with .binding.metadata.name }} {{ $bindingID = . }} {{ end }}
-{{- $namespace := "default" }}
+{{- $namespace := "" }}
+{{- with .instance.metadata.namespace }} {{ $namespace = . }} {{ end }}
 config:
  apiVersion: "v1"
   kind: ConfigMap
@@ -643,7 +645,7 @@ func _getDummyInstance() *osbv1alpha1.SFServiceInstance {
 	return &osbv1alpha1.SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "instance-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: osbv1alpha1.SFServiceInstanceSpec{
 			ServiceID: "service-id",
@@ -659,7 +661,7 @@ func _getDummyInstance() *osbv1alpha1.SFServiceInstance {
 					APIVersion: "v1alpha1",
 					Kind:       "Director",
 					Name:       "dddd",
-					Namespace:  "default",
+					Namespace:  constants.InteroperatorNamespace,
 				},
 			},
 		},
@@ -670,7 +672,7 @@ func _getDummyBinding() *osbv1alpha1.SFServiceBinding {
 	return &osbv1alpha1.SFServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "binding-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 	}
 }
@@ -683,7 +685,7 @@ func _getDummyService() *osbv1alpha1.SFService {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "service-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels:    map[string]string{"serviceId": "service-id"},
 		},
 		Spec: osbv1alpha1.SFServiceSpec{
@@ -731,7 +733,8 @@ func _getDummyPlan() *osbv1alpha1.SFPlan {
 {{- $bindingID := "" }}
 {{- with .instance.metadata.name }} {{ $instanceID = . }} {{ end }}
 {{- with .binding.metadata.name }} {{ $bindingID = . }} {{ end }}
-{{- $namespace := "default" }}
+{{- $namespace := "" }}
+{{- with .instance.metadata.namespace }} {{ $namespace = . }} {{ end }}
 config:
   apiVersion: "v1"
   kind: ConfigMap
@@ -746,7 +749,7 @@ config:
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "plan-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels:    map[string]string{"serviceId": "service-id", "planId": "plan-id"},
 		},
 		Spec: osbv1alpha1.SFPlanSpec{

--- a/interoperator/internal/resources/owner_reference.go
+++ b/interoperator/internal/resources/owner_reference.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"fmt"
 
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -61,6 +62,27 @@ func setOwnerReference(owner, object metav1.Object, scheme *runtime.Scheme) erro
 	// Update owner references
 	object.SetOwnerReferences(existingRefs)
 	return nil
+}
+
+func setInteroperatorNamespaceLabel(owner, object metav1.Object) {
+	if owner == nil || object == nil {
+		return
+	}
+	ownerLabels := owner.GetLabels()
+	if ownerLabels == nil {
+		return
+	}
+	ns, ok := ownerLabels[constants.NamespaceLabelKey]
+	if !ok {
+		return
+	}
+	objectLabels := object.GetLabels()
+	if objectLabels == nil {
+		objectLabels = make(map[string]string)
+	}
+	objectLabels[constants.NamespaceLabelKey] = ns
+	object.SetLabels(objectLabels)
+	return
 }
 
 // Returns true if a and b point to the same object

--- a/interoperator/internal/resources/owner_reference_test.go
+++ b/interoperator/internal/resources/owner_reference_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"testing"
 
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -178,6 +179,96 @@ func Test_referSameObject(t *testing.T) {
 			if got := referSameObject(tt.args.a, tt.args.b); got != tt.want {
 				t.Errorf("referSameObject() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_setInteroperatorNamespaceLabel(t *testing.T) {
+	type args struct {
+		owner  metav1.Object
+		object metav1.Object
+	}
+	tests := []struct {
+		name   string
+		args   args
+		setup  func(args)
+		verify func(args)
+	}{
+		{
+			name: "noop if owner is nil",
+			args: args{
+				object: &unstructured.Unstructured{},
+			},
+		},
+		{
+			name: "noop if object is nil",
+			args: args{
+				owner: &unstructured.Unstructured{},
+			},
+		},
+		{
+			name: "noop if owner does not have labels",
+			args: args{
+				owner:  &unstructured.Unstructured{},
+				object: &unstructured.Unstructured{},
+			},
+			verify: func(a args) {
+				if a.object.GetLabels() != nil {
+					t.Errorf("setInteroperatorNamespaceLabel() : labels = %v, want nil", a.object.GetLabels())
+				}
+			},
+		},
+		{
+			name: "noop if owner does not have required label",
+			args: args{
+				owner:  &unstructured.Unstructured{},
+				object: &unstructured.Unstructured{},
+			},
+			setup: func(a args) {
+				labels := make(map[string]string)
+				a.owner.SetLabels(labels)
+			},
+			verify: func(a args) {
+				if a.object.GetLabels() != nil {
+					t.Errorf("setInteroperatorNamespaceLabel() : labels = %v, want nil", a.object.GetLabels())
+				}
+			},
+		},
+		{
+			name: "set object label",
+			args: args{
+				owner:  &unstructured.Unstructured{},
+				object: &unstructured.Unstructured{},
+			},
+			setup: func(a args) {
+				labels := make(map[string]string)
+				labels[constants.NamespaceLabelKey] = constants.InteroperatorNamespace
+				a.owner.SetLabels(labels)
+			},
+			verify: func(a args) {
+				labels := a.object.GetLabels()
+				if labels == nil {
+					t.Errorf("setInteroperatorNamespaceLabel() : labels = nil, want %v", a.owner.GetLabels())
+				}
+				ns, ok := labels[constants.NamespaceLabelKey]
+				if !ok {
+					t.Errorf("setInteroperatorNamespaceLabel() : label %s = nil, want %s", constants.NamespaceLabelKey, constants.InteroperatorNamespace)
+				}
+				if ns != constants.InteroperatorNamespace {
+					t.Errorf("setInteroperatorNamespaceLabel() : label %s = %s, want %s", constants.NamespaceLabelKey, ns, constants.InteroperatorNamespace)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(tt.args)
+			}
+			if tt.verify != nil {
+				defer tt.verify(tt.args)
+			}
+			setInteroperatorNamespaceLabel(tt.args.owner, tt.args.object)
 		})
 	}
 }

--- a/interoperator/internal/resources/resources.go
+++ b/interoperator/internal/resources/resources.go
@@ -6,6 +6,7 @@ import (
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/dynamic"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/properties"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/utils"
 
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,12 +95,10 @@ func (r resourceManager) ComputeExpectedResources(client kubernetes.Client, inst
 // SetOwnerReference updates the owner reference for all the resources
 func (r resourceManager) SetOwnerReference(owner metav1.Object, resources []*unstructured.Unstructured, scheme *runtime.Scheme) error {
 	for _, obj := range resources {
-		if err := setOwnerReference(owner, obj, scheme); err != nil {
+		if err := utils.SetOwnerReference(owner, obj, scheme); err != nil {
 			log.Error(err, "failed setting owner reference for resource", "owner", owner, "resource", obj)
 			return err
 		}
-		// Set Interoperator Namespace Label for Filtering watch requests
-		setInteroperatorNamespaceLabel(owner, obj)
 	}
 	return nil
 }

--- a/interoperator/internal/resources/resources.go
+++ b/interoperator/internal/resources/resources.go
@@ -98,6 +98,8 @@ func (r resourceManager) SetOwnerReference(owner metav1.Object, resources []*uns
 			log.Error(err, "failed setting owner reference for resource", "owner", owner, "resource", obj)
 			return err
 		}
+		// Set Interoperator Namespace Label for Filtering watch requests
+		setInteroperatorNamespaceLabel(owner, obj)
 	}
 	return nil
 }

--- a/interoperator/internal/resources/resources_test.go
+++ b/interoperator/internal/resources/resources_test.go
@@ -13,6 +13,7 @@ import (
 	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/dynamic"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/properties"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,10 +116,10 @@ func Test_resourceManager_ComputeExpectedResources(t *testing.T) {
 	instance := _getDummyInstance()
 	binding := _getDummyBinding()
 
-	var serviceKey = types.NamespacedName{Name: "service-id", Namespace: "default"}
-	var planKey = types.NamespacedName{Name: "plan-id", Namespace: "default"}
-	var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: "default"}
-	var bindingKey = types.NamespacedName{Name: "binding-id", Namespace: "default"}
+	var serviceKey = types.NamespacedName{Name: "service-id", Namespace: constants.InteroperatorNamespace}
+	var planKey = types.NamespacedName{Name: "plan-id", Namespace: constants.InteroperatorNamespace}
+	var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: constants.InteroperatorNamespace}
+	var bindingKey = types.NamespacedName{Name: "binding-id", Namespace: constants.InteroperatorNamespace}
 
 	g.Expect(c.Create(context.TODO(), service)).NotTo(gomega.HaveOccurred())
 	g.Expect(c.Create(context.TODO(), plan)).NotTo(gomega.HaveOccurred())
@@ -141,7 +142,7 @@ func Test_resourceManager_ComputeExpectedResources(t *testing.T) {
 	output := &unstructured.Unstructured{}
 	output.SetAPIVersion("kubedb.com/v1alpha1")
 	output.SetKind("Postgres")
-	output.SetNamespace("default")
+	output.SetNamespace(constants.InteroperatorNamespace)
 
 	type args struct {
 		client     kubernetes.Client
@@ -169,7 +170,7 @@ func Test_resourceManager_ComputeExpectedResources(t *testing.T) {
 				serviceID:  "service-id",
 				planID:     "plan-id",
 				action:     "provision",
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    []*unstructured.Unstructured{output},
 			wantErr: false,
@@ -184,7 +185,7 @@ func Test_resourceManager_ComputeExpectedResources(t *testing.T) {
 				serviceID:  "service-id",
 				planID:     "plan-id",
 				action:     "bind",
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    []*unstructured.Unstructured{output},
 			wantErr: false,
@@ -199,7 +200,7 @@ func Test_resourceManager_ComputeExpectedResources(t *testing.T) {
 				serviceID:  "service-id",
 				planID:     "plan-id",
 				action:     "provision",
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			wantErr: true,
@@ -214,7 +215,7 @@ func Test_resourceManager_ComputeExpectedResources(t *testing.T) {
 				serviceID:  "service-id",
 				planID:     "plan-id",
 				action:     "provisionInvalid",
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			wantErr: true,
@@ -245,13 +246,13 @@ func Test_resourceManager_SetOwnerReference(t *testing.T) {
 	resource := &unstructured.Unstructured{}
 	resource.SetAPIVersion("kubedb.com/v1alpha1")
 	resource.SetKind("Postgres")
-	resource.SetNamespace("default")
+	resource.SetNamespace(constants.InteroperatorNamespace)
 
 	spec := osbv1alpha1.SFServiceInstanceSpec{}
 	owner := &osbv1alpha1.SFServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "instance-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: spec,
 		Status: osbv1alpha1.SFServiceInstanceStatus{
@@ -265,7 +266,7 @@ func Test_resourceManager_SetOwnerReference(t *testing.T) {
 					APIVersion: "v1alpha1",
 					Kind:       "Director",
 					Name:       "dddd",
-					Namespace:  "default",
+					Namespace:  constants.InteroperatorNamespace,
 				},
 			},
 		},
@@ -302,7 +303,7 @@ func Test_resourceManager_ReconcileResources_ResourceNotFound(t *testing.T) {
 	resource := &unstructured.Unstructured{}
 	resource.SetAPIVersion("deployment.servicefabrik.io/v1alpha1")
 	resource.SetKind("Director")
-	resource.SetNamespace("default")
+	resource.SetNamespace(constants.InteroperatorNamespace)
 	resource.SetName("instance-id")
 	defer c.Delete(context.TODO(), resource)
 
@@ -374,7 +375,7 @@ status:
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(len(foundResources)).To(gomega.Equal(1))
 
-	var foundResourceKey = types.NamespacedName{Name: "instance-id", Namespace: "default"}
+	var foundResourceKey = types.NamespacedName{Name: "instance-id", Namespace: constants.InteroperatorNamespace}
 
 	expectedResources, err2 := dynamic.StringToUnstructured(`apiVersion: deployment.servicefabrik.io/v1alpha1
 kind: Director
@@ -399,13 +400,13 @@ status:
 	lastResource1 := osbv1alpha1.Source{}
 	lastResource1.APIVersion = "deployment.servicefabrik.io/v1alpha1"
 	lastResource1.Kind = "Director"
-	lastResource1.Namespace = "default"
+	lastResource1.Namespace = constants.InteroperatorNamespace
 	lastResource1.Name = "instance-id"
 
 	lastResource2 := osbv1alpha1.Source{}
 	lastResource2.APIVersion = "deployment.servicefabrik.io/v1alpha1"
 	lastResource2.Kind = "Docker"
-	lastResource2.Namespace = "default"
+	lastResource2.Namespace = constants.InteroperatorNamespace
 	lastResource2.Name = "instance-id"
 
 	oldResource := &unstructured.Unstructured{}
@@ -713,7 +714,8 @@ deprovision:
 {{- $binding := "" }}
 {{- with .instance.metadata.name }} {{ $name = . }} {{ end }}
 {{- with .binding.metadata.name }} {{ $binding = . }} {{ end }}
-{{- $namespace := "default" }}
+{{- $namespace := "" }}
+{{- with .instance.metadata.namespace }} {{ $namespace = . }} {{ end }}
 director:
   apiVersion: "deployment.servicefabrik.io/v1alpha1"
   kind: Director
@@ -732,10 +734,10 @@ directorbind:
 	instance := _getDummyInstance()
 	binding := _getDummyBinding()
 
-	var serviceKey = types.NamespacedName{Name: "service-id", Namespace: "default"}
-	var planKey = types.NamespacedName{Name: "plan-id", Namespace: "default"}
-	var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: "default"}
-	var bindingKey = types.NamespacedName{Name: "binding-id", Namespace: "default"}
+	var serviceKey = types.NamespacedName{Name: "service-id", Namespace: constants.InteroperatorNamespace}
+	var planKey = types.NamespacedName{Name: "plan-id", Namespace: constants.InteroperatorNamespace}
+	var instanceKey = types.NamespacedName{Name: "instance-id", Namespace: constants.InteroperatorNamespace}
+	var bindingKey = types.NamespacedName{Name: "binding-id", Namespace: constants.InteroperatorNamespace}
 
 	g.Expect(c.Create(context.TODO(), service)).NotTo(gomega.HaveOccurred())
 	g.Expect(c.Create(context.TODO(), plan)).NotTo(gomega.HaveOccurred())
@@ -787,7 +789,7 @@ directorbind:
 				serviceID:  "service-id",
 				planID:     "plan-id",
 				action:     osbv1alpha1.ProvisionAction,
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			wantErr: true,
@@ -802,7 +804,7 @@ directorbind:
 				serviceID:  "service-id",
 				planID:     "plan-id",
 				action:     osbv1alpha1.ProvisionAction,
-				namespace:  "default",
+				namespace:  constants.InteroperatorNamespace,
 			},
 			want:    &instanceStatus,
 			wantErr: false,
@@ -847,7 +849,7 @@ func Test_resourceManager_DeleteSubResources(t *testing.T) {
 						APIVersion: "deployment.servicefabrik.io/v1alpha1",
 						Kind:       "Director",
 						Name:       "instance-id",
-						Namespace:  "default",
+						Namespace:  constants.InteroperatorNamespace,
 					},
 				},
 			},
@@ -856,7 +858,7 @@ func Test_resourceManager_DeleteSubResources(t *testing.T) {
 				resource.SetKind("Director")
 				resource.SetAPIVersion("deployment.servicefabrik.io/v1alpha1")
 				resource.SetName("instance-id")
-				resource.SetNamespace("default")
+				resource.SetNamespace(constants.InteroperatorNamespace)
 				err := c.Create(context.TODO(), resource)
 				if err != nil {
 					t.Errorf("Failed to create Director %v", err)
@@ -867,9 +869,9 @@ func Test_resourceManager_DeleteSubResources(t *testing.T) {
 				resource.SetKind("Director")
 				resource.SetAPIVersion("deployment.servicefabrik.io/v1alpha1")
 				resource.SetName("instance-id")
-				resource.SetNamespace("default")
+				resource.SetNamespace(constants.InteroperatorNamespace)
 
-				err := c.Get(context.TODO(), types.NamespacedName{Name: "instance-id", Namespace: "default"}, resource)
+				err := c.Get(context.TODO(), types.NamespacedName{Name: "instance-id", Namespace: constants.InteroperatorNamespace}, resource)
 				if err != nil {
 					t.Errorf("Failed to get Director %v", err)
 					return
@@ -903,7 +905,7 @@ func Test_resourceManager_DeleteSubResources(t *testing.T) {
 					APIVersion: "deployment.servicefabrik.io/v1alpha1",
 					Kind:       "Director",
 					Name:       "instance-id",
-					Namespace:  "default",
+					Namespace:  constants.InteroperatorNamespace,
 				},
 			},
 			wantErr: false,
@@ -918,7 +920,7 @@ func Test_resourceManager_DeleteSubResources(t *testing.T) {
 						APIVersion: "deployment.servicefabrik.io/v1alpha1",
 						Kind:       "Director",
 						Name:       "instance-id",
-						Namespace:  "default",
+						Namespace:  constants.InteroperatorNamespace,
 					},
 				},
 			},
@@ -935,13 +937,13 @@ func Test_resourceManager_DeleteSubResources(t *testing.T) {
 						APIVersion: "deployment.servicefabrik.io/v1alpha1",
 						Kind:       "Director",
 						Name:       "instance-id",
-						Namespace:  "default",
+						Namespace:  constants.InteroperatorNamespace,
 					},
 					{
 						APIVersion: "deployment.servicefabrik.io/v1alpha1",
 						Kind:       "Director2",
 						Name:       "instance-id",
-						Namespace:  "default",
+						Namespace:  constants.InteroperatorNamespace,
 					},
 				},
 			},
@@ -950,7 +952,7 @@ func Test_resourceManager_DeleteSubResources(t *testing.T) {
 					APIVersion: "deployment.servicefabrik.io/v1alpha1",
 					Kind:       "Director2",
 					Name:       "instance-id",
-					Namespace:  "default",
+					Namespace:  constants.InteroperatorNamespace,
 				},
 			},
 			wantErr: true,

--- a/interoperator/internal/services/services_test.go
+++ b/interoperator/internal/services/services_test.go
@@ -11,6 +11,7 @@ import (
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +90,7 @@ func TestFindServiceInfo(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "plan-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels:    map[string]string{"serviceId": "service-id", "planId": "plan-id"},
 		},
 		Spec: osbv1alpha1.SFPlanSpec{
@@ -115,7 +116,7 @@ func TestFindServiceInfo(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "service-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 			Labels:    map[string]string{"serviceId": "service-id"},
 		},
 		Spec: osbv1alpha1.SFServiceSpec{
@@ -138,8 +139,8 @@ func TestFindServiceInfo(t *testing.T) {
 		},
 	}
 
-	var serviceKey = types.NamespacedName{Name: "service-id", Namespace: "default"}
-	var planKey = types.NamespacedName{Name: "plan-id", Namespace: "default"}
+	var serviceKey = types.NamespacedName{Name: "service-id", Namespace: constants.InteroperatorNamespace}
+	var planKey = types.NamespacedName{Name: "plan-id", Namespace: constants.InteroperatorNamespace}
 
 	g.Expect(c.Create(context.TODO(), service)).NotTo(gomega.HaveOccurred())
 	g.Expect(c.Create(context.TODO(), plan)).NotTo(gomega.HaveOccurred())
@@ -171,7 +172,7 @@ func TestFindServiceInfo(t *testing.T) {
 				client:    c,
 				serviceID: service.ObjectMeta.Name,
 				planID:    plan.ObjectMeta.Name,
-				namespace: "default",
+				namespace: constants.InteroperatorNamespace,
 			},
 			want:    service,
 			want1:   plan,
@@ -183,7 +184,7 @@ func TestFindServiceInfo(t *testing.T) {
 				client:    c,
 				serviceID: "non-existent-service",
 				planID:    plan.ObjectMeta.Name,
-				namespace: "default",
+				namespace: constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			want1:   nil,
@@ -195,7 +196,7 @@ func TestFindServiceInfo(t *testing.T) {
 				client:    c,
 				serviceID: service.ObjectMeta.Name,
 				planID:    "non-existent-plan",
-				namespace: "default",
+				namespace: constants.InteroperatorNamespace,
 			},
 			want:    nil,
 			want1:   nil,

--- a/interoperator/main.go
+++ b/interoperator/main.go
@@ -58,10 +58,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
-	leaderElectionNamespace := os.Getenv(constants.NamespaceEnvKey)
-	if leaderElectionNamespace == "" {
-		leaderElectionNamespace = constants.DefaultServiceFabrikNamespace
-	}
+	leaderElectionNamespace := constants.InteroperatorNamespace
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,

--- a/interoperator/pkg/cluster/registry/registry.go
+++ b/interoperator/pkg/cluster/registry/registry.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"os"
 
 	resourceV1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
@@ -54,10 +53,7 @@ func New(kubeConfig *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper
 		return nil, err
 	}
 
-	sfNamespace := os.Getenv(constants.NamespaceEnvKey)
-	if sfNamespace == "" {
-		sfNamespace = constants.DefaultServiceFabrikNamespace
-	}
+	sfNamespace := constants.InteroperatorNamespace
 
 	r := &clusterRegistry{
 		scheme:     scheme,

--- a/interoperator/pkg/cluster/registry/registry_test.go
+++ b/interoperator/pkg/cluster/registry/registry_test.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	resourceV1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -249,7 +250,7 @@ func _getDummyCluster() *resourceV1alpha1.SFCluster {
 	return &resourceV1alpha1.SFCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Spec: resourceV1alpha1.SFClusterSpec{},
 	}
@@ -260,7 +261,7 @@ func _getDummySecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster-id",
-			Namespace: "default",
+			Namespace: constants.InteroperatorNamespace,
 		},
 		Data: data,
 	}

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"os"
 	"time"
 )
 
@@ -12,24 +13,44 @@ const (
 	LastOperationKey                      = "interoperator.servicefabrik.io/lastoperation"
 	ErrorThreshold                        = 10
 
-	ConfigMapName          = "interoperator-config"
-	ConfigMapKey           = "config"
-	NamespaceEnvKey        = "POD_NAMESPACE"
-	OwnClusterIDEnvKey     = "CLUSTER_ID"
-	DefaultMasterClusterID = "1"
-	ProvisionerName        = "provisioner"
+	ConfigMapName   = "interoperator-config"
+	ConfigMapKey    = "config"
+	ProvisionerName = "provisioner"
+
+	namespaceEnvKey    = "POD_NAMESPACE"
+	OwnClusterIDEnvKey = "CLUSTER_ID"
+
+	NamespaceLabelKey = "OWNER_INTEROPERATOR_NAMESPACE"
 
 	MultiClusterWatchTimeout = 28800 // 8 hours in seconds
 
-	DefaultServiceFabrikNamespace = "default"
 	DefaultInstanceWorkerCount    = 10
 	DefaultBindingWorkerCount     = 20
 	DefaultSchedulerWorkerCount   = 10
 	DefaultProvisionerWorkerCount = 10
 
-	DefaultSchedulerType       = "default"
+	DefaultSchedulerType = "default"
+
 	LabelSelectorSchedulerType = "label-selector"
 	GoTemplateType             = "gotemplate"
 
 	PlanWatchDrainTimeout = time.Second * 2
 )
+
+// Configs initialized at startup
+var (
+	InteroperatorNamespace = "default"
+	OwnClusterID           = "1" // "1" is the DefaultMasterClusterID
+)
+
+func init() {
+	interoperatorNamespace, ok := os.LookupEnv(namespaceEnvKey)
+	if ok {
+		InteroperatorNamespace = interoperatorNamespace
+	}
+
+	ownClusterID, ok := os.LookupEnv(OwnClusterIDEnvKey)
+	if ok {
+		OwnClusterID = ownClusterID
+	}
+}

--- a/interoperator/pkg/utils/owner_reference.go
+++ b/interoperator/pkg/utils/owner_reference.go
@@ -1,14 +1,31 @@
-package resources
+package utils
 
 import (
 	"fmt"
 
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.Log.WithName("utils")
+
+// SetOwnerReference is almost as same as controllerutil.SetControllerReference
+// This implementation does set Controller field and BlockOwnerDeletion as false
+// It also adds Interoperator Namespace Label for Filtering watch requests
+func SetOwnerReference(owner, object metav1.Object, scheme *runtime.Scheme) error {
+	if err := setOwnerReference(owner, object, scheme); err != nil {
+		log.Error(err, "failed setting owner reference for resource", "owner", owner, "resource", object)
+		return err
+	}
+	// Set Interoperator Namespace Label for Filtering watch requests
+	setInteroperatorNamespaceLabel(owner, object)
+	return nil
+}
 
 // setOwnerReference is almost as same as controllerutil.SetControllerReference
 // This implementation does set Controller field and BlockOwnerDeletion as false

--- a/interoperator/pkg/utils/owner_reference_test.go
+++ b/interoperator/pkg/utils/owner_reference_test.go
@@ -1,15 +1,44 @@
-package resources
+package utils
 
 import (
+	stdlog "log"
+	"os"
+	"path/filepath"
 	"testing"
 
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
+
+func TestMain(m *testing.M) {
+	t := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	var err error
+
+	err = osbv1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	err = resourcev1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	code := m.Run()
+	t.Stop()
+	os.Exit(code)
+}
 
 func Test_setOwnerReference(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
@@ -270,5 +299,102 @@ func Test_setInteroperatorNamespaceLabel(t *testing.T) {
 			}
 			setInteroperatorNamespaceLabel(tt.args.owner, tt.args.object)
 		})
+	}
+}
+
+func _getDummyInstance() *osbv1alpha1.SFServiceInstance {
+	return &osbv1alpha1.SFServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "instance-id",
+			Namespace: constants.InteroperatorNamespace,
+		},
+		Spec: osbv1alpha1.SFServiceInstanceSpec{
+			ServiceID: "service-id",
+			PlanID:    "plan-id",
+		},
+		Status: osbv1alpha1.SFServiceInstanceStatus{
+			DashboardURL: "",
+			State:        "",
+			Error:        "",
+			Description:  "",
+			Resources: []osbv1alpha1.Source{
+				{
+					APIVersion: "v1alpha1",
+					Kind:       "Director",
+					Name:       "dddd",
+					Namespace:  constants.InteroperatorNamespace,
+				},
+			},
+		},
+	}
+}
+
+func _getDummyBinding() *osbv1alpha1.SFServiceBinding {
+	return &osbv1alpha1.SFServiceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "binding-id",
+			Namespace: constants.InteroperatorNamespace,
+		},
+	}
+}
+
+func _getDummyPlan() *osbv1alpha1.SFPlan {
+	templateSpec := []osbv1alpha1.TemplateSpec{
+		{
+			Action:  "provision",
+			Type:    "gotemplate",
+			Content: "provisionContent",
+		},
+		{
+			Action:  "bind",
+			Type:    "gotemplate",
+			Content: "bindContent",
+		},
+		{
+			Action:  "status",
+			Type:    "gotemplate",
+			Content: "statusContent",
+		},
+		{
+			Action: "sources",
+			Type:   "gotemplate",
+			Content: `{{- $instanceID := "" }}
+{{- $bindingID := "" }}
+{{- with .instance.metadata.name }} {{ $instanceID = . }} {{ end }}
+{{- with .binding.metadata.name }} {{ $bindingID = . }} {{ end }}
+{{- $namespace := "" }}
+{{- with .instance.metadata.namespace }} {{ $namespace = . }} {{ end }}
+config:
+  apiVersion: "v1"
+  kind: ConfigMap
+  name: {{ $instanceID }}
+  namespace: {{ $namespace }}`,
+		},
+	}
+	return &osbv1alpha1.SFPlan{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SFPlan",
+			APIVersion: "osb.servicefabrik.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plan-id",
+			Namespace: constants.InteroperatorNamespace,
+			Labels:    map[string]string{"serviceId": "service-id", "planId": "plan-id"},
+		},
+		Spec: osbv1alpha1.SFPlanSpec{
+			Name:          "plan-name",
+			ID:            "plan-id",
+			Description:   "description",
+			Metadata:      nil,
+			Free:          false,
+			Bindable:      true,
+			PlanUpdatable: true,
+			Schemas:       nil,
+			Templates:     templateSpec,
+			ServiceID:     "service-id",
+			RawContext:    nil,
+			Manager:       nil,
+		},
+		Status: osbv1alpha1.SFPlanStatus{},
 	}
 }


### PR DESCRIPTION
## Feature
Provide a way to install and operator multiple Interoperator in same cluster in different namespaces managing different services

## Flow
- Broker adds a label on SFServiceInstance and SFServiceBinding
  - Label name: `OWNER_INTEROPERATOR_NAMESPACE`
  - Value: namespace in which interoperator is deployed
- Interoperator add the same label on all the created resources
- On watch events for Instance and Binding controllers
  - If label is absent, use event
  - If label is present and namespace is equal to interoperator namespace, use event
  - If label is present and namespace is not equal to interoperator namespace, drop event
- On watch events for `SFPlan`, `SFService`, `SFCluster`
  - If namespace same as interoperator namespace, use event
  - If namespace different from interoperator namespace, drop event

## Broker Changes
- Broker reads `POD_NAMESPACE` env variable as `sf_namespace`. Only available in k8s deployment
- When creating `SFServiceInstance` and `SFServiceBinding`:
  - If `sf_namespace` is set:  Add `OWNER_INTEROPERATOR_NAMESPACE` label
  - If `sf_namespace` is not set:  Extra label not added
- When fetching `SFService` and `SFPlan`:
  - If `sf_namespace` is set:  Fetch only from that namespace
  - If `sf_namespace` is not set:  Fetch from all namespaces.
- `DEFAULT_NAMESPACE` replaced with `_.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE)`

## Deploying multiple interoperator in the same cluster

Multiple instances of interoperator can be deployed on a single cluster. But each instance must be deployed in a separate namespace. Only one instance of interoperator can be deployed in one namespace. The the custom resources like `sfservice`, `sfplans` and `sfcluster` (along with the `secret` it refers to) related on deployment of interoperator must be created in the namespace where interoperator is deployed. 

Deploy the first instance of interoperator on a cluster 
```shell
helm install --set cluster.host=sf.ingress.< clusterdomain > --set installCRDS=true --name interoperator --namespace interoperator [--version <helm chart version>] sf-charts/interoperator
```

All the subsequent installations must use `installCRDS=false` flag during the installation
```shell
helm install --set cluster.host=sf.ingress.< clusterdomain > --set installCRDS=false --name interoperator --namespace interoperator [--version <helm chart version>] sf-charts/interoperator
```