### PR TITLE
Fix staticcheck failures

### DIFF
--- a/interoperator/internal/renderer/gotemplate/renderer_test.go
+++ b/interoperator/internal/renderer/gotemplate/renderer_test.go
@@ -181,10 +181,6 @@ func Test_gotemplateRenderer_Render(t *testing.T) {
 				t.Errorf("gotemplateRenderer.Render() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if _, ok := got.(renderer.Output); (got != nil) != tt.want || ok != tt.want {
-				t.Errorf("gotemplateRenderer.Render() = %v, want %v", got, tt.want)
-				return
-			}
 			if tt.want {
 				out, err := got.FileContent("main")
 				if err != nil {

--- a/interoperator/pkg/cluster/registry/registry_test.go
+++ b/interoperator/pkg/cluster/registry/registry_test.go
@@ -58,13 +58,10 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.args.kubeConfig, tt.args.scheme, tt.args.mapper)
+			_, err := New(tt.args.kubeConfig, tt.args.scheme, tt.args.mapper)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return
-			}
-			if _, ok := got.(ClusterRegistry); ok != tt.want {
-				t.Errorf("New() = %v, want ClusterRegistry", got)
 			}
 		})
 	}


### PR DESCRIPTION
Builds are failing in Travis due to minor staticcheck failure, [Job #4956.4](https://travis-ci.org/github/cloudfoundry-incubator/service-fabrik-broker/jobs/753162200)
```
internal/renderer/gotemplate/renderer_test.go:184:16: type assertion to the same type: got already has type renderer.Output (S1040)
pkg/cluster/registry/registry_test.go:66:16: type assertion to the same type: got already has type ClusterRegistry (S1040)
```
These are only test files. Either we can fix this or ignore the error.

 S1040 rule in staticcheck fails when type assertion is tried to current type. More information of S1040 rule is [here](https://staticcheck.io/docs/checks#S1040).