### PR TITLE
Enable Dependabot for golang

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,16 @@ updates:
       - dependency-name: pkgcloud
       - dependency-name: dockerode
       - dependency-name: agenda
+  - package-ecosystem: "gomod"
+    directory: "/interoperator"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+  - package-ecosystem: "gomod"
+    directory: "/operator-apis"
+    schedule:
+      interval: "weekly"
+      day: "monday"
   - package-ecosystem: "docker"
     directory: "/broker"
     schedule:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ matrix:
         - go get -v honnef.co/go/tools/cmd/staticcheck
       install:
         - cd interoperator
-        - PKGS=$(go list ./... | grep -v /vendor/)
         - env GO111MODULE=on go mod download
         - cd ../webhooks
         - dep ensure -v
@@ -81,6 +80,7 @@ matrix:
         - env GO111MODULE=on go fmt ./api/... ./controllers/... ./internal/... ./pkg/... ./
         - env GO111MODULE=on go vet ./api/... ./controllers/... ./internal/... ./pkg/... ./
         - env GO111MODULE=on golint ./api/... ./controllers/... ./internal/... ./pkg/... ./
+        - PKGS=$(go list ./... | grep -v /vendor/)
         - staticcheck $PKGS
         - popd
         - pushd webhooks
@@ -92,6 +92,8 @@ matrix:
         - go fmt ./internal/...
         - go vet ./internal/...
         - golint ./internal/...
+        - PKGS=$(go list ./... | grep -v /vendor/)
+        - staticcheck $PKGS
         - popd
     - language: node_js
       node_js:


### PR DESCRIPTION
- For golang currently in alpha
- Enable go staticheck for operator apis

-[Need to run `go mod tidy`](https://github.com/agilepathway/label-checker/blob/master/.github/DEPENDENCIES.md#process-for-updating-go-modules-dependencies) manually on the Dependabot created branch