### PR TITLE
reading primary cluster id from the configmap instead of hardcoded value

### DIFF
--- a/helm-charts/interoperator/templates/interoperator_config.yaml
+++ b/helm-charts/interoperator/templates/interoperator_config.yaml
@@ -9,3 +9,4 @@ data:
     bindingWorkerCount: "{{ .Values.interoperator.config.bindingWorkerCount }}"
     schedulerWorkerCount: "{{ .Values.interoperator.config.schedulerWorkerCount }}"
     provisionerWorkerCount: "{{ .Values.interoperator.config.provisionerWorkerCount }}"
+    primaryClusterId: "1"

--- a/helm-charts/interoperator/templates/interoperator_config.yaml
+++ b/helm-charts/interoperator/templates/interoperator_config.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   config: |-
-    instanceWorkerCount: "{{ .Values.interoperator.config.instanceWorkerCount }}"
-    bindingWorkerCount: "{{ .Values.interoperator.config.bindingWorkerCount }}"
-    schedulerWorkerCount: "{{ .Values.interoperator.config.schedulerWorkerCount }}"
-    provisionerWorkerCount: "{{ .Values.interoperator.config.provisionerWorkerCount }}"
+    instanceWorkerCount: {{ .Values.interoperator.config.instanceWorkerCount }}
+    bindingWorkerCount: {{ .Values.interoperator.config.bindingWorkerCount }}
+    schedulerWorkerCount: {{ .Values.interoperator.config.schedulerWorkerCount }}
+    provisionerWorkerCount: {{ .Values.interoperator.config.provisionerWorkerCount }}
     primaryClusterId: "1"

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
@@ -198,6 +198,7 @@ func (r *ReconcileProvisioner) reconcilePrimaryClusterIDConfig() error {
 			return err
 		}
 		constants.OwnClusterID = sfClustersList.Items[0].GetName() // keep OwnClusterID up-to-date
