### PR TITLE
Switching dependency from Riemannjs to Riemann

### DIFF
--- a/broker/applications/admin/package.json
+++ b/broker/applications/admin/package.json
@@ -57,7 +57,7 @@
     "pubsub-js": "1.8.0",
     "pug": "3.0.0",
     "request": "2.88.2",
-    "riemannjs": "1.0.1",
+    "riemann": "2.0.0",
     "rxjs": "5.0.0",
     "session-file-store": "1.4.0",
     "ssh2": "0.8.9",

--- a/broker/applications/deployment_hooks/package.json
+++ b/broker/applications/deployment_hooks/package.json
@@ -51,7 +51,7 @@
     "pubsub-js": "1.8.0",
     "pug": "3.0.0",
     "request": "2.88.2",
-    "riemannjs": "1.0.1",
+    "riemann": "2.0.0",
     "rxjs": "5.0.0",
     "session-file-store": "1.4.0",
     "ssh2": "0.8.9",

--- a/broker/applications/extensions/package.json
+++ b/broker/applications/extensions/package.json
@@ -57,7 +57,7 @@
     "pubsub-js": "1.8.0",
     "pug": "3.0.0",
     "request": "2.88.2",
-    "riemannjs": "1.0.1",
+    "riemann": "2.0.0",
     "rxjs": "5.0.0",
     "session-file-store": "1.4.0",
     "ssh2": "0.8.9",

--- a/broker/applications/operators/package.json
+++ b/broker/applications/operators/package.json
@@ -59,7 +59,7 @@
     "pubsub-js": "1.8.0",
     "pug": "3.0.0",
     "request": "2.88.2",
-    "riemannjs": "1.0.1",
+    "riemann": "2.0.0",
     "rxjs": "5.0.0",
     "selfsigned": "1.10.7",
     "session-file-store": "1.4.0",

--- a/broker/applications/osb-broker/package.json
+++ b/broker/applications/osb-broker/package.json
@@ -35,7 +35,7 @@
     "pubsub-js": "1.8.0",
     "pug": "3.0.0",
     "request": "2.88.2",
-    "riemannjs": "1.0.1",
+    "riemann": "2.0.0",
     "rxjs": "5.0.0",
     "uuid": "8.2.0",
     "winston": "3.3.3",

--- a/broker/applications/quota-app/package.json
+++ b/broker/applications/quota-app/package.json
@@ -40,7 +40,7 @@
     "pubsub-js": "1.8.0",
     "pug": "3.0.0",
     "request": "2.88.2",
-    "riemannjs": "1.0.1",
+    "riemann": "2.0.0",
     "rxjs": "5.0.0",
     "uuid": "8.2.0",
     "winston": "3.3.3",

--- a/broker/applications/reports/package.json
+++ b/broker/applications/reports/package.json
@@ -51,7 +51,7 @@
     "pubsub-js": "1.8.0",
     "pug": "3.0.0",
     "request": "2.88.2",
-    "riemannjs": "1.0.1",
+    "riemann": "2.0.0",
     "rxjs": "5.0.0",
     "session-file-store": "1.4.0",
     "ssh2": "0.8.9",

--- a/broker/applications/scheduler/package.json
+++ b/broker/applications/scheduler/package.json
@@ -52,7 +52,7 @@
     "pubsub-js": "1.8.0",
     "pug": "3.0.0",
     "request": "2.88.2",
-    "riemannjs": "1.0.1",
+    "riemann": "2.0.0",
     "rxjs": "5.0.0",
     "session-file-store": "1.4.0",
     "ssh2": "0.8.9",

--- a/broker/core/utils/test/utils.EventLogRiemannClient.spec.js
+++ b/broker/core/utils/test/utils.EventLogRiemannClient.spec.js
@@ -144,6 +144,7 @@ describe('utils', function () {
             key: 'response',
             value: (typeof event.response === 'object' ? JSON.stringify(event.response) : event.response)
           }])
