### PR TITLE
Operator-api and quotaapp deployed conditionally

### DIFF
--- a/helm-charts/interoperator/conf/resources.yaml
+++ b/helm-charts/interoperator/conf/resources.yaml
@@ -1,0 +1,11 @@
+resources:
+  {{- with .limits }}
+  limits:
+    cpu: {{ .cpu }}
+    memory: {{ .memory }}
+  {{- end }}
+  {{- with .requests }}
+  requests:
+    cpu: {{ .cpu }}
+    memory: {{ .memory }}
+  {{- end }}

--- a/helm-charts/interoperator/templates/broker.yaml
+++ b/helm-charts/interoperator/templates/broker.yaml
@@ -51,7 +51,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-broker
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ default .Values.replicaCount .Values.broker.replicaCount }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}-broker
@@ -151,18 +151,12 @@ spec:
         - applications/osb-broker/src/server.js
         command:
         - node
+        {{- $resourceSpec := dict }}
         {{- with .Values.broker.resources }}
-        resources:
-          {{- with .limits }}
-          limits:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
-          {{- end }}
-          {{- with .requests }}
-          requests:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
-          {{- end }}
+          {{- $resourceSpec = deepCopy . }}
+        {{- end }}
+        {{- if not (empty $resourceSpec) }}
+        {{- tpl (.Files.Get "conf/resources.yaml") (merge $resourceSpec .) | nindent 8 }}
         {{- end }}
       volumes:
         - name: settings

--- a/helm-charts/interoperator/templates/multiclusterdeployer.yaml
+++ b/helm-charts/interoperator/templates/multiclusterdeployer.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-multiclusterdeployer-controller-manager
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ default .Values.replicaCount .Values.interoperator.replicaCount }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}-controller-manager
@@ -39,24 +39,22 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: REPLICA_COUNT
-          value: "{{ .Values.replicaCount }}"
+          value: "{{ default .Values.replicaCount .Values.interoperator.replicaCount }}"
         command:
         - /multiclusterdeploy
         args:
         - --metrics-addr=:8443
         - --enable-leader-election
-        {{- with .Values.interoperator.resources }}
-        resources:
-          {{- with .limits }}
-          limits:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
+        {{- $resourceSpec := dict }}
+        {{- with .Values.interoperator.multiclusterdeployer.resources }}
+          {{- $resourceSpec = deepCopy . }}
+        {{- else }}
+          {{- with .Values.interoperator.resources }}
+            {{- $resourceSpec = deepCopy . }}
           {{- end }}
-          {{- with .requests }}
-          requests:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
-          {{- end }}
+        {{- end }}
+        {{- if not (empty $resourceSpec) }}
+        {{- tpl (.Files.Get "conf/resources.yaml") (merge $resourceSpec .) | nindent 8 }}
         {{- end }}
         livenessProbe:
           failureThreshold: 3

--- a/helm-charts/interoperator/templates/operator_api_app.yaml
+++ b/helm-charts/interoperator/templates/operator_api_app.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.operator_apis.enabled -}}
 {{ $randomString := randAlphaNum 5 | quote -}}
 apiVersion: v1
 kind: Service
@@ -129,3 +130,4 @@ spec:
           {{- end }}
         {{- end }}
       restartPolicy: Always
+{{- end }}

--- a/helm-charts/interoperator/templates/operator_api_app.yaml
+++ b/helm-charts/interoperator/templates/operator_api_app.yaml
@@ -51,7 +51,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-op-apis-app
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ default .Values.replicaCount .Values.operator_apis.replicaCount }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}-op-apis-app
@@ -116,18 +116,12 @@ spec:
           timeoutSeconds: 1
         command: 
         - /operator-apis
+        {{- $resourceSpec := dict }}
         {{- with .Values.operator_apis.resources }}
-        resources:
-          {{- with .limits }}
-          limits:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
-          {{- end }}
-          {{- with .requests }}
-          requests:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
-          {{- end }}
+          {{- $resourceSpec = deepCopy . }}
+        {{- end }}
+        {{- if not (empty $resourceSpec) }}
+        {{- tpl (.Files.Get "conf/resources.yaml") (merge $resourceSpec .) | nindent 8 }}
         {{- end }}
       restartPolicy: Always
 {{- end }}

--- a/helm-charts/interoperator/templates/provisioner.yaml
+++ b/helm-charts/interoperator/templates/provisioner.yaml
@@ -47,18 +47,16 @@ spec:
         image: "{{ .Values.interoperator.image.repository }}:{{ .Values.interoperator.image.tag }}"
         imagePullPolicy: {{ .Values.interoperator.image.pullPolicy }}
         name: manager