+		log.Info("Updated primary cluster id in configmap", "primaryClusterId", sfClustersList.Items[0].GetName())
 	} else if len(sfClustersList.Items) > 1 {
 		//more than one sfcluster has primary cluster label
 		log.Info("More than one sfcluster CR with label: " + constants.PrimaryClusterKey)

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
@@ -18,6 +18,7 @@ package provisioner
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
@@ -201,7 +202,7 @@ func (r *ReconcileProvisioner) reconcilePrimaryClusterIDConfig() error {
 		log.Info("Updated primary cluster id in configmap", "primaryClusterId", sfClustersList.Items[0].GetName())
 	} else if len(sfClustersList.Items) > 1 {
 		//more than one sfcluster has primary cluster label
-		log.Info("More than one sfcluster CR with label: " + constants.PrimaryClusterKey)
+		log.Error(fmt.Errorf("More than one primary cluster"), "More than one sfcluster CR with label: "+constants.PrimaryClusterKey)
 		os.Exit(1)
 	}
 	return nil

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
@@ -202,7 +202,7 @@ func (r *ReconcileProvisioner) reconcilePrimaryClusterIDConfig() error {
 		log.Info("Updated primary cluster id in configmap", "primaryClusterId", sfClustersList.Items[0].GetName())
 	} else if len(sfClustersList.Items) > 1 {
 		//more than one sfcluster has primary cluster label
-		log.Error(fmt.Errorf("More than one primary cluster"), "More than one sfcluster CR with label: "+constants.PrimaryClusterKey)
+		log.Error(fmt.Errorf("more than one primary cluster"), "More than one sfcluster CR with label: "+constants.PrimaryClusterKey)
 		os.Exit(1)
 	}
 	return nil

--- a/interoperator/controllers/multiclusterdeploy/watchmanager/internal.go
+++ b/interoperator/controllers/multiclusterdeploy/watchmanager/internal.go
@@ -3,8 +3,8 @@ package watchmanager
 import (
 	"sync"
 
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/config"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
-	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/errors"
 
 	"k8s.io/client-go/rest"
@@ -16,6 +16,7 @@ import (
 type watchManager struct {
 	defaultCluster  kubernetes.Client
 	clusterRegistry registry.ClusterRegistry
+	cfgManager      config.Config
 
 	clusterWatchers []*clusterWatcher
 	mux             sync.Mutex // Locking clusterWatchers array
@@ -61,8 +62,12 @@ func (wm *watchManager) addCluster(clusterID string) error {
 		return err
 	}
 
+	log.Info("In the add cluster")
 	var cfg *rest.Config
-	if clusterID == constants.OwnClusterID {
+	interoperatorCfg := wm.cfgManager.GetConfig()
+	currPrimaryClusterID := interoperatorCfg.PrimaryClusterID
+
+	if clusterID == currPrimaryClusterID {
 		// Use in cluster config
 		cfg, err = ctrl.GetConfig()
 	} else {

--- a/interoperator/controllers/multiclusterdeploy/watchmanager/internal.go
+++ b/interoperator/controllers/multiclusterdeploy/watchmanager/internal.go
@@ -62,7 +62,6 @@ func (wm *watchManager) addCluster(clusterID string) error {
 		return err
 	}
 
-	log.Info("In the add cluster")
 	var cfg *rest.Config
 	interoperatorCfg := wm.cfgManager.GetConfig()
 	currPrimaryClusterID := interoperatorCfg.PrimaryClusterID

--- a/interoperator/controllers/multiclusterdeploy/watchmanager/internal_test.go
+++ b/interoperator/controllers/multiclusterdeploy/watchmanager/internal_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	mock_v1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1/mock_sfcluster"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/config"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
+
 	mock_clusterRegistry "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry/mock_registry"
 
 	gomock "github.com/golang/mock/gomock"
@@ -130,11 +132,13 @@ func Test_watchManager_addCluster(t *testing.T) {
 	var ctrl *gomock.Controller
 
 	setupClients(g)
+	setupCfgManager(g)
 
 	type fields struct {
 		defaultCluster  kubernetes.Client
 		clusterRegistry registry.ClusterRegistry
 		clusterWatchers []*clusterWatcher
+		cfgManager      config.Config
 	}
 	type args struct {
 		clusterID string
@@ -189,6 +193,7 @@ func Test_watchManager_addCluster(t *testing.T) {
 			fields: fields{
 				defaultCluster:  c1,
 				clusterWatchers: []*clusterWatcher{},
+				cfgManager:      cfgManager,
 			},
 			args: args{
 				clusterID: "bar",
@@ -211,6 +216,7 @@ func Test_watchManager_addCluster(t *testing.T) {
 			fields: fields{
 				defaultCluster:  c1,
 				clusterWatchers: []*clusterWatcher{},
+				cfgManager:      cfgManager,
 			},
 			args: args{
 				clusterID: "bar",
@@ -236,6 +242,7 @@ func Test_watchManager_addCluster(t *testing.T) {
 				defaultCluster:  tt.fields.defaultCluster,
 				clusterRegistry: tt.fields.clusterRegistry,
 				clusterWatchers: tt.fields.clusterWatchers,
+				cfgManager:      tt.fields.cfgManager,
 			}
 			if tt.setup != nil {
 				tt.setup(wm)

--- a/interoperator/controllers/multiclusterdeploy/watchmanager/manager.go
+++ b/interoperator/controllers/multiclusterdeploy/watchmanager/manager.go
@@ -1,6 +1,7 @@
 package watchmanager
 
 import (
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/config"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/errors"
 
@@ -62,6 +63,12 @@ func Initialize(kubeConfig *rest.Config, scheme *runtime.Scheme, mapper meta.RES
 	if err != nil {
 		return err
 	}
+
+	cfgManager, err := config.New(kubeConfig, scheme, mapper)
+	if err != nil {
+		return err
+	}
+
 	instanceEvents := make(chan event.GenericEvent, 1024)
 	bindingEvents := make(chan event.GenericEvent, 1024)
 	clusterEvents := make(chan event.GenericEvent, 1024)
@@ -70,6 +77,7 @@ func Initialize(kubeConfig *rest.Config, scheme *runtime.Scheme, mapper meta.RES
 	wm := &watchManager{
 		defaultCluster:  defaultCluster,
 		clusterRegistry: clusterRegistry,
+		cfgManager:      cfgManager,
 		clusterWatchers: make([]*clusterWatcher, 0),
 		instanceEvents:  instanceEvents,
 		bindingEvents:   bindingEvents,

--- a/interoperator/go.sum
+++ b/interoperator/go.sum
@@ -881,6 +881,7 @@ k8s.io/apiextensions-apiserver v0.18.8/go.mod h1:7f4ySEkkvifIr4+BRrRWriKKIJjPyg9
 k8s.io/apimachinery v0.18.6/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
 k8s.io/apimachinery v0.18.8 h1:jimPrycCqgx2QPearX3to1JePz7wSbVLq+7PdBTTwQ0=
 k8s.io/apimachinery v0.18.8/go.mod h1:6sQd+iHEqmOtALqOFjSWp2KZ9F0wlU/nWm0ZgsYWMig=
+k8s.io/apimachinery v0.20.2 h1:hFx6Sbt1oG0n6DZ+g4bFt5f6BoMkOjKWsQFu077M3Vg=
 k8s.io/apiserver v0.18.6/go.mod h1:Zt2XvTHuaZjBz6EFYzpp+X4hTmgWGy8AthNVnTdm3Wg=
 k8s.io/apiserver v0.18.8/go.mod h1:12u5FuGql8Cc497ORNj79rhPdiXQC4bf53X/skR/1YM=
 k8s.io/cli-runtime v0.18.8 h1:ycmbN3hs7CfkJIYxJAOB10iW7BVPmXGXkfEyiV9NJ+k=

--- a/interoperator/internal/config/config.go
+++ b/interoperator/internal/config/config.go
@@ -111,12 +111,12 @@ func (cfg *config) GetConfig() *InteroperatorConfig {
 	interoperatorConfig := &InteroperatorConfig{}
 	err := cfg.fetchConfig()
 	if err != nil {
-		log.Info("failed to read interoperator config. using defaults.")
+		log.Error(err, "failed to read interoperator config. using defaults.")
 		return setConfigDefaults(interoperatorConfig)
 	}
 	err = yaml.Unmarshal([]byte(cfg.configMap.Data[constants.ConfigMapKey]), interoperatorConfig)
 	if err != nil {
-		log.Info("failed to decode interoperator config. using defaults.")
+		log.Error(err, "failed to decode interoperator config. using defaults.")
 		return setConfigDefaults(interoperatorConfig)
 	}
 	return setConfigDefaults(interoperatorConfig)

--- a/interoperator/internal/config/config.go
+++ b/interoperator/internal/config/config.go
@@ -23,10 +23,11 @@ var log = logf.Log.WithName("config.manager")
 
 // InteroperatorConfig contains tuneable configs used by interoperator
 type InteroperatorConfig struct {
-	InstanceWorkerCount    int `yaml:"instanceWorkerCount,omitempty"`
-	BindingWorkerCount     int `yaml:"bindingWorkerCount,omitempty"`
-	SchedulerWorkerCount   int `yaml:"schedulerWorkerCount,omitempty"`
-	ProvisionerWorkerCount int `yaml:"provisionerWorkerCount,omitempty"`
+	InstanceWorkerCount    int    `yaml:"instanceWorkerCount,omitempty"`
+	BindingWorkerCount     int    `yaml:"bindingWorkerCount,omitempty"`
+	SchedulerWorkerCount   int    `yaml:"schedulerWorkerCount,omitempty"`
+	ProvisionerWorkerCount int    `yaml:"provisionerWorkerCount,omitempty"`
+	PrimaryClusterID       string `yaml:"primaryClusterId,omitempty"`
 
 	InstanceContollerWatchList []osbv1alpha1.APIVersionKind `yaml:"instanceContollerWatchList,omitempty"`
 	BindingContollerWatchList  []osbv1alpha1.APIVersionKind `yaml:"bindingContollerWatchList,omitempty"`
@@ -45,6 +46,9 @@ func setConfigDefaults(interoperatorConfig *InteroperatorConfig) *InteroperatorC
 	}
 	if interoperatorConfig.ProvisionerWorkerCount == 0 {
 		interoperatorConfig.ProvisionerWorkerCount = constants.DefaultProvisionerWorkerCount
+	}
+	if interoperatorConfig.PrimaryClusterID == "" {
+		interoperatorConfig.PrimaryClusterID = constants.DefaultPrimaryClusterID
 	}
 
 	return interoperatorConfig

--- a/interoperator/internal/config/config_test.go
+++ b/interoperator/internal/config/config_test.go
@@ -147,6 +147,7 @@ instanceContollerWatchList:
 		InstanceWorkerCount:    constants.DefaultInstanceWorkerCount,
 		SchedulerWorkerCount:   constants.DefaultSchedulerWorkerCount,
 		ProvisionerWorkerCount: constants.DefaultProvisionerWorkerCount,
+		PrimaryClusterID:       "1",
 		InstanceContollerWatchList: []osbv1alpha1.APIVersionKind{
 			osbv1alpha1.APIVersionKind{
 				APIVersion: "kubedb.com/v1alpha1",

--- a/interoperator/pkg/cluster/registry/registry.go
+++ b/interoperator/pkg/cluster/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	resourceV1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/config"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/errors"
 
@@ -83,7 +84,15 @@ func (r *clusterRegistry) GetClient(clusterID string) (kubernetes.Client, error)
 		return nil, err
 	}
 	var cfg *rest.Config
-	if clusterID == constants.OwnClusterID {
+
+	cfgManager, err := config.New(r.kubeConfig, r.scheme, r.mapper)
+	if err != nil {
+		return nil, err
+	}
+	interoperatorCfg := cfgManager.GetConfig()
+	currPrimaryClusterID := interoperatorCfg.PrimaryClusterID
+
+	if clusterID == constants.OwnClusterID || clusterID == currPrimaryClusterID {
 		// Use in cluster config
 		cfg, err = ctrl.GetConfig()
 	} else {

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -11,6 +11,7 @@ const (
 	SFServiceInstanceCounterFinalizerName = "sfserviceinstancecounter.servicefabrik.io"
 	ErrorCountKey                         = "interoperator.servicefabrik.io/error"
 	LastOperationKey                      = "interoperator.servicefabrik.io/lastoperation"
+	PrimaryClusterKey                     = "interoperator.servicefabrik.io/primarycluster"
 	ErrorThreshold                        = 10
 
 	ConfigMapName   = "interoperator-config"
@@ -28,6 +29,7 @@ const (
 	DefaultBindingWorkerCount     = 20
 	DefaultSchedulerWorkerCount   = 10
 	DefaultProvisionerWorkerCount = 10
+	DefaultPrimaryClusterID       = "1"
 
 	GoTemplateType = "gotemplate"
 


### PR DESCRIPTION
- As of now, cluster id of the master/primary cluster is hardcoded to `1` . This PR introduces changes so that it can be made configurable.
- To achive this we introduce a new label `interoperator.servicefabrik.io/primarycluster`, such that this label will have value `true` for sfcluster CR of the primary cluster.
- Further we add new config field `primaryClusterId`in the interoperator configmap, which will always store current primary cluster id.
- This configmap field is reconciled `provisioner_controller` in the mcd deployment. 
- Replicators in mcd will always fetch `primaryClusterId` from the configmap instead of relying on hardcoded value.