### PR TITLE
Updating dockerode from 2.2.10 to 3.2.1

### DIFF
--- a/broker/applications/admin/package.json
+++ b/broker/applications/admin/package.json
@@ -37,7 +37,7 @@
     "camelcase-keys": "6.2.2",
     "connect-timeout": "1.9.0",
     "decamelize-keys-deep": "0.1.1",
-    "dockerode": "2.2.10",
+    "dockerode": "3.2.1",
     "express": "4.17.1",
     "express-interceptor": "1.2.0",
     "express-jwt": "6.0.0",

--- a/broker/applications/deployment_hooks/package.json
+++ b/broker/applications/deployment_hooks/package.json
@@ -31,7 +31,7 @@
     "camelcase-keys": "6.2.2",
     "connect-timeout": "1.9.0",
     "decamelize-keys-deep": "0.1.1",
-    "dockerode": "2.2.10",
+    "dockerode": "3.2.1",
     "express": "4.17.1",
     "express-interceptor": "1.2.0",
     "express-jwt": "6.0.0",

--- a/broker/applications/extensions/package.json
+++ b/broker/applications/extensions/package.json
@@ -38,7 +38,7 @@
     "camelcase-keys": "6.2.2",
     "connect-timeout": "1.9.0",
     "decamelize-keys-deep": "0.1.1",
-    "dockerode": "2.2.10",
+    "dockerode": "3.2.1",
     "express": "4.17.1",
     "express-interceptor": "1.2.0",
     "express-jwt": "6.0.0",

--- a/broker/applications/operators/package.json
+++ b/broker/applications/operators/package.json
@@ -40,7 +40,7 @@
     "camelcase-keys": "6.2.2",
     "connect-timeout": "1.9.0",
     "decamelize-keys-deep": "0.1.1",
-    "dockerode": "2.2.10",
+    "dockerode": "3.2.1",
     "express": "4.17.1",
     "express-interceptor": "1.2.0",
     "express-jwt": "6.0.0",

--- a/broker/applications/operators/src/docker-operator/DockerService.js
+++ b/broker/applications/operators/src/docker-operator/DockerService.js
@@ -790,7 +790,8 @@ class DockerService extends BaseService {
       .logsAsync({
         stdout: 1,
         stderr: 1,
-        timestamps: 1
+        timestamps: 1,
+        follow: true
       })
       .then(stream => demux(stream, {
         tail: 1000

--- a/broker/applications/reports/package.json
+++ b/broker/applications/reports/package.json
@@ -32,7 +32,7 @@
     "camelcase-keys": "6.2.2",
     "connect-timeout": "1.9.0",
     "decamelize-keys-deep": "0.1.1",
-    "dockerode": "2.2.10",
+    "dockerode": "3.2.1",
     "express": "4.17.1",
     "express-interceptor": "1.2.0",
     "express-jwt": "6.0.0",

--- a/broker/applications/scheduler/package.json
+++ b/broker/applications/scheduler/package.json
@@ -33,7 +33,7 @@
     "camelcase-keys": "6.2.2",
     "connect-timeout": "1.9.0",
     "decamelize-keys-deep": "0.1.1",
-    "dockerode": "2.2.10",
+    "dockerode": "3.2.1",
     "express": "4.17.1",
     "express-interceptor": "1.2.0",
     "express-jwt": "6.0.0",

--- a/broker/core/utils/src/commonFunctions.js
+++ b/broker/core/utils/src/commonFunctions.js
@@ -598,6 +598,10 @@ function demux(stream, options) {
     stream.on('readable', onreadable);
     stream.once('end', onend);
     stream.once('error', onerror);
+
+    setTimeout(function() {
+      stream.destroy();
+    }, 2000);
   });
 }
 

--- a/broker/test/test_broker/mocks/docker.js
+++ b/broker/test/test_broker/mocks/docker.js
@@ -197,7 +197,8 @@ function getContainerLogs() {
     .query({
       stdout: 1,
       stderr: 1,
-      timestamps: 1
+      timestamps: 1,
+      follow: true
     })
     .reply(200, '');
 }


### PR DESCRIPTION
Breaking change:
Promises interface was standardized, output property was removed.