-        {{- with .Values.interoperator.resources }}
-        resources:
-          {{- with .limits }}
-          limits:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
+        {{- $resourceSpec := dict }}
+        {{- with .Values.interoperator.provisioner.resources }}
+          {{- $resourceSpec = deepCopy . }}
+        {{- else }}
+          {{- with .Values.interoperator.resources }}
+            {{- $resourceSpec = deepCopy . }}
           {{- end }}
-          {{- with .requests }}
-          requests:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
-          {{- end }}
+        {{- end }}
+        {{- if not (empty $resourceSpec) }}
+        {{- tpl (.Files.Get "conf/resources.yaml") (merge $resourceSpec .) | nindent 8 }}
         {{- end }}
         livenessProbe:
           failureThreshold: 3

--- a/helm-charts/interoperator/templates/provisioner.yaml
+++ b/helm-charts/interoperator/templates/provisioner.yaml
@@ -13,6 +13,10 @@ spec:
       control-plane: {{ .Release.Name }}-controller-manager
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8443"
+        prometheus.io/scrape: "true"
       labels:
         control-plane: {{ .Release.Name }}-controller-manager
         rollme: {{ $randomString }}

--- a/helm-charts/interoperator/templates/quota_app.yaml
+++ b/helm-charts/interoperator/templates/quota_app.yaml
@@ -23,7 +23,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-quota-app
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ default .Values.replicaCount .Values.quota_app.replicaCount }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}-quota-app
@@ -113,18 +113,12 @@ spec:
         - applications/quota-app/src/index.js
         command:
         - node
+        {{- $resourceSpec := dict }}
         {{- with .Values.quota_app.resources }}
-        resources:
-          {{- with .limits }}
-          limits:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
-          {{- end }}
-          {{- with .requests }}
-          requests:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
-          {{- end }}
+          {{- $resourceSpec = deepCopy . }}
+        {{- end }}
+        {{- if not (empty $resourceSpec) }}
+        {{- tpl (.Files.Get "conf/resources.yaml") (merge $resourceSpec .) | nindent 8 }}
         {{- end }}
       volumes:
         - name: settings

--- a/helm-charts/interoperator/templates/quota_app.yaml
+++ b/helm-charts/interoperator/templates/quota_app.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.broker.quota.enabled -}}
 {{ $randomString := randAlphaNum 5 | quote -}}
 apiVersion: v1
 kind: Service
@@ -130,3 +131,4 @@ spec:
           configMap:
             name: sf-settings-config
       restartPolicy: Always
+{{- end }}

--- a/helm-charts/interoperator/templates/scheduler.yaml
+++ b/helm-charts/interoperator/templates/scheduler.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-scheduler-controller-manager
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ default .Values.replicaCount .Values.interoperator.replicaCount }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}-controller-manager
@@ -43,18 +43,16 @@ spec:
         args:
         - --metrics-addr=:8443
         - --enable-leader-election
-        {{- with .Values.interoperator.resources }}
-        resources:
-          {{- with .limits }}
-          limits:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
+        {{- $resourceSpec := dict }}
+        {{- with .Values.interoperator.scheduler.resources }}
+          {{- $resourceSpec = deepCopy . }}
+        {{- else }}
+          {{- with .Values.interoperator.resources }}
+            {{- $resourceSpec = deepCopy . }}
           {{- end }}
-          {{- with .requests }}
-          requests:
-            cpu: {{ .cpu }}
-            memory: {{ .memory }}
-          {{- end }}
+        {{- end }}
+        {{- if not (empty $resourceSpec) }}
+        {{- tpl (.Files.Get "conf/resources.yaml") (merge $resourceSpec .) | nindent 8 }}
         {{- end }}
         livenessProbe:
           failureThreshold: 3

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -81,6 +81,7 @@ interoperator:
     provisionerWorkerCount: 2
 
 operator_apis:
+  enabled: true
   port: 9297
   username: admin
   password: secret

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -17,13 +17,16 @@ broker:
   services_namespace: "services"
   allow_concurrent_operations: true
   allow_concurrent_binding_operations: true
+
+  # override the global replicaCount just for broker
+  replicaCount: 4
   resources:
     limits:
-      cpu: 400m
-      memory: 512Mi
-    requests:
-      cpu: 100m
+      cpu: 800m
       memory: 256Mi
+    requests:
+      cpu: 400m
+      memory: 128Mi
   quota:
     enabled: false
     oauthDomain: https://myauth-domain.com
@@ -52,13 +55,16 @@ quota_app:
   port: 9296
   username: quota
   password: secret
+
+  # override the global replicaCount just for quota_app
+  #replicaCount: 1
   resources:
     limits:
       cpu: 400m
