### PR TITLE
adding middleware for injecting plan in the request

### DIFF
--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -13,6 +13,7 @@ const {
   },
   commonFunctions
 } = require('@sf/common-utils');
+const Promise = require('bluebird');
 const logger = require('@sf/logger');
 const config = require('@sf/app-config');
 const { catalog } = require('@sf/models');
@@ -117,18 +118,18 @@ exports.injectPlanInRequest = function() {
           resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
           resourceId: req.params.instance_id
         })
-        .then(resource => {
-          _.set(req, 'body.plan_id', _.get(resource, 'spec.options.planId'));
-          logger.info(`injected plan_id ${req.body.plan_id} in request for instance ${req.params.instance_id}`);
-        })
-        .catch(err => {
-          logger.warn(`resource could not be fetched for instance id ${req.params.instance_id}. Error: ${err}`);
-        })
-        .finally(() => next())
+          .then(resource => {
+            _.set(req, 'body.plan_id', _.get(resource, 'spec.planId'));
+            logger.info(`injected plan_id ${req.body.plan_id} in request for instance ${req.params.instance_id}`);
+          })
+          .catch(err => {
+            logger.warn(`resource could not be fetched for instance id ${req.params.instance_id}. Error: ${err}`);
+          })
+          .finally(() => next());
       }
