### PR TITLE
Rename the provisioner deployment

### DIFF
--- a/helm-charts/interoperator/templates/provisioner.yaml
+++ b/helm-charts/interoperator/templates/provisioner.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   labels:
     control-plane: {{ .Release.Name }}-controller-manager
-  name: provisioner
+  name: provisioner-template
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 0

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
@@ -107,7 +107,7 @@ func (r *ReconcileProvisioner) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	// 2. Get deploment instance for provisioner
 	deplomentInstance := &appsv1.Deployment{}
 	err = r.Get(ctx, types.NamespacedName{
-		Name:      constants.LeaderProvisionerName,
+		Name:      constants.ProvisionerTemplateName,
 		Namespace: constants.InteroperatorNamespace,
 	}, deplomentInstance)
 	if err != nil {

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
@@ -107,7 +107,7 @@ func (r *ReconcileProvisioner) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	// 2. Get deploment instance for provisioner
 	deplomentInstance := &appsv1.Deployment{}
 	err = r.Get(ctx, types.NamespacedName{
-		Name:      constants.ProvisionerName,
+		Name:      constants.LeaderProvisionerName,
 		Namespace: constants.InteroperatorNamespace,
 	}, deplomentInstance)
 	if err != nil {
@@ -414,11 +414,11 @@ func (r *ReconcileProvisioner) reconcileDeployment(deploymentInstance *appsv1.De
 
 	log.Info("Updating provisioner", "Cluster", clusterID)
 	getDeploymentErr := targetClient.Get(ctx, types.NamespacedName{
-		Name:      deploymentInstance.GetName(),
+		Name:      constants.ProvisionerName,
 		Namespace: deploymentInstance.GetNamespace(),
 	}, provisionerInstance)
 
-	provisionerInstance.SetName(deploymentInstance.GetName())
+	provisionerInstance.SetName(constants.ProvisionerName)
 	provisionerInstance.SetNamespace(deploymentInstance.GetNamespace())
 	provisionerInstance.SetLabels(deploymentInstance.GetLabels())
 	// copy spec

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller_test.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller_test.go
@@ -68,7 +68,7 @@ var clusterSecret = &corev1.Secret{
 
 var deploymentInstance = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      "provisioner",
+		Name:      constants.LeaderProvisionerName,
 		Namespace: constants.InteroperatorNamespace,
 	},
 	Spec: appsv1.DeploymentSpec{
@@ -168,7 +168,7 @@ func TestReconcile(t *testing.T) {
 	provisionerInstance := &appsv1.Deployment{}
 	g.Eventually(func() error {
 		err := targetReconciler.Get(context.TODO(), types.NamespacedName{
-			Name:      deploymentInstance.GetName(),
+			Name:      constants.ProvisionerName,
 			Namespace: deploymentInstance.GetNamespace(),
 		}, provisionerInstance)
 		if err != nil {

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller_test.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller_test.go
@@ -68,7 +68,7 @@ var clusterSecret = &corev1.Secret{
 
 var deploymentInstance = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      constants.LeaderProvisionerName,
+		Name:      constants.ProvisionerTemplateName,
 		Namespace: constants.InteroperatorNamespace,
 	},
 	Spec: appsv1.DeploymentSpec{

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -16,8 +16,8 @@ const (
 
 	ConfigMapName         = "interoperator-config"
 	ConfigMapKey          = "config"
-	ProvisionerName       = "active-provisioner"
-	LeaderProvisionerName = "provisioner"
+	ProvisionerName       = "provisioner"
+	LeaderProvisionerName = "provisioner-template"
 
 	NamespaceEnvKey    = "POD_NAMESPACE"
 	OwnClusterIDEnvKey = "CLUSTER_ID"

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -14,9 +14,10 @@ const (
 	PrimaryClusterKey                     = "interoperator.servicefabrik.io/primarycluster"
 	ErrorThreshold                        = 10
 
-	ConfigMapName   = "interoperator-config"
-	ConfigMapKey    = "config"
-	ProvisionerName = "provisioner"
+	ConfigMapName         = "interoperator-config"
+	ConfigMapKey          = "config"
+	ProvisionerName       = "active-provisioner"
+	LeaderProvisionerName = "provisioner"
 
 	NamespaceEnvKey    = "POD_NAMESPACE"
 	OwnClusterIDEnvKey = "CLUSTER_ID"

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -14,10 +14,10 @@ const (
 	PrimaryClusterKey                     = "interoperator.servicefabrik.io/primarycluster"
 	ErrorThreshold                        = 10
 
-	ConfigMapName         = "interoperator-config"
-	ConfigMapKey          = "config"
-	ProvisionerName       = "provisioner"
-	LeaderProvisionerName = "provisioner-template"
+	ConfigMapName           = "interoperator-config"
+	ConfigMapKey            = "config"
+	ProvisionerName         = "provisioner"
+	ProvisionerTemplateName = "provisioner-template"
 
 	NamespaceEnvKey    = "POD_NAMESPACE"
 	OwnClusterIDEnvKey = "CLUSTER_ID"


### PR DESCRIPTION
### Multi-Cluster Deployment
In Multi-Cluster Deployment, The Leader Cluster has the provisioner deployment with the name `provisioner`. The helm manages this deployment. This deployment of the provisioner acts as a template and has a replica count set to 0. The Multi-Cluster Deployer then uses this template and creates provisioners in the sister clusters. The provisioner deployment in sister clusters is now called `active-provisioner`.

Deployments in the Leader Cluster,
```
NAME                                                    READY   UP-TO-DATE   AVAILABLE   AGE
interoperator-broker                                    2/2     2            2           174m
interoperator-multiclusterdeployer-controller-manager   0/0     0            0           174m
interoperator-op-apis-app                               2/2     2            2           174m
interoperator-quota-app                                 2/2     2            2           174m
interoperator-scheduler-controller-manager              2/2     2            2           174m
provisioner                                             0/0     0            0           174m
```
Deployments in the Sister Cluster,
```
NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
active-provisioner   1/1     1            1           156m
```
### Single-Cluster Deployment
In Single-Cluster Deployment, the current practice is to edit the provisioner deployment and set the replica to 1. The helm is unaware of this change made by MCD and may cause problems during the upgrade. To mitigate this, now we have a new active-provisioner deployment along with the provisioner deployment.

Deployments in the Leader/Single Cluster,
```
NAME                                                    READY   UP-TO-DATE   AVAILABLE   AGE
active-provisioner                                      1/1     1            1           168m
interoperator-broker                                    2/2     2            2           174m
interoperator-multiclusterdeployer-controller-manager   0/0     0            0           174m
interoperator-op-apis-app                               2/2     2            2           174m
interoperator-quota-app                                 2/2     2            2           174m
interoperator-scheduler-controller-manager              2/2     2            2           174m
provisioner                                             0/0     0            0           174m
```

Feature: HCPCFS-2661