### PR TITLE
Add Url and Method to HttpClient Error log

### DIFF
--- a/broker/core/utils/src/HttpClient.js
+++ b/broker/core/utils/src/HttpClient.js
@@ -264,6 +264,7 @@ class HttpClient {
         return result;
       })
       .catch(error => {
+        logger.info(`Got error for: ${error.config.url}, HTTP Method: ${error.config.method}`);
         if (error.response) {
           // The request was made and the server responded with a status code
           // that falls out of the expected range.
@@ -273,6 +274,7 @@ class HttpClient {
           // or, something happened in setting up the request that triggered an Error.
           const err = _.pick(error.toJSON(), [
             'message', 'name', 'description',
+            'config.url', 'config.method',
             'stack', 'code'
           ]);
           logger.error('HTTP request failed:', err);

--- a/broker/core/utils/test/utils.HttpClient.spec.js
+++ b/broker/core/utils/test/utils.HttpClient.spec.js
@@ -39,6 +39,10 @@ class StubAxios {
         resolve(response);
       } else {
         var error = new Error('Request failed with status code ' + response.status);
+        error.config = {
+          url: "/Dummy-URL",
+          method: "POST"
+        }
         error.response = response;
         reject(error);
       }


### PR DESCRIPTION
Add `url` and `method` to the error log in HttpClient when the request fails without a response.
The log entry after the changes will look like this,
```json
2021-01-05T06:10:57.521Z - info: Got error for: http://x.x.x.x:xxxx/v1/info, HTTP Method: get
2021-01-05T06:10:57.521Z - error: HTTP request failed: Nock: Disallowed net connect for "x.x.x.x:xxxx/v1/info"
{
  "message": "Nock: Disallowed net connect for \"x.x.x.x:xxxx//v1/info\"",
  "name": "NetConnectNotAllowedError",
  "config": {
    "url": "http://x.x.x.x:xxxx/v1/info",
    "method": "get"
  },
  "stack": "Some stack trace",
  "code": "ENETUNREACH"
}
```
:beetle: NGPBUG-137177