-    })
-  }
-}
+    });
+  };
+};
 
 function getPlanFromRequest(req) {
   const plan_id = req.body.plan_id || req.query.plan_id;

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -116,7 +116,7 @@ exports.injectPlanInRequest = function() {
         return apiServerClient.getResource({
           resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
           resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
-          resourceId: req.params.instance_id
+          resourceId: commonFunctions.getKubernetesName(req.params.instance_id)
         })
           .then(resource => {
             _.set(req, 'body.plan_id', _.get(resource, 'spec.planId'));

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -16,7 +16,7 @@ const {
 const logger = require('@sf/logger');
 const config = require('@sf/app-config');
 const { catalog } = require('@sf/models');
-const { lockManager } = require('@sf/eventmesh');
+const { lockManager, apiServerClient } = require('@sf/eventmesh');
 const QuotaClient = require('./QuotaClient');
 
 exports.validateCreateRequest = function () {
@@ -103,6 +103,32 @@ exports.checkQuota = function () {
     }
   };
 };
+
+exports.injectPlanInRequest = function() {
+  return function (req, res, next) {
+    /* jshint unused:false */
+    return Promise.try(() => {
+      const plan_id = req.body.plan_id || req.query.plan_id;
+      if(!_.isEmpty(plan_id)) {
+        next();
+      } else {
+        return apiServerClient.getResource({
+          resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
+          resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
+          resourceId: req.params.instance_id
+        })
+        .then(resource => {
+          _.set(req, 'body.plan_id', _.get(resource, 'spec.options.planId'));
+          logger.info(`injected plan_id ${req.body.plan_id} in request for instance ${req.params.instance_id}`);
+        })
+        .catch(err => {
+          logger.warn(`resource could not be fetched for instance id ${req.params.instance_id}. Error: ${err}`);
+        })
+        .finally(() => next())
+      }
+    })
+  }
+}
 
 function getPlanFromRequest(req) {
   const plan_id = req.body.plan_id || req.query.plan_id;

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
@@ -31,7 +31,7 @@ router.use(middleware.error({
 /* Service Instance Router */
 instanceRouter.route('/')
   .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), middleware.validateSchemaForRequest('service_instance', 'create'), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
-  .patch([middleware.checkQuota(), middleware.validateRequest(), middleware.validateSchemaForRequest('service_instance', 'update'), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
+  .patch([middleware.injectPlanInRequest(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateSchemaForRequest('service_instance', 'update'), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
   .delete([middleware.validateRequest(), controller.handleWithResourceLocking('deleteInstance', CONST.OPERATION_TYPE.DELETE)])
   .all(middleware.methodNotAllowed(['PUT', 'PATCH', 'DELETE']));
 instanceRouter.route('/last_operation')

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -755,6 +755,86 @@ describe('service-broker-api-2.0', function () {
             });
         });
 
+        it('returns 202 Accepted if resource is already present and plan_id is not present in the request', function () {
+          const context = {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          };
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, {
+            spec: {
+              options: JSON.stringify({
+                lockedResourceDetails: {
+                  operation: 'update'
+                }
+              })
+            }
+          });
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.LOCK, CONST.APISERVER.RESOURCE_TYPES.DEPLOYMENT_LOCKS, instance_id, {
+            metadata: {
+              resourceVersion: 10
+            }
+          });
+          const testPayload = _.cloneDeep(payload);
+          testPayload.spec = camelcaseKeys(payload.spec);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {
+            spec: {
+              planId: plan_id_update
+            }
+          });
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, { spec: { parameters: null } });
+          mocks.apiServerEventMesh.nockPatchResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, testPayload);
+          return chai.request(app)
+            .patch(`${base_url}/service_instances/${instance_id}?accepts_incomplete=true`)
+            .send({
+              service_id: service_id,
+              parameters: parameters,
+              context: context,
+              previous_values: {
+                plan_id: plan_id,
+                service_id: service_id
+              }
+            })
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .then(res => {
+              mocks.verify();
+              expect(res).to.have.status(202);
+              expect(res.body.operation).to.deep.equal(commonFunctions.encodeBase64({
+                'type': 'update'
+              }));
+            });
+        });
+
+        it('returns ServicePlanNotFound error if resource could not be fetched and plan_id is not present in the request', function () {
+          const context = {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          };
+          const testPayload = _.cloneDeep(payload);
+          testPayload.spec = camelcaseKeys(payload.spec);
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1 , 500);
+          return chai.request(app)
+            .patch(`${base_url}/service_instances/${instance_id}?accepts_incomplete=true`)
+            .send({
+              service_id: service_id,
+              parameters: parameters,
+              context: context,
+              previous_values: {
+                plan_id: plan_id,
+                service_id: service_id
+              }
+            })
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .catch(err => err.response)
+            .then(res => {
+              mocks.verify();
+              expect(res).to.have.status(404);
+            });
+        });
+
         it('returns 422 Unprocessable Entity when accepts_incomplete not in query', function () {
           return chai.request(app)
             .patch(`${base_url}/service_instances/${instance_id}`)

--- a/broker/core/utils/src/commonFunctions.js
+++ b/broker/core/utils/src/commonFunctions.js
@@ -24,6 +24,7 @@ exports.uuidV4 = uuidV4;
 exports.sha224Sum = sha224Sum;
 exports.isValidKubernetesName = isValidKubernetesName;
 exports.isValidKubernetesLabelValue = isValidKubernetesLabelValue;
+exports.getKubernetesName = getKubernetesName;
 exports.isServiceFabrikOperation = isServiceFabrikOperation;
 exports.streamToPromise = streamToPromise;
 exports.isFeatureEnabled = isFeatureEnabled;
@@ -137,6 +138,13 @@ function isValidKubernetesName(str) {
 
   const dns1123SubdomainRegexp = new RegExp('^' + dns1123SubdomainFmt + '$');
   return dns1123SubdomainRegexp.test(str);
+}
+
+function getKubernetesName(id) {
+  if (isValidKubernetesName(id)) {
+    return id;
+  }
+  return sha224Sum(id);
 }
 
 // isValidKubernetesLabelValue tests whether the value passed is a valid label value.

--- a/broker/test/test_broker/fabrik.ServiceBrokerApi.spec.js
+++ b/broker/test/test_broker/fabrik.ServiceBrokerApi.spec.js
@@ -3,7 +3,8 @@
 const api = require('../../applications/osb-broker/src/api-controllers').serviceBrokerApi;
 const {
   commonFunctions: {
-    isValidKubernetesName
+    isValidKubernetesName,
+    getKubernetesName
   },
   errors: {
     PreconditionFailed,
@@ -78,13 +79,13 @@ describe('fabrik', function () {
       it('should return the same name if the name is valid', function () {
         const str = 'abcd.1234-efgh';
         expect(isValidKubernetesName(str)).to.be.true;
-        expect(api.getKubernetesName(str)).to.eql(str);
+        expect(getKubernetesName(str)).to.eql(str);
       });
 
       it('should return a valid name if it is invalid starting with -', function () {
         const str = '-abcd1234';
         expect(isValidKubernetesName(str)).to.be.false;
-        const res = api.getKubernetesName(str)
+        const res = getKubernetesName(str)
         expect(res).not.to.eql(str);
         expect(isValidKubernetesName(res)).to.be.true;
       });
@@ -92,7 +93,7 @@ describe('fabrik', function () {
       it('should return a valid name if it is invalid starting with .', function () {
         const str = '.abcd1234';
         expect(isValidKubernetesName(str)).to.be.false;
-        const res = api.getKubernetesName(str)
+        const res = getKubernetesName(str)
         expect(res).not.to.eql(str);
         expect(isValidKubernetesName(res)).to.be.true;
       });
@@ -100,7 +101,7 @@ describe('fabrik', function () {
       it('should return a valid name if it is invalid with upper case', function () {
         const str = 'abcD.1234';
         expect(isValidKubernetesName(str)).to.be.false;
-        const res = api.getKubernetesName(str)
+        const res = getKubernetesName(str)
         expect(res).not.to.eql(str);
         expect(isValidKubernetesName(res)).to.be.true;
       });


### PR DESCRIPTION
- To handle the cases where incoming request for updates might not contain `plan_id` (e.g., at present update requests coming in from `svcat` don't contain `plan_id`)