### PR TITLE
Delete snapshot only after validation

### DIFF
--- a/broker/data-access-layer/iaas/src/BackupStore.js
+++ b/broker/data-access-layer/iaas/src/BackupStore.js
@@ -118,8 +118,12 @@ class BackupStore {
   }
 
   deleteServiceBackup(data, options) {
-    return Promise.try(() => data.snapshotId ? this.cloudProvider.deleteSnapshot(data.snapshotId) : Promise.resolve({}))
-      .then(() => this.deleteBackupInServiceContainer(data, options));
+    return this.deleteBackupInServiceContainer(data, options)
+      .then(() => {
+        if (data.snapshotId) {
+          return this.cloudProvider.deleteSnapshot(data.snapshotId);
+        }
+      });
   }
 
   putFile(data) {


### PR DESCRIPTION
When deleting a backup, the snapshot is deleted even if there is any validation error. This behaviour is incorrect as the backup is unusable now (even as delete operation did not complete successfully) as the corresponding snapshot got deleted.

Bug: HCPCFS-2885

#### Reproducing the Error

```sh
$ cf list-backup bp_test1
Getting the list of  backups ...
Instance  bp_test1 is of service  blueprint
OK
  backup_guid                            username                          type     trigger     started_at                 finished_at
  47eab593-6b57-454c-837e-d6a55b574cb6   provisioned_user_service-fabrik   online   scheduled   2020-12-20T07:10:00.913Z   2020-12-20T07:12:01.223Z
```

The deletion operation of the backup fails since the deletion of the
scheduled backup is not permitted within retention period.
```sh
$ ./scripts/broker delete-backup 47eab593-6b57-454c-837e-d6a55b574cb6
{
  "status": 403,
  "error": "Forbidden",
  "description": "Delete of scheduled backup not permitted within retention period of 14 days"
}
```

From `service-fabrik-backup-manager.log` we see that the snapshot is deleted.
```
2020-12-20T14:36:57.403Z - info: Deleted snapshot sf-snapshot-24019-20201220071003
```

When restore is attempted with the backup, it fails.
```sh
$./scripts/broker restore-start bp_test1 47eab593-6b57-454c-837e-d6a55b574cb6
{
  "name": "restore",
  "guid": "55dcec87-f49d-42aa-8791-4fe520025468"
}
```

```sh
$./scripts/broker restore-state bp_test1
{
  "service_id": "24731fb8-7b84-4f57-914f-c3d55d793dd4",
  "plan_id": "e86e2cf2-569a-11e7-a2e3-02a8da424bc3",
  "instance_guid": "33cdf3a5-a1c6-4128-82cc-ef50c140a1d3",
  "username": "provisioned_user_cf_admin",
  "operation": "restore",
  "backup_guid": "47eab593-6b57-454c-837e-d6a55b574cb6",
  "state": "failed",
  "started_at": "2020-12-20T14:47:21.578Z",
  "finished_at": "2020-12-20T14:47:34.114Z",
  "tenant_id": "7c7bf413-d69b-48e7-a0ba-e03cb111fd0e",
  "last_restore_guid": "55dcec87-f49d-42aa-8791-4fe520025468",
  "restore_dates": {
    "failed": [
      "2020-12-20T14:47:34.114Z"
    ]         
  }
}
```
