### PR TITLE
Support uppercase instance id

### DIFF
--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -87,7 +87,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
       'space_guid',
       'origin',
       'subaccount_id'
-    ]); 
+    ]);
+    _.set(params, 'instance_id', req.params.instance_id);
+
     function done(sfserviceinstance) {
       _.set(context, 'instance', sfserviceinstance);
       const dashboardUrl = this.getDashboardUrl(context);
@@ -236,6 +238,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             }
           });
         } else {
+          _.set(params, 'instance_id', req.params.instance_id);
           return eventmesh.apiServerClient.patchOSBResource({
             resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
             resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,

--- a/broker/core/utils/src/commonFunctions.js
+++ b/broker/core/utils/src/commonFunctions.js
@@ -21,6 +21,8 @@ exports.compareVersions = compareVersions;
 exports.encodeBase64 = encodeBase64;
 exports.decodeBase64 = decodeBase64;
 exports.uuidV4 = uuidV4;
+exports.sha224Sum = sha224Sum;
+exports.isValidKubernetesName = isValidKubernetesName;
 exports.isServiceFabrikOperation = isServiceFabrikOperation;
 exports.streamToPromise = streamToPromise;
 exports.isFeatureEnabled = isFeatureEnabled;
@@ -110,6 +112,30 @@ function uuidV4() {
     .then(buffer => uuid.v4({
       random: buffer
     }));
+}
+
+function sha224Sum(str) {
+  const hash = crypto.createHash('sha224');
+  hash.update(str, 'utf8');
+  return hash.digest('hex');
+}
+
+function isValidKubernetesName(str) {
+  // "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters,
+  // '-' or '.', and must start and end with an alphanumeric character"
+  const dns1123LabelFmt = '[a-z0-9]([-a-z0-9]*[a-z0-9])?';
+
+  const dns1123SubdomainFmt = dns1123LabelFmt + '(\\.' + dns1123LabelFmt + ')*';
+
+  // DNS1123SubdomainMaxLength is a subdomain's max length in DNS (RFC 1123)
+  const DNS1123SubdomainMaxLength = 253;
+
+  if (str.length <= 0 || str.length > DNS1123SubdomainMaxLength) {
+    return false;
+  }
+
+  const dns1123SubdomainRegexp = new RegExp('^' + dns1123SubdomainFmt + '$');
+  return dns1123SubdomainRegexp.test(str);
 }
 
 function isServiceFabrikOperation(params) {

--- a/broker/core/utils/src/commonFunctions.js
+++ b/broker/core/utils/src/commonFunctions.js
@@ -23,6 +23,7 @@ exports.decodeBase64 = decodeBase64;
 exports.uuidV4 = uuidV4;
 exports.sha224Sum = sha224Sum;
 exports.isValidKubernetesName = isValidKubernetesName;
+exports.isValidKubernetesLabelValue = isValidKubernetesLabelValue;
 exports.isServiceFabrikOperation = isServiceFabrikOperation;
 exports.streamToPromise = streamToPromise;
 exports.isFeatureEnabled = isFeatureEnabled;
@@ -136,6 +137,26 @@ function isValidKubernetesName(str) {
 
   const dns1123SubdomainRegexp = new RegExp('^' + dns1123SubdomainFmt + '$');
   return dns1123SubdomainRegexp.test(str);
+}
+
+// isValidKubernetesLabelValue tests whether the value passed is a valid label value.
+// a valid label must be an empty string or consist of alphanumeric characters, '-', '_' 
+// or '.', and must start and end with an alphanumeric character
+function isValidKubernetesLabelValue(value) {
+  const qnameCharFmt = '[A-Za-z0-9]';
+  const qnameExtCharFmt = '[-A-Za-z0-9_.]';
+  const qualifiedNameFmt = '(' + qnameCharFmt + qnameExtCharFmt + '*)?' + qnameCharFmt;
+  const labelValueFmt = '(' + qualifiedNameFmt + ')?';
+
+  // LabelValueMaxLength is a label's max length
+  const LabelValueMaxLength = 63;
+
+  const labelValueRegexp = new RegExp('^' + labelValueFmt + '$');
+
+  if (value.length > LabelValueMaxLength) {
+    return false;
+  }
+  return labelValueRegexp.test(value);
 }
 
 function isServiceFabrikOperation(params) {

--- a/broker/test/test_broker/fabrik.ServiceBrokerApi.spec.js
+++ b/broker/test/test_broker/fabrik.ServiceBrokerApi.spec.js
@@ -2,6 +2,9 @@
 
 const api = require('../../applications/osb-broker/src/api-controllers').serviceBrokerApi;
 const {
+  commonFunctions: {
+    isValidKubernetesName
+  },
   errors: {
     PreconditionFailed,
     ContinueWithNext
@@ -69,6 +72,38 @@ describe('fabrik', function () {
           .catch(err => expect(err).to.be.instanceof(ContinueWithNext));
       });
 
+    });
+
+    describe('#getKubernetesName', function () {
+      it('should return the same name if the name is valid', function () {
+        const str = 'abcd.1234-efgh';
+        expect(isValidKubernetesName(str)).to.be.true;
+        expect(api.getKubernetesName(str)).to.eql(str);
+      });
+
+      it('should return a valid name if it is invalid starting with -', function () {
+        const str = '-abcd1234';
+        expect(isValidKubernetesName(str)).to.be.false;
+        const res = api.getKubernetesName(str)
+        expect(res).not.to.eql(str);
+        expect(isValidKubernetesName(res)).to.be.true;
+      });
+
+      it('should return a valid name if it is invalid starting with .', function () {
+        const str = '.abcd1234';
+        expect(isValidKubernetesName(str)).to.be.false;
+        const res = api.getKubernetesName(str)
+        expect(res).not.to.eql(str);
+        expect(isValidKubernetesName(res)).to.be.true;
+      });
+
+      it('should return a valid name if it is invalid with upper case', function () {
+        const str = 'abcD.1234';
+        expect(isValidKubernetesName(str)).to.be.false;
+        const res = api.getKubernetesName(str)
+        expect(res).not.to.eql(str);
+        expect(isValidKubernetesName(res)).to.be.true;
+      });
     });
   });
 });

--- a/broker/test/test_broker/utils.spec.js
+++ b/broker/test/test_broker/utils.spec.js
@@ -58,6 +58,36 @@ describe('utils', function () {
     });
   });
 
