### PR TITLE
Allow custom error messages for invalid quota & send instance_id

### DIFF
--- a/broker/applications/osb-broker/src/api-controllers/middleware/QuotaClient.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/QuotaClient.js
@@ -40,7 +40,10 @@ class QuotaClient extends HttpClient {
       json: true
     }, CONST.HTTP_STATUS_CODE.OK);
     logger.info(`Quota app returned following quotaValidStatus: ${res.body.quotaValidStatus}`);
-    return res.body.quotaValidStatus;
+    return {
+      quotaValid: res.body.quotaValidStatus,
+      message: _.get(res, 'message')
+    };
   }
   async putCompositeQuotaInfo(options) {
     const subaccountId = _.get(options, 'subaccountId');
@@ -55,7 +58,10 @@ class QuotaClient extends HttpClient {
       json: true
     }, CONST.HTTP_STATUS_CODE.OK);
     logger.info(`Quota app returned following quotaValidStatus: ${res.body.quotaValidStatus}`);
-    return res.body.quotaValidStatus;
+    return {
+      quotaValid: res.body.quotaValidStatus,
+      message: _.get(res, 'message')
+    };
   }
 }
 

--- a/broker/applications/osb-broker/src/api-controllers/middleware/QuotaClient.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/QuotaClient.js
@@ -42,7 +42,7 @@ class QuotaClient extends HttpClient {
     logger.info(`Quota app returned following quotaValidStatus: ${res.body.quotaValidStatus}`);
     return {
       quotaValid: res.body.quotaValidStatus,
-      message: _.get(res, 'message')
+      message: _.get(res.body, 'message')
     };
   }
   async putCompositeQuotaInfo(options) {
@@ -60,7 +60,7 @@ class QuotaClient extends HttpClient {
     logger.info(`Quota app returned following quotaValidStatus: ${res.body.quotaValidStatus}`);
     return {
       quotaValid: res.body.quotaValidStatus,
-      message: _.get(res, 'message')
+      message: _.get(res.body, 'message')
     };
   }
 }

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -81,15 +81,15 @@ exports.checkQuota = function () {
           quotaClientOptions.data = _.cloneDeep(req.body);
         }
         return quotaClient.checkQuotaValidity(quotaClientOptions, instanceBasedQuota)
