### PR TITLE
Set log level to debug for pre-actions

### DIFF
--- a/broker/applications/deployment_hooks/src/lib/controllers/DeploymentHookController.js
+++ b/broker/applications/deployment_hooks/src/lib/controllers/DeploymentHookController.js
@@ -20,7 +20,7 @@ class DeploymentHookController extends HookBaseController {
     }
     return ActionManager
       .executeActions(req.body.phase, req.body.actions, req.body.context)
-      .tap(body => logger.info('Sending response body: ', body))
+      .tap(body => logger.debug('Sending response body: ', body))
       .then(body => res
         .status(200)
         .send(body));

--- a/broker/core/provisioner-services/src/DirectorService.js
+++ b/broker/core/provisioner-services/src/DirectorService.js
@@ -590,7 +590,7 @@ class DirectorService extends BaseDirectorService {
           .set('context', _.omit(context, 'params.previous_manifest'))
           .value();
         return deploymentHookClient.executeDeploymentActions(options)
-          .tap(actionResponse => logger.info(`${phase} response ...`, actionResponse));
+          .tap(actionResponse => logger.debug(`${phase} response ...`, actionResponse));
       } else {
         logger.info(`No actions to perform for ${context.deployment_name}`);
         return {};


### PR DESCRIPTION
Since the hooks may respond with service instance specific credentials, the response should not be logged on the info level.