### PR TITLE
Pass selfsigned module to generate ssl certificate

### DIFF
--- a/broker/applications/operators/bosh-operator/DirectorService.js
+++ b/broker/applications/operators/bosh-operator/DirectorService.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const Promise = require('bluebird');
 const _ = require('lodash');
 const yaml = require('js-yaml');
+const selfSigned = require('selfsigned');
 
 const config = require('@sf/app-config');
 const logger = require('@sf/logger');
@@ -954,7 +955,8 @@ class DirectorService extends BaseDirectorService {
           multi_az_enabled: isMultiAzEnabled,
           stemcell: this.stemcell,
           actions: preDeployResponse,
-          preUpdateAgentResponse: preUpdateAgentResponse
+          preUpdateAgentResponse: preUpdateAgentResponse,
+          selfSigned: selfSigned
         }, opts.context));
         logger.info('Predeploy response -', preDeployResponse);
         logger.info('Multi-az Enabled : ', context.spec.multi_az_enabled);

--- a/broker/applications/package.json
+++ b/broker/applications/package.json
@@ -69,6 +69,7 @@
     "request": "2.84.0",
     "riemannjs": "1.0.1",
     "rxjs": "5.4.0",
+    "selfsigned": "1.10.7",
     "session-file-store": "0.2.0",
     "ssh2": "^0.8.2",
     "uuid": "2.0.2",


### PR DESCRIPTION
Backing services provisioned by SF might need self-signed ssl certificate support. 
This PR add [`selfsigned`](https://www.npmjs.com/package/selfsigned) npm module and code which can be used by the backing services to generate self-signed certificate.