+  describe('#sha224Sum', function () {
+    it('should return a valid kubernetes name', function () {
+      expect(commonFunctions.isValidKubernetesName(commonFunctions.sha224Sum('-abcd1234'))).to.be.true;
+    });
+    it('should return a valid kubernetes name', function () {
+      expect(commonFunctions.isValidKubernetesName(commonFunctions.sha224Sum('.abcd1234'))).to.be.true;
+    });
+    it('should return a valid kubernetes name', function () {
+      expect(commonFunctions.isValidKubernetesName(commonFunctions.sha224Sum('abcD1234'))).to.be.true;
+    });
+    it('should return a valid kubernetes name', function () {
+      expect(commonFunctions.isValidKubernetesName(commonFunctions.sha224Sum('abcd.1234-efgh'))).to.be.true;
+    });
+  });
+
+  describe('#isValidKubernetesName', function () {
+    it('should return false if str starts with -', function () {
+      expect(commonFunctions.isValidKubernetesName('-abcd1234')).to.be.false;
+    });
+    it('should return false if str starts with .', function () {
+      expect(commonFunctions.isValidKubernetesName('.abcd1234')).to.be.false;
+    });
+    it('should return false if str contains Uppercase with .', function () {
+      expect(commonFunctions.isValidKubernetesName('abcD1234')).to.be.false;
+    });
+    it('should return true if str consist of lower case alphanumeric characters, - or . ,  start and end with an alphanumeric character', function () {
+      expect(commonFunctions.isValidKubernetesName('abcd.1234-efgh')).to.be.true;
+    });
+  });
+
   describe('#isServiceFabrikOperation', function () {
     /* jshint expr:true */
     const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';

--- a/broker/test/test_broker/utils.spec.js
+++ b/broker/test/test_broker/utils.spec.js
@@ -83,8 +83,41 @@ describe('utils', function () {
     it('should return false if str contains Uppercase with .', function () {
       expect(commonFunctions.isValidKubernetesName('abcD1234')).to.be.false;
     });
+    it('should return false if str is too long', function () {
+      let str = '';
+      for(let i = 0; i < 31; i++) {
+        str += '12345678';
+      }
+      str += '123456';
+      expect(commonFunctions.isValidKubernetesName(str)).to.be.false;
+    });
     it('should return true if str consist of lower case alphanumeric characters, - or . ,  start and end with an alphanumeric character', function () {
       expect(commonFunctions.isValidKubernetesName('abcd.1234-efgh')).to.be.true;
+    });
+  });
+
+  describe('#isValidKubernetesLabelValue', function () {
+    it('should return false if str starts with -', function () {
+      expect(commonFunctions.isValidKubernetesLabelValue('-abcD1234')).to.be.false;
+    });
+    it('should return false if str starts with .', function () {
+      expect(commonFunctions.isValidKubernetesLabelValue('.abcD1234')).to.be.false;
+    });
+    it('should return false if str does not end with alphanumeric character', function () {
+      expect(commonFunctions.isValidKubernetesLabelValue('abcD1234_')).to.be.false;
+    });
+    it('should return false if str is too long', function () {
+      let str = '';
+      for(let i = 0; i < 8; i++) {
+        str += '12345678';
+      }
+      expect(commonFunctions.isValidKubernetesLabelValue(str)).to.be.false;
+    });
+    it('should return true if str is an empty string', function () {
+      expect(commonFunctions.isValidKubernetesLabelValue('')).to.be.true;
+    });
+    it('should return true if str consist of alphanumeric characters, - _ or . ,  start and end with an alphanumeric character', function () {
+      expect(commonFunctions.isValidKubernetesLabelValue('abcd.1234-efgh_HIJK')).to.be.true;
     });
   });
 

--- a/docs/Interoperator.md
+++ b/docs/Interoperator.md
@@ -635,9 +635,14 @@ For example,
 apiVersion: osb.servicefabrik.io/v1alpha1
 kind: SFServiceInstance
 metadata:
-  # Name would map to the instance_id from the OSB provision request.
+  # Name would map to the instance_id from the OSB provision request,
+  # if the instance_id is a valid k8s name. Otherwise the name is 
+  # the sha224 sum of the instance_id.
   name: '0304b210-fcfd-11e8-a31b-b6001f10c97f'
 spec:
+  # instance_id as in the OSB provision request.
+  instanceId: 0304b210-fcfd-11e8-a31b-b6001f10c97f
+
   # service_id as in the OSB provision request.
   serviceId: '24731fb8-7b84-5f57-914f-c3d55d793dd4'
 
@@ -685,10 +690,15 @@ For example,
 apiVersion: osb.servicefabrik.io/v1alpha1
 kind: SFServiceBinding
 metadata:
-  # Name would map to the binding_id from the OSB bind request.
+  # Name would map to the binding_id from the OSB bind request,
+  # if the binding_id is a valid k8s name. Otherwise the name is 
+  # the sha224 sum of the binding_id
   name: 'de3dd272-fcfc-11e8-a31b-b6001f10c97f'
 spec:
-  # instance_id as in the OSB bind request.
+  # binding_id as in the OSB bind request.
+  id: de3dd272-fcfc-11e8-a31b-b6001f10c97f
+
+  # instance_id is the name of of the SFServiceInstance
   instanceId: 0304b210-fcfd-11e8-a31b-b6001f10c97f
 
   # service_id as in the OSB bind request.

--- a/helm-charts/interoperator/crds/sfserviceinstance.yaml
+++ b/helm-charts/interoperator/crds/sfserviceinstance.yaml
@@ -51,6 +51,8 @@ spec:
               context:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              instanceId:
+                type: string
               organizationGuid:
                 type: string
               parameters:
@@ -80,6 +82,8 @@ spec:
                   context:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  instanceId:
+                    type: string
                   organizationGuid:
                     type: string
                   parameters:

--- a/interoperator/api/osb/v1alpha1/sfserviceinstance_types.go
+++ b/interoperator/api/osb/v1alpha1/sfserviceinstance_types.go
@@ -26,8 +26,9 @@ import (
 
 // SFServiceInstanceSpec defines the desired state of SFServiceInstance
 type SFServiceInstanceSpec struct {
-	ServiceID string `json:"serviceId"`
-	PlanID    string `json:"planId"`
+	InstanceID string `json:"instanceId,omitempty"`
+	ServiceID  string `json:"serviceId"`
+	PlanID     string `json:"planId"`
 
 	// +kubebuilder:pruning:PreserveUnknownFields
 	RawContext       *runtime.RawExtension `json:"context,omitempty"`

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfserviceinstances.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfserviceinstances.yaml
@@ -51,6 +51,8 @@ spec:
               context:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              instanceId:
+                type: string
               organizationGuid:
                 type: string
               parameters:
@@ -80,6 +82,8 @@ spec:
                   context:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  instanceId:
+                    type: string
                   organizationGuid:
                     type: string
                   parameters:

--- a/operator-apis/internal/handlers/handlers.go
+++ b/operator-apis/internal/handlers/handlers.go
@@ -111,9 +111,10 @@ func (h *OperatorApisHandler) GetDeploymentsSummary(w http.ResponseWriter, r *ht
 // GetDeployment returns summary of the given deployment
 func (h *OperatorApisHandler) GetDeployment(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	deploymentID := vars["deploymentID"]
+	instanceID := vars["deploymentID"]
+	deploymentID := GetKubernetesName(instanceID)
 	instanceNamespace := "sf-" + deploymentID
-	log.Info("Trying to get summary for : ", "deployment", deploymentID, "namespace", instanceNamespace)
+	log.Info("Trying to get summary for : ", "instanceID", instanceID, "deployment", deploymentID, "namespace", instanceNamespace)
 	clientset, err := initInteroperatorClientset(h.appConfig.Kubeconfig)
 	if err != nil {
 		log.Error(err, "Error while initializing clientset")
@@ -147,8 +148,9 @@ func (h *OperatorApisHandler) GetDeployment(w http.ResponseWriter, r *http.Reque
 // UpdateDeployment triggers update of a single deployment
 func (h *OperatorApisHandler) UpdateDeployment(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	deploymentID := vars["deploymentID"]
-	log.Info("Trying to trigger update for: ", "deployment", deploymentID)
+	instanceID := vars["deploymentID"]
+	deploymentID := GetKubernetesName(instanceID)
+	log.Info("Trying to trigger update for: ", "instanceID", instanceID, "deployment", deploymentID)
 	clientset, err := initInteroperatorClientset(h.appConfig.Kubeconfig)
 	if err != nil {
 		log.Error(err, "Error while initializing clients")
@@ -170,7 +172,7 @@ func (h *OperatorApisHandler) UpdateDeployment(w http.ResponseWriter, r *http.Re
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	log.Info("Triggered update for: ", "deployment", deploymentID)
+	log.Info("Triggered update for: ", "instanceID", instanceID, "deployment", deploymentID)
 	fmt.Fprintf(w, "Update for %s was successfully triggered", deploymentID)
 }
 

--- a/operator-apis/internal/handlers/utils_test.go
+++ b/operator-apis/internal/handlers/utils_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"testing"
+)
+
+func TestGetKubernetesName(t *testing.T) {
+	longID := ""
+	for i := 0; i < 31; i++ {
+		longID += "12345678"
+	}
+	longID += "123456"
+
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "should return the same name if the name is valid",
+			args: args{
+				id: "abcd.1234-efgh",
+			},
+			want: "abcd.1234-efgh",
+		},
+		{
+			name: "should return a valid name if it is invalid starting with -",
+			args: args{
+				id: "-abcd1234",
+			},
+			want: Sha224Sum("-abcd1234"),
+		},
+		{
+			name: "should return a valid name if it is invalid starting with -",
+			args: args{
+				id: ".abcd1234",
+			},
+			want: Sha224Sum(".abcd1234"),
+		},
+		{
+			name: "should return a valid name if it is invalid starting with -",
+			args: args{
+				id: "abcD.1234",
+			},
+			want: Sha224Sum("abcD.1234"),
+		},
+		{
+			name: "should return a valid name if it too long",
+			args: args{
+				id: longID,
+			},
+			want: Sha224Sum(longID),
+		},
+		{
+			name: "should return a valid name if it too short",
+			args: args{
+				id: "",
+			},
+			want: Sha224Sum(""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetKubernetesName(tt.args.id); got != tt.want || !IsDNS1123Subdomain(got) {
+				t.Errorf("GetKubernetesName() = %v, want %v, valid %t", got, tt.want, IsDNS1123Subdomain(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
- If instanceId/bindingId is not in k8s format, use hash
- Use sha224 hash of the id
- Trim label values and validate them
- Add instanceId to SfServiceInstance spec
- Set by broker for new instances
- Set by broker on update of old instances
- Update docs

Feature: HCPCFS-2851