+          .set('metricF', event.metric)
           .value();
         riemannClient.handleEvent(config.internal.event_type, {
           event: event,
@@ -188,6 +189,7 @@ describe('utils', function () {
             key: 'response',
             value: (typeof event.response === 'object' ? JSON.stringify(event.response) : event.response)
           }])
+          .set('metricF', event.metric)
           .value();
         const expectedSecondResultObject = _
           .chain(event)
@@ -201,6 +203,7 @@ describe('utils', function () {
             key: 'response',
             value: (typeof event.response === 'object' ? JSON.stringify(event.response) : event.response)
           }])
+          .set('metricF', event.metric)
           .value();
 
         riemannClient.handleEvent(config.internal.event_type, {
@@ -249,6 +252,7 @@ describe('utils', function () {
             key: 'response',
             value: (typeof event.response === 'object' ? JSON.stringify(event.response) : event.response)
           }])
+          .set('metricF', event.metric)
           .value();
         const expectedSecondResultObject = _
           .chain(event)
@@ -262,6 +266,7 @@ describe('utils', function () {
             key: 'response',
             value: (typeof event.response === 'object' ? JSON.stringify(event.response) : event.response)
           }])
+          .set('metricF', event.metric)
           .value();
 
         riemannClient.handleEvent(config.internal.event_type, {
@@ -310,6 +315,7 @@ describe('utils', function () {
             key: 'response',
             value: (typeof event.response === 'object' ? JSON.stringify(event.response) : event.response)
           }])
+          .set('metricF', event.metric)
           .value();
         const expectedSecondResultObject = _
           .chain(event)
@@ -323,6 +329,7 @@ describe('utils', function () {
             key: 'response',
             value: (typeof event.response === 'object' ? JSON.stringify(event.response) : event.response)
           }])
+          .set('metricF', event.metric)
           .value();
 
         riemannClient.handleEvent(config.internal.event_type, {
@@ -422,6 +429,7 @@ describe('utils', function () {
             key: 'request',
             value: (typeof event.request === 'object' ? JSON.stringify(event.request) : event.request)
           }])
+          .set('metricF', event.metric)
           .value();
         expect(riemannClient.status).to.eql(CONST.EVENT_LOG_RIEMANN_CLIENT_STATUS.DISCONNECTED);
         riemannClient.handleEvent(config.internal.event_type, {

--- a/broker/core/utils/test/utils.EventLogRiemannClient.spec.js
+++ b/broker/core/utils/test/utils.EventLogRiemannClient.spec.js
@@ -19,7 +19,7 @@ const riemannJSStub = {
 
 let riemannClientEventHandlers = {};
 const RiemannClient = proxyquire('../../../data-access-layer/event-logger/src/EventLogRiemannClient', {
-  'riemannjs': {
+  'riemann': {
     createClient: function () {
       return {
         on: function (event, callback) {

--- a/broker/data-access-layer/event-logger/src/EventLogRiemannClient.js
+++ b/broker/data-access-layer/event-logger/src/EventLogRiemannClient.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const riemannClient = require('riemannjs');
+const riemannClient = require('riemann');
 const pubsub = require('pubsub-js');
 
 const logger = require('@sf/logger');

--- a/broker/data-access-layer/event-logger/src/EventLogRiemannClient.js
+++ b/broker/data-access-layer/event-logger/src/EventLogRiemannClient.js
@@ -158,6 +158,8 @@ class EventLogRiemannClient {
         return false;
       } else {
         try {
+          // Following line is added to handle https://github.com/riemann/riemann-nodejs-client/issues/36
+          _.set(info, 'metricF', info.metric); 
           logger.debug(`Trying to send event to riemann, attempt ${attempt} : `, info);
           this.riemannClient.send(this.riemannClient.Event(info));
           logger.debug('logging following to riemann : ', info);


### PR DESCRIPTION
We were dependent on https://www.npmjs.com/package/riemannjs which seems to be a [fork](https://github.com/sandfox/riemann-nodejs-client) of original https://www.npmjs.com/package/riemann from riemann official github [repo](https://github.com/riemann/riemann-nodejs-client).

Switching to this official one since the protobuf.js version used in the current one is outdated and has vulnerability.