### PR TITLE
Update nock to 13.0.4

### DIFF
--- a/broker/package.json
+++ b/broker/package.json
@@ -57,7 +57,7 @@
     "lerna": "^3.18.4",
     "mocha": "^2.5.3",
     "mocha-lcov-reporter": "^1.3.0",
-    "nock": "^8.0.0",
+    "nock": "^13.0.4",
     "prettier": "1.16.4",
     "prettier-eslint": "8.8.2",
     "prettier-eslint-cli": "4.7.1",

--- a/broker/test/test_broker/acceptance/service-broker-api.catalog.spec.js
+++ b/broker/test/test_broker/acceptance/service-broker-api.catalog.spec.js
@@ -35,7 +35,8 @@ describe('service-broker-api', function () {
             name: 's1'
           }
         }]
-      });
+      },
+        {});
       mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_PLANS, {
         items: [{
           spec: {
@@ -45,7 +46,8 @@ describe('service-broker-api', function () {
         }]
       }, {
         labelSelector: 'serviceId=service1'
-      });
+      },
+        {});
       config.apiserver.isServiceDefinitionAvailableOnApiserver = true;
       return chai.request(app)
         .get(`${baseCFUrl}/catalog`)

--- a/broker/test/test_broker/eventmesh.LockManager.spec.js
+++ b/broker/test/test_broker/eventmesh.LockManager.spec.js
@@ -290,7 +290,6 @@ describe('eventmesh', () => {
       it('should successfully unlock resource in first try given lockId', () => {
         const payload1 = {
           metadata: {
-            resourceVersion: samplelock6.metadata.resourceVersion,
             labels: {
               state: CONST.APISERVER.RESOURCE_STATE.UNLOCKED
             }
@@ -299,18 +298,19 @@ describe('eventmesh', () => {
             state: CONST.APISERVER.RESOURCE_STATE.UNLOCKED
           }
         };
-        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, 'samplelock6', samplelock6, 1, payload1);
-        return lockManager.unlock('samplelock6', samplelock6.metadata.resourceVersion)
+        const lockId = samplelock4.metadata.resourceVersion;
+        if (lockId) {
+          // update payload, if lockId is available
+          payload1.metadata.resourceVersion = lockId;
+        }
+        mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, 'samplelock4', samplelock4, 1, payload1);
+        return lockManager.unlock('samplelock4', lockId)
           .then(() => {
             mocks.verify();
           });
       });
       it('should successfully unlock resource in first try if lock is not found', () => {
-        const payload1 = {
-          metadata: {
-            resourceVersion: samplelock6.metadata.resourceVersion
-          }
-        };
+        const payload1 = {};
         mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, 'samplelock6', samplelock6, 1, payload1, 404);
         return lockManager.unlock('samplelock6', samplelock6.metadata.resourceVersion)
           .then(() => {
@@ -318,11 +318,7 @@ describe('eventmesh', () => {
           });
       });
       it('should successfully unlock resource in first try if apiserver returns conflict', () => {
-        const payload1 = {
-          metadata: {
-            resourceVersion: samplelock6.metadata.resourceVersion
-          }
-        };
+        const payload1 = {};
         mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, 'samplelock6', samplelock6, 1, payload1, 409);
         return lockManager.unlock('samplelock6', samplelock6.metadata.resourceVersion)
           .then(() => {

--- a/broker/test/test_broker/mocks/agent.js
+++ b/broker/test/test_broker/mocks/agent.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const nock = require('nock');
 const credentials = {
   host: 'example.org:31415',
@@ -69,7 +70,7 @@ function deprovision() {
 function preUpdate(expectedReturnStatusCode) {
   return nock(agentUrl)
     .replyContentLength()
-    .post('/v1/lifecycle/preupdate', {})
+    .post('/v1/lifecycle/preupdate', _.matches({}))
     .reply(expectedReturnStatusCode || 200, {});
 }
 
@@ -95,9 +96,9 @@ function createCredentials() {
 
 function deleteCredentials() {
   return nock(agentUrl)
-    .post('/v1/credentials/delete', {
+    .post('/v1/credentials/delete', _.matches({
       credentials: credentials
-    })
+    }))
     .reply(200);
 }
 

--- a/broker/test/test_broker/mocks/apiServerEventMesh.js
+++ b/broker/test/test_broker/mocks/apiServerEventMesh.js
@@ -104,7 +104,7 @@ function nockGetCrd(resourceGroup, resourceType, response, times, expectedStatus
 
 function nockCreateResource(resourceGroup, resourceType, response, times, verifier, expectedStatusCode) {
   nock(apiServerHost)
-    .post(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}`, verifier)
+    .post(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}`, _.matches(verifier))
     .times(times || 1)
     .reply(expectedStatusCode || 201, response);
 }
@@ -121,7 +121,9 @@ function nockPatchResource(resourceGroup, resourceType, id, response, times, pay
         'content-type': CONST.APISERVER.PATCH_CONTENT_TYPE
       }
     })
-    .patch(`/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}/${id}`, payload)
+    .patch(
+      `/apis/${resourceGroup}/v1alpha1/namespaces/default/${resourceType}/${id}`, _.matches(payload)
+    )
     .times(times || 1)
     .reply(expectedStatusCode || 200, response);
 }

--- a/broker/test/test_broker/mocks/cloudController.js
+++ b/broker/test/test_broker/mocks/cloudController.js
@@ -176,12 +176,9 @@ function getServicePlans(broker_guid, plan_guid, plan_unique_id) {
     });
 }
 
-function getSpaces(broker_guid, space_guid) {
+function getSpaces(space_guid) {
   return nock(cloudControllerUrl)
     .get('/v2/spaces')
-    .query({
-      q: `service_broker_guid:${broker_guid}`
-    })
     .reply(200, {
       resources: [{
         metadata: {
@@ -192,12 +189,9 @@ function getSpaces(broker_guid, space_guid) {
     });
 }
 
-function getOrganizations(broker_guid, org_guid) {
+function getOrganizations(org_guid) {
   return nock(cloudControllerUrl)
     .get('/v2/organizations')
-    .query({
-      q: `service_broker_guid:${broker_guid}`
-    })
     .reply(200, {
       resources: [{
         metadata: {

--- a/broker/test/test_broker/mocks/serviceBrokerClient.js
+++ b/broker/test/test_broker/mocks/serviceBrokerClient.js
@@ -31,7 +31,7 @@ function startDeploymentBackup(name, response, payload) {
   });
   return nock(serviceBrokerAdminUrl)
     .replyContentLength()
-    .post(`/admin/deployments/${name}/backup`, payload)
+    .post(`/admin/deployments/${name}/backup`, _.matches(payload))
     .reply(response.status || 202, {
       operation: 'backup',
       backup_guid: response.backup_guid || backupGuid,

--- a/broker/test/test_broker/mocks/uaa.js
+++ b/broker/test/test_broker/mocks/uaa.js
@@ -42,12 +42,12 @@ exports.jwtTokenOtherUser = jwtTokenOtherUser;
 
 function getAccessToken() {
   return nock(tokenEndpointUrl)
-    .post('/oauth/token', {
+    .post('/oauth/token', _.matches({
       grant_type: 'password',
       client_id: 'cf',
       username: 'admin',
       password: 'admin'
-    })
+    }))
     .reply(200, {
       access_token: jwtToken,
       refresh_token: jwtToken,
@@ -64,11 +64,11 @@ function getAccessTokenWithAuthorizationCode(service_id) {
       authorization: `Basic ${basicAuth}`
     }
   })
-    .post('/oauth/token', {
+    .post('/oauth/token', _.matches({
       grant_type: 'authorization_code',
       code: authorizationCode,
       redirect_uri: redirect_uri
-    })
+    }))
     .reply(200, {
       access_token: jwtToken,
       refresh_token: jwtToken,

--- a/broker/test/test_broker/operators.DirectorService.spec.js
+++ b/broker/test/test_broker/operators.DirectorService.spec.js
@@ -1568,7 +1568,7 @@ describe('#DirectorService', function () {
           mocks.cloudController.findSecurityGroupByName(binding_id, []);
           mocks.director.getDeploymentInstances(deployment_name);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeplResourceWithContext);
-          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id);
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, undefined, undefined, {});
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BIND, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR_BIND, binding_id, dummyBindResource, 1, 200);
           mocks.agent.getInfo();
           mocks.agent.deleteCredentials();

--- a/broker/test/test_broker/utils.spec.js
+++ b/broker/test/test_broker/utils.spec.js
@@ -505,7 +505,7 @@ describe('utils', function () {
           }
         }]
       };
-      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, expectedResponse);
+      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, expectedResponse, {});
       return utils.getAllServices()
         .then(res => {
           expect(res).to.eql([expectedResponse.items[0].spec]);
@@ -513,7 +513,7 @@ describe('utils', function () {
         });
     });
     it('Throws error on getting list of services from apiserver', () => {
-      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, {}, undefined, 1, 500);
+      mocks.apiServerEventMesh.nockGetResourcesAcrossAllNamespaces(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICES, {}, {}, 1, 500);
       return utils.getAllServices()
         .catch(err => {
           expect(err.status).to.eql(500);


### PR DESCRIPTION
The [nock](https://github.com/nock/nock) version used in Service Fabrik broker is `v8.0.0`.
Upgrade the nock version to `13.0.4`.
These are some breaking changes in nock 13.0.4 which affects Service Fabrik test cases.

## Strict Matching of Request Body

The nock version from [v9.0.19](https://github.com/nock/nock/releases/tag/v9.0.19) breaks the unit test cases of SF broker.
Most of the test cases which uses nock fails after the update.
The comparison of v9.0.18 and v9.0.19 is [here](https://github.com/nock/nock/compare/v9.0.18...v9.0.19).

The major change in the behaviour of nock from `v9.0.18` to `v9.0.19` is fix for the issue [#920](https://github.com/nock/nock/issues/920).
The support of partial matching of request body is replaced by a strict matching implementation by merge of [#921](https://github.com/nock/nock/pull/921).

###  Sample Issues from Test Case after Upgrading Nock

The test case, **Jobs ScheduleBackupJob #RunBackup**, failed.
 From nock debug logs,
 ```sh
nock.scope matching https://uaa.bosh-lite.com:443 to POST https://uaa.bosh-lite.com:443/oauth/token: true
nock.scope bodies don't match:
nock.scope  {
grant_type: 'password',
client_id: 'cf',
username: 'xxxxxx',
password: 'xxxxxx'
}
grant_type=password&client_id=cf&username=xxxxxx&password=xxxxxx&login_hint=xxxxxxxxxx
```
The error says, the nock scope `{"grant_type":"password","client_id":"cf","username":"xxxxxx","password":"xxxxxx"}` don't match `grant_type=password&client_id=cf&username=xxxxxx&password=xxxxxx&login_hint=xxxxxxxxxx` in request body due to the occurrence of login_hint. The same will pass in nock v9.0.18 since it is a partial match.

#### Current Implementation

Http request send from client is,
```json
{
  "method": "POST",
  "url": "/oauth/token",
  "auth": {
    "user": "cf",
    "pass": ""
  },
  "form": {
    "grant_type": "password",
    "client_id": "cf",
    "username": "xxxxxx",
    "password": "xxxxxx",
    "login_hint": "xxxxxxxxxx"
  }
}
```

The Nock snippet that intercepts this request is designed as,
```Javascript
function getAccessToken() {
  return nock(tokenEndpointUrl)
    .post('/oauth/token', {
      grant_type: 'password',
      client_id: 'cf',
      username: 'xxxxxx',
      password: 'xxxxxx'
    })
    .reply(200, {
      access_token: jwtToken,
      refresh_token: jwtToken,
      scope: 'cloud_controller.admin',
      token_type: 'bearer'
    });
}
```
The snippet is from `test/test_broker/mocks/uaa.js`. The `getAccessToken()` function is part of `before hook` of broker test cases.

#### Possible options to Perform Partial Match

[lodash.matches](https://lodash.com/docs/4.17.15#matches) can be used to achieve a partial match. The `getAccessToken()` will be,

```Javascript
const _ = require('lodash');

function getAccessToken() {
  return nock(tokenEndpointUrl)
    .post('/oauth/token', _.matches({
      grant_type: 'password',
      client_id: 'cf',
      username: 'xxxxxx',
      password: 'xxxxxx'
    }))
    .reply(200, {
      access_token: jwtToken,
      refresh_token: jwtToken,
      scope: 'cloud_controller.admin',
      token_type: 'bearer'
    });
}
```
In this configuration, we are setting a function (returned by lodash.matches) to perform the match of body.
More information [here](https://github.com/nock/nock#specifying-request-body).

## Strict Checks in Query String

From nock v11.0.0, `.query` method has strict checks. Nock throws error if the query string is not an instance of `url.URLSearchParams`.
Prior to this change, the `.query` method silently ignores the query string if it is not in the right format.

This behaviour breaks some of the test cases of Service Fabrik broker.
Some test cases passes `undefined` to `.query()` method which now throws an error and breaks the test case.

More information [here](https://github.com/nock/nock/blob/75507727cf09a0b7bf0aa7ebdf3621952921b82e/migration_guides/migrating_to_11.md#breaking-changes).

## Query Method Checks

Before nock v9.0.7, the `.query` method is ignored when making a request with no query string.
The request without querystring will not be validated with the checks in `.query`.
This is a bug which is fixed from nock v9.0.7.

More  information in [#610](https://github.com/nock/nock/issues/610) 

Please review these changes in test cases and let me know what you think!