-          .then(quotaValid => {
+          .then(({ quotaValid, message }) => {
             const plan = getPlanFromRequest(req);
             logger.debug(`quota api response : ${quotaValid}`);
             if (quotaValid === CONST.QUOTA_API_RESPONSE_CODES.NOT_ENTITLED) {
               logger.error(`[QUOTA] Not entitled to create service instance: org '${req.body.organization_guid}', subaccount '${subaccountId}', service '${plan.service.name}', plan '${plan.name}'`);
-              next(new Forbidden('Not entitled to create service instance'));
+              next(new Forbidden(message ? message : 'Not entitled to create service instance'));
             } else if (quotaValid === CONST.QUOTA_API_RESPONSE_CODES.INVALID_QUOTA) {
               logger.error(`[QUOTA] Quota is not sufficient for this request: org '${req.body.organization_guid}', subaccount '${subaccountId}', service '${plan.service.name}', plan '${plan.name}'`);
-              next(new Forbidden('Quota is not sufficient for this request'));
+              next(new Forbidden(message ? message : 'Quota is not sufficient for this request'));
             } else {
               logger.debug('[Quota]: calling next handler..');
               next();

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -79,6 +79,7 @@ exports.checkQuota = function () {
         const instanceBasedQuota = supportsInstanceBasedQuota(req.body.service_id);
         if(!instanceBasedQuota) {
           quotaClientOptions.data = _.cloneDeep(req.body);
+          _.set(quotaClientOptions.data, 'instance_id', req.params.instance_id)
         }
         return quotaClient.checkQuotaValidity(quotaClientOptions, instanceBasedQuota)
           .then(({ quotaValid, message }) => {

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -79,7 +79,7 @@ exports.checkQuota = function () {
         const instanceBasedQuota = supportsInstanceBasedQuota(req.body.service_id);
         if(!instanceBasedQuota) {
           quotaClientOptions.data = _.cloneDeep(req.body);
-          _.set(quotaClientOptions.data, 'instance_id', req.params.instance_id)
+          _.set(quotaClientOptions.data, 'instance_id', req.params.instance_id);
         }
         return quotaClient.checkQuotaValidity(quotaClientOptions, instanceBasedQuota)
           .then(({ quotaValid, message }) => {

--- a/broker/test/test_broker/broker.middleware.QuotaClient.spec.js
+++ b/broker/test/test_broker/broker.middleware.QuotaClient.spec.js
@@ -33,7 +33,7 @@ describe('#QuotaClient', () => {
   });
   it('should make appropriate call for instance based quota', async () => {
     requestStub.resolves({body: { quotaValidStatus: 0}});
-    const quotaStatus = await quotaClient.checkQuotaValidity(reqOptions, true);
+    const { quotaValid } = await quotaClient.checkQuotaValidity(reqOptions, true);
     expect(requestStub).to.have.been.calledWithExactly({
       url: `${config.quota_app.quota_endpoint}/${subaccount_id}/quota`,
       method: CONST.HTTP_METHOD.GET,
@@ -43,10 +43,10 @@ describe('#QuotaClient', () => {
       },
       qs: _.get(reqOptions, 'queryParams'),
       json: true
-      }, 
+      },
       CONST.HTTP_STATUS_CODE.OK
     );
-    expect(quotaStatus).to.be.equal(0);
+    expect(quotaValid).to.be.equal(0);
   });
   it('should make appropriate call for non-instance based quota', async () => {
     reqOptions.data = {
@@ -54,7 +54,7 @@ describe('#QuotaClient', () => {
         context: {}
     };
     requestStub.resolves({body: { quotaValidStatus: 0}});
-    const quotaStatus = await quotaClient.checkQuotaValidity(reqOptions, false);
+    const { quotaValid } = await quotaClient.checkQuotaValidity(reqOptions, false);
     expect(requestStub).to.have.been.calledWithExactly({
       url: `${config.quota_app.quota_endpoint}/${subaccount_id}/quota`,
       method: CONST.HTTP_METHOD.PUT,
@@ -64,9 +64,9 @@ describe('#QuotaClient', () => {
       },
       body: _.get(reqOptions, 'data'),
       json: true
-      }, 
+      },
       CONST.HTTP_STATUS_CODE.OK
     );
-    expect(quotaStatus).to.be.equal(0);
+    expect(quotaValid).to.be.equal(0);
   });
 });

--- a/broker/test/test_broker/broker.middleware.spec.js
+++ b/broker/test/test_broker/broker.middleware.spec.js
@@ -214,6 +214,9 @@ describe('#checkQuota', () => {
       name: 'user',
       pass: 'secret'
     },
+    params: {
+      instance_id: '54ce7ed5-d1ca-466d-b043-81de527c74c7'
+    },
     body: {
       plan_id: 'bc158c9a-7934-401e-94ab-057082a5073f'
     }
@@ -365,7 +368,10 @@ describe('#checkQuota', () => {
         reqMethod: 'PATCH',
         orgId: organization_guid
       },
-      data: req.body
+      data: {
+        instance_id: '54ce7ed5-d1ca-466d-b043-81de527c74c7',
+        ...req.body
+      }
     }, false);
     getServiceStub.restore();
     return Promise.delay(PROMISE_WAIT_SIMULATED_DELAY)


### PR DESCRIPTION
This adds the possibility to allow custom error messages if the quota is invalid. The reason for this is that we may want to provide additional information why the entitlements are not sufficient.

In addition it forwards the instance_id to the non-instance based quota check. This is quite important to have for the update case.