-      memory: 512Mi
+      memory: 256Mi
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 128Mi
   service:
     type: ClusterIP
 
@@ -67,18 +73,48 @@ interoperator:
     repository: servicefabrikjenkins/service-fabrik-interoperator
     tag: 0.13.0
     pullPolicy: Always
+
+  # override the global replicaCount just for interoperator components
+  #replicaCount: 2
   resources:
     limits:
       cpu: 400m
-      memory: 512Mi
+      memory: 256Mi
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 128Mi
   config:
     instanceWorkerCount: 2
     bindingWorkerCount: 4
     schedulerWorkerCount: 2
     provisionerWorkerCount: 2
+
+  provisioner:
+    resources:
+      limits:
+        cpu: 1800m
+        memory: 512Mi
+      requests:
+        cpu: 600m
+        memory: 256Mi
+
+  scheduler:
+    resources:
+      limits:
+        cpu: 400m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 64Mi
+
+  multiclusterdeployer:
+    resources:
+      limits:
+        cpu: 1200m
+        memory: 128Mi
+      requests:
+        cpu: 400m
+        memory: 64Mi
 
 operator_apis:
   enabled: true
@@ -90,6 +126,9 @@ operator_apis:
     repository: servicefabrikjenkins/operatorapis
     tag: 0.13.0
     pullPolicy: Always
