### PR TITLE
Updated sfplan crds for mismatched schema's property

### DIFF
--- a/helm-charts/interoperator/crds/sfplan.yaml
+++ b/helm-charts/interoperator/crds/sfplan.yaml
@@ -70,7 +70,7 @@ spec:
                 description: ServiceSchemas is definitions for Service Instances and
                   Service Bindings for the Service Plan.
                 properties:
-                  binding:
+                  service_binding:
                     description: ServiceBindingSchema is the  schema definition for
                       creating a Service Binding. Used only if the Service Plan is
                       bindable.
@@ -85,7 +85,7 @@ spec:
                         - parameters
                         type: object
                     type: object
-                  instance:
+                  service_instance:
                     description: ServiceInstanceSchema is the schema definitions for
                       creating and updating a Service Instance.
                     properties:

--- a/interoperator/api/osb/v1alpha1/sfplan_types.go
+++ b/interoperator/api/osb/v1alpha1/sfplan_types.go
@@ -67,8 +67,8 @@ type ServiceBindingSchema struct {
 // ServiceSchemas is definitions for Service Instances and
 // Service Bindings for the Service Plan.
 type ServiceSchemas struct {
-	Instance ServiceInstanceSchema `json:"instance,omitempty"`
-	Binding  ServiceBindingSchema  `json:"binding,omitempty"`
+	Instance ServiceInstanceSchema `json:"service_instance,omitempty"`
+	Binding  ServiceBindingSchema  `json:"service_binding,omitempty"`
 }
 
 // SFPlanSpec defines the desired state of SFPlan

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfplans.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfplans.yaml
@@ -70,7 +70,7 @@ spec:
                 description: ServiceSchemas is definitions for Service Instances and
                   Service Bindings for the Service Plan.
                 properties:
-                  binding:
+                  service_binding:
                     description: ServiceBindingSchema is the  schema definition for
                       creating a Service Binding. Used only if the Service Plan is
                       bindable.
@@ -85,7 +85,7 @@ spec:
                         - parameters
                         type: object
                     type: object
-                  instance:
+                  service_instance:
                     description: ServiceInstanceSchema is the schema definitions for
                       creating and updating a Service Instance.
                     properties:


### PR DESCRIPTION
Updated the sfplan crd to avoid mismatching during schema validation from broker at the time of service instance creation/updation and the service binding creation.

https://jtrack.wdf.sap.corp/browse/HCPCFS-2878