### PR TITLE
Update Node version in Broker Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "15.5"
+        - "14.15"
       env:
         - SETTINGS_PATH="$(pwd)/broker/config/settings.yml"
       script:
@@ -107,7 +107,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "15.5"
+        - "14.15"
       env:
         - SETTINGS_PATH="$(pwd)/broker/config/settings.yml"
       script:
@@ -118,7 +118,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "15.5"
+        - "14.15"
       before_install:
         # - pip install --user truffleHog==2.0.89
         - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "12.18"
+        - "15.5"
       env:
         - SETTINGS_PATH="$(pwd)/broker/config/settings.yml"
       script:
@@ -107,7 +107,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "12.18"
+        - "15.5"
       env:
         - SETTINGS_PATH="$(pwd)/broker/config/settings.yml"
       script:
@@ -118,7 +118,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "12.18"
+        - "15.5"
       before_install:
         # - pip install --user truffleHog==2.0.89
         - |

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,5 +1,5 @@
 # FROM node:12.18-alpine3.12 also works here for a smaller image
-FROM node:15.5-alpine3.12
+FROM node:14.15-alpine3.12
 
 # set our node environment, either development or production
 # defaults to production, compose overrides this to development on build and run

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,5 +1,5 @@
 # FROM node:12.18-alpine3.12 also works here for a smaller image
-FROM node:12.18-alpine3.12
+FROM node:15.5-alpine3.12
 
 # set our node environment, either development or production
 # defaults to production, compose overrides this to development on build and run


### PR DESCRIPTION
Update Node version to 14.15 LTS
- update in `dockerfile` of broker
- update in Travis configuration file

Feature: HCPCFS-2784

|Dockerfile|Current Version|Latest Stable Version|LTS|
|---|---|---|---|
|[broker](https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/master/broker/Dockerfile#L2) |node:12.18-alpine3.12|node:15.5.1|14.15.4|

[Node release schedule](https://github.com/nodejs/Release#release-schedule)