+
+  # override the global replicaCount just for operator apis
+  #replicaCount: 2
   resources:
     limits:
       cpu: 400m

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/multiclusterdeploy/watchmanager"
@@ -177,7 +178,15 @@ func (r *ReconcileProvisioner) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	requeueAfter, err := time.ParseDuration(interoperatorCfg.ClusterReconcileInterval)
+	if err != nil {
+		log.Error(err, "Failed to parse ClusterReconcileInterval",
+			"ClusterReconcileInterval", interoperatorCfg.ClusterReconcileInterval)
+		requeueAfter, _ = time.ParseDuration(constants.DefaultClusterReconcileInterval)
+	}
+	return ctrl.Result{
+		RequeueAfter: requeueAfter,
+	}, nil
 }
 
 func (r *ReconcileProvisioner) reconcilePrimaryClusterIDConfig() error {

--- a/interoperator/internal/config/config.go
+++ b/interoperator/internal/config/config.go
@@ -23,11 +23,12 @@ var log = logf.Log.WithName("config.manager")
 
 // InteroperatorConfig contains tuneable configs used by interoperator
 type InteroperatorConfig struct {
-	InstanceWorkerCount    int    `yaml:"instanceWorkerCount,omitempty"`
-	BindingWorkerCount     int    `yaml:"bindingWorkerCount,omitempty"`
-	SchedulerWorkerCount   int    `yaml:"schedulerWorkerCount,omitempty"`
-	ProvisionerWorkerCount int    `yaml:"provisionerWorkerCount,omitempty"`
-	PrimaryClusterID       string `yaml:"primaryClusterId,omitempty"`
+	InstanceWorkerCount      int    `yaml:"instanceWorkerCount,omitempty"`
+	BindingWorkerCount       int    `yaml:"bindingWorkerCount,omitempty"`
+	SchedulerWorkerCount     int    `yaml:"schedulerWorkerCount,omitempty"`
+	ProvisionerWorkerCount   int    `yaml:"provisionerWorkerCount,omitempty"`
+	PrimaryClusterID         string `yaml:"primaryClusterId,omitempty"`
+	ClusterReconcileInterval string `yaml:"clusterReconcileInterval,omitempty"`
 
 	InstanceContollerWatchList []osbv1alpha1.APIVersionKind `yaml:"instanceContollerWatchList,omitempty"`
 	BindingContollerWatchList  []osbv1alpha1.APIVersionKind `yaml:"bindingContollerWatchList,omitempty"`
@@ -49,6 +50,9 @@ func setConfigDefaults(interoperatorConfig *InteroperatorConfig) *InteroperatorC
 	}
 	if interoperatorConfig.PrimaryClusterID == "" {
 		interoperatorConfig.PrimaryClusterID = constants.DefaultPrimaryClusterID
+	}
+	if interoperatorConfig.ClusterReconcileInterval == "" {
+		interoperatorConfig.ClusterReconcileInterval = constants.DefaultClusterReconcileInterval
 	}
 
 	return interoperatorConfig

--- a/interoperator/internal/config/config_test.go
+++ b/interoperator/internal/config/config_test.go
@@ -123,6 +123,7 @@ func Test_config_GetConfig(t *testing.T) {
 	data := make(map[string]string)
 	config := `
 instanceWorkerCount: 2
+clusterReconcileInterval: 17m
 instanceContollerWatchList:
 - apiVersion: kubedb.com/v1alpha1
   kind: Postgres
@@ -143,21 +144,22 @@ instanceContollerWatchList:
 		Namespace: constants.InteroperatorNamespace,
 	}
 	interoperatorConfig := &InteroperatorConfig{
-		BindingWorkerCount:     constants.DefaultBindingWorkerCount,
-		InstanceWorkerCount:    constants.DefaultInstanceWorkerCount,
-		SchedulerWorkerCount:   constants.DefaultSchedulerWorkerCount,
-		ProvisionerWorkerCount: constants.DefaultProvisionerWorkerCount,
-		PrimaryClusterID:       "1",
+		BindingWorkerCount:       constants.DefaultBindingWorkerCount,
+		InstanceWorkerCount:      constants.DefaultInstanceWorkerCount,
+		SchedulerWorkerCount:     constants.DefaultSchedulerWorkerCount,
+		ProvisionerWorkerCount:   constants.DefaultProvisionerWorkerCount,
+		PrimaryClusterID:         "1",
+		ClusterReconcileInterval: "17m",
 		InstanceContollerWatchList: []osbv1alpha1.APIVersionKind{
-			osbv1alpha1.APIVersionKind{
+			{
 				APIVersion: "kubedb.com/v1alpha1",
 				Kind:       "Postgres",
 			},
-			osbv1alpha1.APIVersionKind{
+			{
 				APIVersion: "kubernetes.sapcloud.io/v1alpha1",
 				Kind:       "Postgresql",
 			},
-			osbv1alpha1.APIVersionKind{
+			{
 				APIVersion: "deployment.servicefabrik.io/v1alpha1",
 				Kind:       "Director",
 			},
@@ -180,6 +182,7 @@ instanceContollerWatchList:
 					return err
 				}, timeout).Should(gomega.Succeed())
 				interoperatorConfig.InstanceWorkerCount = 2
+				interoperatorConfig.ClusterReconcileInterval = "17m"
 			},
 			want: interoperatorConfig,
 		},
@@ -199,6 +202,7 @@ instanceContollerWatchList:
 				data[constants.ConfigMapKey] = config
 				g.Expect(c.Update(context.TODO(), configMap)).NotTo(gomega.HaveOccurred())
 				interoperatorConfig.InstanceWorkerCount = constants.DefaultInstanceWorkerCount
+				interoperatorConfig.ClusterReconcileInterval = constants.DefaultClusterReconcileInterval
 			},
 			want: interoperatorConfig,
 		},
@@ -218,6 +222,7 @@ instanceContollerWatchList:
 					return fmt.Errorf("not deleted")
 				}, timeout).Should(gomega.Succeed())
 				interoperatorConfig.InstanceWorkerCount = constants.DefaultInstanceWorkerCount
+				interoperatorConfig.ClusterReconcileInterval = constants.DefaultClusterReconcileInterval
 				interoperatorConfig.InstanceContollerWatchList = nil
 			},
 			want: interoperatorConfig,
@@ -246,15 +251,15 @@ func Test_config_UpdateConfig(t *testing.T) {
 		BindingWorkerCount:  constants.DefaultBindingWorkerCount,
 		InstanceWorkerCount: constants.DefaultInstanceWorkerCount,
 		InstanceContollerWatchList: []osbv1alpha1.APIVersionKind{
-			osbv1alpha1.APIVersionKind{
+			{
 				APIVersion: "kubedb.com/v1alpha1",
 				Kind:       "Postgres",
 			},
-			osbv1alpha1.APIVersionKind{
+			{
 				APIVersion: "kubernetes.sapcloud.io/v1alpha1",
 				Kind:       "Postgresql",
 			},
-			osbv1alpha1.APIVersionKind{
+			{
 				APIVersion: "deployment.servicefabrik.io/v1alpha1",
 				Kind:       "Director",
 			},

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -34,7 +34,8 @@ const (
 
 	GoTemplateType = "gotemplate"
 
-	PlanWatchDrainTimeout = time.Second * 2
+	PlanWatchDrainTimeout           = time.Second * 2
+	DefaultClusterReconcileInterval = "20m"
 
 	ListPaginationLimit = 50
 )


### PR DESCRIPTION
- Deploy these apps only if they are enabled

### Fix metrics scrape in sister cluster
- The metrics svc of provisioner is not replicated
- Add prometheus annotations instead

### Make resources configurable per deployment
- Seperate resources values for each deployment
- Seperate replicaCount config for each deployment

### Requeue SFCluster for mcd periodically
- Requeue every 20 minutes for self healing
- Connection issues might close multi cluster watches

Feature: HCPCFS-2864