### PR TITLE
Adding default login_hint as sap.ids

### DIFF
--- a/broker/applications/extensions/src/api-controllers/DashboardController.js
+++ b/broker/applications/extensions/src/api-controllers/DashboardController.js
@@ -286,7 +286,7 @@ function saveSession(session) {
 }
 
 function manageInstancePath(session) {
-  return session.instance_type ? `/manage/dashboards/${session.instance_type}/instances/${session.instance_id}` : `/manage/instances/${session.service_id}/${session.plan_id}/${session.instance_id}`;
+  return session.instance_type ? `/manage/dashboards/${session.instance_type}/instances/${session.instance_id}?login_hint=${session.login_hint}` : `/manage/instances/${session.service_id}/${session.plan_id}/${session.instance_id}?login_hint=${session.login_hint}`;
 }
 
 function createService(plan_id, instance_id, context) {

--- a/broker/applications/extensions/src/api-controllers/DashboardController.js
+++ b/broker/applications/extensions/src/api-controllers/DashboardController.js
@@ -124,7 +124,7 @@ class DashboardController extends FabrikBaseController {
   validateSession(req, res) {
     /* jshint unused:false */
     logger.info(`Validating session '${req.session.id}'`);
-    if ((!req.session.service_id || req.session.service_id === req.params.service_id) || (!req.session.instance_type || req.session.instance_type === req.params.instance_type)) {
+    if ((!req.session.service_id || req.session.service_id === req.params.service_id) || (!req.session.instance_type || req.session.instance_type === req.params.instance_type) || (!req.session.login_hint || req.session.login_hint === req.query.login_hint || req.session.login_hint === 'sap.ids')) {
       throw new ContinueWithNext();
     }
     logger.info('Regenerating session...');
@@ -207,6 +207,8 @@ class DashboardController extends FabrikBaseController {
     req.session.instance_type = req.params.instance_type;
     if (req.query.login_hint) {
       req.session.login_hint = req.query.login_hint;
+    } else {
+      req.session.login_hint = 'sap.ids';
     }
     const oldestAllowableLastSeen = Date.now() - config.external.session_expiry * 1000;
     if (req.session.user_id && req.session.access_token && req.session.last_seen > oldestAllowableLastSeen) {

--- a/broker/test/test_broker/acceptance/dashboard.director.spec.js
+++ b/broker/test/test_broker/acceptance/dashboard.director.spec.js
@@ -70,7 +70,7 @@ describe('dashboard', function () {
       it('should redirect to authorization server', function () {
         const agent = chai.request.agent(app);
         agent.app.listen(0);
-        mocks.uaa.getAuthorizationCode(service_id);
+        mocks.uaa.getAuthorizationCodeLoginHint(service_id, 1, 'sap.ids');
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getAccessToken();
         mocks.uaa.getUserInfo();
@@ -119,7 +119,7 @@ describe('dashboard', function () {
       it('should redirect to authorization server(in case of no context)', function () {
         const agent = chai.request.agent(app);
         agent.app.listen(0);
-        mocks.uaa.getAuthorizationCode(service_id);
+        mocks.uaa.getAuthorizationCodeLoginHint(service_id, 1, 'sap.ids');
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
@@ -175,7 +175,7 @@ describe('dashboard', function () {
       it('should redirect to authorization server', function () {
         const agent = chai.request.agent(app);
         agent.app.listen(0);
-        mocks.uaa.getAuthorizationCode(service_id);
+        mocks.uaa.getAuthorizationCodeLoginHint(service_id, 1, 'sap.ids');
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
@@ -222,7 +222,7 @@ describe('dashboard', function () {
       it('should use spec.options to fetch resource data when status.appliedOptions is not present', function () {
         const agent = chai.request.agent(app);
         agent.app.listen(0);
-        mocks.uaa.getAuthorizationCode(service_id);
+        mocks.uaa.getAuthorizationCodeLoginHint(service_id, 1, 'sap.ids');
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
@@ -271,7 +271,7 @@ describe('dashboard', function () {
       it('should handle login_hint query param if present', function () {
         const agent = chai.request.agent(app);
         agent.app.listen(0);
-        mocks.uaa.getAuthorizationCodeLoginHint(service_id);
+        mocks.uaa.getAuthorizationCodeLoginHint(service_id, 1, 'uaa');
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);

--- a/broker/test/test_broker/acceptance/dashboard.docker.spec.js
+++ b/broker/test/test_broker/acceptance/dashboard.docker.spec.js
@@ -66,7 +66,7 @@ describe('dashboard', function () {
       it('should redirect to authorization server', function () {
         const agent = chai.request.agent(app);
         agent.app.listen(0);
-        mocks.uaa.getAuthorizationCode(service_id);
+        mocks.uaa.getAuthorizationCodeLoginHint(service_id, 1, 'sap.ids');
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
@@ -121,7 +121,7 @@ describe('dashboard', function () {
       it('should redirect to authorization server', function () {
         const agent = chai.request.agent(app);
         agent.app.listen(0);
-        mocks.uaa.getAuthorizationCode(service_id);
+        mocks.uaa.getAuthorizationCodeLoginHint(service_id, 1, 'sap.ids');
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);

--- a/broker/test/test_broker/acceptance/dashboard.virtualHost.spec.js
+++ b/broker/test/test_broker/acceptance/dashboard.virtualHost.spec.js
@@ -92,7 +92,7 @@ describe('dashboard', function () {
       it('should redirect to authorization server', function () {
         const agent = chai.request.agent(app);
         agent.app.listen(0);
-        mocks.uaa.getAuthorizationCode(service_id);
+        mocks.uaa.getAuthorizationCodeLoginHint(service_id, 1, 'sap.ids');
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);
@@ -144,7 +144,7 @@ describe('dashboard', function () {
       it('should redirect to authorization server', function () {
         const agent = chai.request.agent(app);
         agent.app.listen(0);
-        mocks.uaa.getAuthorizationCode(service_id);
+        mocks.uaa.getAuthorizationCodeLoginHint(service_id, 1, 'sap.ids');
         mocks.uaa.getAccessTokenWithAuthorizationCode(service_id);
         mocks.uaa.getUserInfo();
         mocks.cloudController.getServiceInstancePermissions(instance_id);

--- a/broker/test/test_broker/mocks/uaa.js
+++ b/broker/test/test_broker/mocks/uaa.js
@@ -124,7 +124,7 @@ function getAuthorizationCode(service_id, times) {
     });
 }
 
-function getAuthorizationCodeLoginHint(service_id, times) {
+function getAuthorizationCodeLoginHint(service_id, times, loginHint) {
   const dashboard_client = catalog.getService(service_id).dashboard_client;
   return nock(authorizationEndpointUrl)
     .get('/oauth/authorize')
@@ -136,7 +136,7 @@ function getAuthorizationCodeLoginHint(service_id, times) {
         client_id: dashboard_client.id,
         redirect_uri: redirect_uri,
         scope: 'cloud_controller_service_permissions.read openid',
-        login_hint: '{"origin":"uaa"}'
+        login_hint: `{"origin":"${loginHint}"}`
       })
       .value()
     )


### PR DESCRIPTION
* It is necessary as currently `login_hint` param is not set when sending authorization request to UAA if it's not provided in the dashboard URL. And with this change by default `sap.ids` will be used as `login_hint`.
* Also this enables adding check for `login_hint` in `validateSession` while dashboard rendering.
