### PR TITLE
Development- Get Endpoints for instance and binding

### DIFF
--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -535,7 +535,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
 
   getServiceInstance(req, res) {
     function badRequest(err) {
-      res.status(CONST.HTTP_STATUS_CODE.FORBIDDEN).send({});
+      res.status(CONST.HTTP_STATUS_CODE.BAD_REQUEST).send({});
     }
     function notFound(err) {
       res.status(CONST.HTTP_STATUS_CODE.NOT_FOUND).send({});

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -660,14 +660,13 @@ class ServiceBrokerApiController extends FabrikBaseController {
           if(!isPlanBindable) {
             throw new BadRequest('Service plan is not bindable');
           }
-          const resourceStatus = _.get(resource, 'status');
-          const resourceState = resourceStatus.state;
+          const resourceState = _.get(resource, 'status.state');
           if(resourceState === CONST.APISERVER.RESOURCE_STATE.SUCCEEDED) {
             // return response with 200
             const body = {};
             _.set(body,'parameters',_.get(resource, 'spec.parameters'));
 
-            const secretName = resourceStatus.response.secretRef;
+            const secretName = _.get(resource, 'status.response.secretRef');
             return eventmesh.apiServerClient.getSecret(secretName, eventmesh.apiServerClient.getNamespaceId(req.params.instance_id))
               .then(secret => done(secret.data.response, body));
           } else {

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -146,7 +146,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         status: {
           state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE
         },
-        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
       }))
       .then(() => {
         if (!plan.manager.async) {
@@ -157,7 +157,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             namespaceId: eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
             start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
             started_at: new Date(),
-            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
           });
         }
       })
@@ -221,7 +221,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       namespaceId: eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
       start_state: CONST.APISERVER.RESOURCE_STATE.UPDATE,
       started_at: new Date(),
-      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
     };
     return Promise
       .try(() => {
@@ -251,7 +251,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
               state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
               response: {}
             },
-            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
           });
         } else {
           _.set(params, 'instance_id', req.params.instance_id);
@@ -265,7 +265,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
               state: CONST.APISERVER.RESOURCE_STATE.UPDATE,
               description: ''
             },
-            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
           });
         }
       })
@@ -297,7 +297,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
             getKubernetesName(req.params.instance_id),
             eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
-            _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+            _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
           );
         }
       })
@@ -315,7 +315,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
       resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
       resourceId: getKubernetesName(req.params.instance_id),
-      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
     })
       .then(() => eventmesh.apiServerClient.patchOSBResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
@@ -325,7 +325,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
           state: CONST.APISERVER.RESOURCE_STATE.DELETE,
           description: ''
         },
-        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
       }))
       .then(() => {
         if (!plan.manager.async) {
@@ -336,7 +336,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             namespaceId: eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
             start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
             started_at: new Date(),
-            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
           });
         }
       })
@@ -363,7 +363,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             resourceType,
             resourceId,
             eventmesh.apiServerClient.getNamespaceId(resourceId),
-            _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+            _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
           );
         }
       })
@@ -395,7 +395,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceType: resourceType,
       resourceId: resourceId,
       namespaceId: resourceType === CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES ? eventmesh.apiServerClient.getNamespaceId(resourceId) : undefined,
-      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
     })
       .tap(() => logger.debug(`Returning state of operation: ${operation.serviceflow_id}, ${resourceGroup}, ${resourceType}`))
       .then(done.bind(this))
@@ -449,7 +449,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
           status: {
             state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE
           },
-          requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+          requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
         });
       })
       .then(() => eventmesh.apiServerClient.getOSBResourceOperationStatus({
@@ -460,7 +460,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
         started_at: new Date(),
         timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC,
-        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
       }))
       .then(operationStatus => {
         const secretName = operationStatus.response.secretRef;
@@ -485,7 +485,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
         params.binding_id,
         eventmesh.apiServerClient.getNamespaceId(params.instance_id),
-        _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+        _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
       )
         .then(() => res.status(CONST.HTTP_STATUS_CODE.OK).send({}));
     }
@@ -501,7 +501,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
       resourceId: params.binding_id,
       namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
-      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
     })
       .then(() => eventmesh.apiServerClient.updateOSBResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
@@ -511,7 +511,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         status: {
           state: CONST.APISERVER.RESOURCE_STATE.DELETE
         },
-        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
       }))
       .then(() => eventmesh.apiServerClient.getOSBResourceOperationStatus({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
@@ -521,7 +521,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
         started_at: new Date(),
         timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC,
-        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
       }))
       .then(done.bind(this))
       .catch(NotFound, gone)
@@ -570,7 +570,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
         resourceId: getKubernetesName(req.params.instance_id),
-        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
       })
         .then(resource => {
           const isServiceInstanceRetrievable = _.get(catalog.getService(_.get(resource, 'spec.serviceId')), 'instance_retrievable',false);
@@ -646,7 +646,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
         resourceId: req.params.binding_id,
         namespaceId: eventmesh.apiServerClient.getNamespaceId(req.params.instance_id),
-        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
       })
         .then(resource => {
           const isServiceBindingRetrievable = _.get(catalog.getService(_.get(resource, 'spec.serviceId')), 'bindings_retrievable',false);

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -35,13 +35,14 @@ class ServiceBrokerApiController extends FabrikBaseController {
     super();
   }
 
-  removeFinalizersFromOSBResource(resourceType, resourceId, namespaceId) {
+  removeFinalizersFromOSBResource(resourceType, resourceId, namespaceId, requestIdentity) {
     return eventmesh.apiServerClient.removeFinalizers({
       resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
       resourceType: resourceType,
       resourceId: resourceId,
       namespaceId: namespaceId,
-      finalizer: CONST.APISERVER.FINALIZERS.BROKER
+      finalizer: CONST.APISERVER.FINALIZERS.BROKER,
+      requestIdentity: requestIdentity
     });
   }
 
@@ -295,7 +296,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
           return this.removeFinalizersFromOSBResource(
             CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
             getKubernetesName(req.params.instance_id),
-            eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id))
+            eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
+            _.get(req.headers, 'x-broker-api-request-identity')
           );
         }
       })
@@ -360,7 +362,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
           return this.removeFinalizersFromOSBResource(
             resourceType,
             resourceId,
-            eventmesh.apiServerClient.getNamespaceId(resourceId)
+            eventmesh.apiServerClient.getNamespaceId(resourceId),
+            _.get(req.headers, 'x-broker-api-request-identity')
           );
         }
       })
@@ -481,7 +484,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
       return this.removeFinalizersFromOSBResource(
         CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
         params.binding_id,
-        eventmesh.apiServerClient.getNamespaceId(params.instance_id)
+        eventmesh.apiServerClient.getNamespaceId(params.instance_id),
+        _.get(req.headers, 'x-broker-api-request-identity')
       )
         .then(() => res.status(CONST.HTTP_STATUS_CODE.OK).send({}));
     }

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -562,11 +562,14 @@ class ServiceBrokerApiController extends FabrikBaseController {
           }
           const resourceState = _.get(resource, 'status.state');
           // if resource state is enqueued or deleted.
-          if(resourceState === CONST.APISERVER.RESOURCE_STATE.IN_QUEUE || resourceState === CONST.APISERVER.RESOURCE_STATE.DELETE) {
+          if(resourceState === CONST.APISERVER.RESOURCE_STATE.IN_QUEUE) {
             throw new NotFound('Service Instance not found');
           } else if(resourceState === CONST.APISERVER.RESOURCE_STATE.UPDATE) {
             // resource is being updated?
             throw new UnprocessableEntity('Service Instance is being updated and therefore cannot be fetched at this time', 'ConcurrencyError');
+          } else if(resourceState === CONST.APISERVER.RESOURCE_STATE.DELETE) {
+            // resource is being deleted?
+            throw new UnprocessableEntity('Service Instance is being deleted and therefore cannot be fetched at this time', 'ConcurrencyError');
           } else if(resourceState === CONST.OPERATION.IN_PROGRESS || resourceState === CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS) {
             // check the last operation and send 422 accordingly.
             const labels = _.get(resource, 'metadata.labels', false);

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -356,7 +356,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         body.state === CONST.APISERVER.RESOURCE_STATE.IN_QUEUE) {
         body.state = CONST.OPERATION.IN_PROGRESS;
       }
-      logger.debug('returning ..', body);
+      logger.debug('RequestIdentity:', _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent'), ',returning ..', body);
       return Promise.try(() => {
         if (_.get(operation, 'type') === 'delete' && body.state === CONST.OPERATION.SUCCEEDED && resourceGroup === CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR) {
           return this.removeFinalizersFromOSBResource(
@@ -397,7 +397,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       namespaceId: resourceType === CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES ? eventmesh.apiServerClient.getNamespaceId(resourceId) : undefined,
       requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
     })
-      .tap(() => logger.debug(`Returning state of operation: ${operation.serviceflow_id}, ${resourceGroup}, ${resourceType}`))
+      .tap(() => logger.debug(`RequestIdentity: ${_.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')} , Returning state of operation: ${operation.serviceflow_id}, ${resourceGroup}, ${resourceType}`))
       .then(done.bind(this))
       .catch(NotFound, notFound);
   }

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -557,7 +557,6 @@ class ServiceBrokerApiController extends FabrikBaseController {
           const isServiceInstanceRetrievable = _.get(catalog.getService(_.get(resource, 'spec.serviceId')), 'instance_retrievable',false);
           // if service instance is not retrievable
           if(!isServiceInstanceRetrievable) {
-            // note clarify when to throw when to call next
             throw new BadRequest('Service does not support instance retrieval');
           }
           const resourceState = _.get(resource, 'status.state');

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -144,7 +144,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
         spec: params,
         status: {
           state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE
-        }
+        },
+        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
       }))
       .then(() => {
         if (!plan.manager.async) {
@@ -154,7 +155,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
             resourceId: getKubernetesName(req.params.instance_id),
             namespaceId: eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
             start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
-            started_at: new Date()
+            started_at: new Date(),
+            requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
           });
         }
       })
@@ -217,7 +219,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceId: getKubernetesName(req.params.instance_id),
       namespaceId: eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
       start_state: CONST.APISERVER.RESOURCE_STATE.UPDATE,
-      started_at: new Date()
+      started_at: new Date(),
+      requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
     };
     return Promise
       .try(() => {
@@ -246,7 +249,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
             status: {
               state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
               response: {}
-            }
+            },
+            requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
           });
         } else {
           _.set(params, 'instance_id', req.params.instance_id);
@@ -259,7 +263,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
             status: {
               state: CONST.APISERVER.RESOURCE_STATE.UPDATE,
               description: ''
-            }
+            },
+            requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
           });
         }
       })
@@ -307,7 +312,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     return eventmesh.apiServerClient.deleteResource({
       resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
       resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
-      resourceId: getKubernetesName(req.params.instance_id)
+      resourceId: getKubernetesName(req.params.instance_id),
+      requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
     })
       .then(() => eventmesh.apiServerClient.patchOSBResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
@@ -316,7 +322,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
         status: {
           state: CONST.APISERVER.RESOURCE_STATE.DELETE,
           description: ''
-        }
+        },
+        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
       }))
       .then(() => {
         if (!plan.manager.async) {
@@ -326,7 +333,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
             resourceId: getKubernetesName(req.params.instance_id),
             namespaceId: eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
             start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
-            started_at: new Date()
+            started_at: new Date(),
+            requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
           });
         }
       })
@@ -383,7 +391,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceGroup: resourceGroup,
       resourceType: resourceType,
       resourceId: resourceId,
-      namespaceId: resourceType === CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES ? eventmesh.apiServerClient.getNamespaceId(resourceId) : undefined
+      namespaceId: resourceType === CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES ? eventmesh.apiServerClient.getNamespaceId(resourceId) : undefined,
+      requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
     })
       .tap(() => logger.debug(`Returning state of operation: ${operation.serviceflow_id}, ${resourceGroup}, ${resourceType}`))
       .then(done.bind(this))
@@ -436,7 +445,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
           spec: params,
           status: {
             state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE
-          }
+          },
+          requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
         });
       })
       .then(() => eventmesh.apiServerClient.getOSBResourceOperationStatus({
@@ -446,7 +456,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
         namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
         start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
         started_at: new Date(),
-        timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC
+        timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC,
+        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
       }))
       .then(operationStatus => {
         const secretName = operationStatus.response.secretRef;
@@ -485,7 +496,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
       resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
       resourceId: params.binding_id,
-      namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id)
+      namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
+      requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
     })
       .then(() => eventmesh.apiServerClient.updateOSBResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
@@ -494,7 +506,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
         namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
         status: {
           state: CONST.APISERVER.RESOURCE_STATE.DELETE
-        }
+        },
+        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
       }))
       .then(() => eventmesh.apiServerClient.getOSBResourceOperationStatus({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
@@ -503,7 +516,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
         namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
         start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
         started_at: new Date(),
-        timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC
+        timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC,
+        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
       }))
       .then(done.bind(this))
       .catch(NotFound, gone)
@@ -551,7 +565,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
       return eventmesh.apiServerClient.getResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
-        resourceId: getKubernetesName(req.params.instance_id)
+        resourceId: getKubernetesName(req.params.instance_id),
+        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
       })
         .then(resource => {
           const isServiceInstanceRetrievable = _.get(catalog.getService(_.get(resource, 'spec.serviceId')), 'instance_retrievable',false);
@@ -627,7 +642,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
         resourceId: req.params.binding_id,
-        namespaceId: eventmesh.apiServerClient.getNamespaceId(req.params.instance_id)
+        namespaceId: eventmesh.apiServerClient.getNamespaceId(req.params.instance_id),
+        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
       })
         .then(resource => {
           const isServiceBindingRetrievable = _.get(catalog.getService(_.get(resource, 'spec.serviceId')), 'bindings_retrievable',false);

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -582,7 +582,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
               throw new UnprocessableEntity('Service Instance deletion is in progress and therefore cannot be fetched at this time', 'ConcurrencyError');
             }
             throw new UnprocessableEntity(`Service Instance cannot be fetched:lastOperation: ${lastOperation}`, 'ConcurrencyError');
-          } else if(resourceState === CONST.APISERVER.RESOURCE_STATE.SUCCEEDED) {
+          } else if(resourceState === CONST.APISERVER.RESOURCE_STATE.SUCCEEDED || resourceState === CONST.APISERVER.RESOURCE_STATE.FAILED) {
             // return response with 200
             const body = {};
             // generate dashboard client

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -146,7 +146,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         status: {
           state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE
         },
-        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
       }))
       .then(() => {
         if (!plan.manager.async) {
@@ -157,7 +157,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             namespaceId: eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
             start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
             started_at: new Date(),
-            requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
           });
         }
       })
@@ -221,7 +221,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       namespaceId: eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
       start_state: CONST.APISERVER.RESOURCE_STATE.UPDATE,
       started_at: new Date(),
-      requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
     };
     return Promise
       .try(() => {
@@ -251,7 +251,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
               state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
               response: {}
             },
-            requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
           });
         } else {
           _.set(params, 'instance_id', req.params.instance_id);
@@ -265,7 +265,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
               state: CONST.APISERVER.RESOURCE_STATE.UPDATE,
               description: ''
             },
-            requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
           });
         }
       })
@@ -297,7 +297,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
             getKubernetesName(req.params.instance_id),
             eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
-            _.get(req.headers, 'x-broker-api-request-identity')
+            _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
           );
         }
       })
@@ -315,7 +315,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
       resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
       resourceId: getKubernetesName(req.params.instance_id),
-      requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
     })
       .then(() => eventmesh.apiServerClient.patchOSBResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
@@ -325,7 +325,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
           state: CONST.APISERVER.RESOURCE_STATE.DELETE,
           description: ''
         },
-        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
       }))
       .then(() => {
         if (!plan.manager.async) {
@@ -336,7 +336,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             namespaceId: eventmesh.apiServerClient.getNamespaceId(getKubernetesName(req.params.instance_id)),
             start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
             started_at: new Date(),
-            requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+            requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
           });
         }
       })
@@ -363,7 +363,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             resourceType,
             resourceId,
             eventmesh.apiServerClient.getNamespaceId(resourceId),
-            _.get(req.headers, 'x-broker-api-request-identity')
+            _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
           );
         }
       })
@@ -395,7 +395,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceType: resourceType,
       resourceId: resourceId,
       namespaceId: resourceType === CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES ? eventmesh.apiServerClient.getNamespaceId(resourceId) : undefined,
-      requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
     })
       .tap(() => logger.debug(`Returning state of operation: ${operation.serviceflow_id}, ${resourceGroup}, ${resourceType}`))
       .then(done.bind(this))
@@ -449,7 +449,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
           status: {
             state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE
           },
-          requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+          requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
         });
       })
       .then(() => eventmesh.apiServerClient.getOSBResourceOperationStatus({
@@ -460,7 +460,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         start_state: CONST.APISERVER.RESOURCE_STATE.IN_QUEUE,
         started_at: new Date(),
         timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC,
-        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
       }))
       .then(operationStatus => {
         const secretName = operationStatus.response.secretRef;
@@ -485,7 +485,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
         params.binding_id,
         eventmesh.apiServerClient.getNamespaceId(params.instance_id),
-        _.get(req.headers, 'x-broker-api-request-identity')
+        _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
       )
         .then(() => res.status(CONST.HTTP_STATUS_CODE.OK).send({}));
     }
@@ -501,7 +501,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
       resourceId: params.binding_id,
       namespaceId: eventmesh.apiServerClient.getNamespaceId(params.instance_id),
-      requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+      requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
     })
       .then(() => eventmesh.apiServerClient.updateOSBResource({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
@@ -511,7 +511,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         status: {
           state: CONST.APISERVER.RESOURCE_STATE.DELETE
         },
-        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
       }))
       .then(() => eventmesh.apiServerClient.getOSBResourceOperationStatus({
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
@@ -521,7 +521,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         start_state: CONST.APISERVER.RESOURCE_STATE.DELETE,
         started_at: new Date(),
         timeout_in_sec: CONST.OSB_OPERATION.OSB_SYNC_OPERATION_TIMEOUT_IN_SEC,
-        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
       }))
       .then(done.bind(this))
       .catch(NotFound, gone)
@@ -570,7 +570,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
         resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,
         resourceId: getKubernetesName(req.params.instance_id),
-        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
       })
         .then(resource => {
           const isServiceInstanceRetrievable = _.get(catalog.getService(_.get(resource, 'spec.serviceId')), 'instance_retrievable',false);
@@ -647,7 +647,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
         resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS,
         resourceId: req.params.binding_id,
         namespaceId: eventmesh.apiServerClient.getNamespaceId(req.params.instance_id),
-        requestIdentity: _.get(req.headers, 'x-broker-api-request-identity')
+        requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY)
       })
         .then(resource => {
           const isServiceBindingRetrievable = _.get(catalog.getService(_.get(resource, 'spec.serviceId')), 'bindings_retrievable',false);

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -590,8 +590,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             throw new UnprocessableEntity('Service Instance is being deleted and therefore cannot be fetched at this time', 'ConcurrencyError');
           } else if(resourceState === CONST.OPERATION.IN_PROGRESS || resourceState === CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS) {
             // check the last operation and send 422 accordingly.
-            const labels = _.get(resource, 'metadata.labels', false);
-            const lastOperation = labels ? labels['interoperator.servicefabrik.io/lastoperation'] : '';
+            const lastOperation = _.get(resource, ['metadata','labels', CONST.APISERVER.LASTOPERATION_LABEL_KEY], '');
 
             if(lastOperation === CONST.APISERVER.RESOURCE_STATE.IN_QUEUE) {
               throw new NotFound('Service Instance not found');

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -222,7 +222,7 @@ exports.addRequestIdentity = function () {
     if(requestIdentity) {
       res.set('X-Broker-API-Request-Identity', requestIdentity);
     }
-    next()
+    next();
   };
 };
 

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -216,7 +216,7 @@ exports.minApiVersion = function (minVersion) {
   };
 };
 
-exports.addRequestIdentity = function () {
+exports.addRequestIdentityToResponse = function () {
   return function (req, res, next) {
     const requestIdentity = _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY);
     if(requestIdentity) {

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -208,7 +208,6 @@ exports.checkBlockingOperationInProgress = function () {
 
 exports.minApiVersion = function (minVersion) {
   return function (req, res, next) {
-    logger.info(`Bansal ${minVersion}`);
     const version = _.get(req.headers, 'x-broker-api-version', '1.0');
     if(commonFunctions.compareVersions(version, minVersion) < 0) {
       return next(new PreconditionFailed(`At least Broker API version ${minVersion} is required.`));

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -218,7 +218,7 @@ exports.minApiVersion = function (minVersion) {
 
 exports.addRequestIdentity = function () {
   return function (req, res, next) {
-    const requestIdentity = _.get(req.headers, 'x-broker-api-request-identity');
+    const requestIdentity = _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY);
     if(requestIdentity) {
       res.set('X-Broker-API-Request-Identity', requestIdentity);
     }

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -216,4 +216,14 @@ exports.minApiVersion = function (minVersion) {
   };
 };
 
+exports.addRequestIdentity = function () {
+  return function (req, res, next) {
+    const requestIdentity = _.get(req.headers, 'x-broker-api-request-identity');
+    if(requestIdentity) {
+      res.set('X-Broker-API-Request-Identity', requestIdentity);
+    }
+    next()
+  };
+};
+
 Object.assign(module.exports, require('@sf/express-commons').middleware);

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -5,6 +5,7 @@ const Ajv = require('ajv');
 const {
   CONST,
   errors: {
+    PreconditionFailed,
     BadRequest,
     Forbidden,
     DeploymentAlreadyLocked,
@@ -200,6 +201,17 @@ exports.checkBlockingOperationInProgress = function () {
           logger.error('[LOCK]: exception occurred --', err);
           next(err);
         });
+    }
+    next();
+  };
+};
+
+exports.minApiVersion = function (minVersion) {
+  return function (req, res, next) {
+    logger.info(`Bansal ${minVersion}`);
+    const version = _.get(req.headers, 'x-broker-api-version', '1.0');
+    if(commonFunctions.compareVersions(version, minVersion) < 0) {
+      return next(new PreconditionFailed(`At least Broker API version ${minVersion} is required.`));
     }
     next();
   };

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
@@ -33,7 +33,7 @@ instanceRouter.route('/')
   .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), middleware.validateSchemaForRequest('service_instance', 'create'), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
   .patch([middleware.injectPlanInRequest(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateSchemaForRequest('service_instance', 'update'), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
   .delete([middleware.validateRequest(), controller.handleWithResourceLocking('deleteInstance', CONST.OPERATION_TYPE.DELETE)])
-  .get(controller.handler('getServiceInstance'))
+  .get([middleware.minApiVersion('2.14'), controller.handler('getServiceInstance')])
   .all(middleware.methodNotAllowed(['PUT', 'PATCH', 'DELETE', 'GET']));
 instanceRouter.route('/last_operation')
   .get(controller.handler('getLastInstanceOperation'))

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
@@ -33,7 +33,8 @@ instanceRouter.route('/')
   .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), middleware.validateSchemaForRequest('service_instance', 'create'), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
   .patch([middleware.injectPlanInRequest(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateSchemaForRequest('service_instance', 'update'), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
   .delete([middleware.validateRequest(), controller.handleWithResourceLocking('deleteInstance', CONST.OPERATION_TYPE.DELETE)])
-  .all(middleware.methodNotAllowed(['PUT', 'PATCH', 'DELETE']));
+  .get(controller.handler('getServiceInstance'))
+  .all(middleware.methodNotAllowed(['PUT', 'PATCH', 'DELETE', 'GET']));
 instanceRouter.route('/last_operation')
   .get(controller.handler('getLastInstanceOperation'))
   .all(middleware.methodNotAllowed(['GET']));

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
@@ -16,6 +16,8 @@ const instanceRouter = express.Router({
 
 /* Service Broker API Router */
 router.use(middleware.basicAuth(config.username, config.password));
+router.use(middleware.addRequestIdentity());
+
 if (_.includes(['production', 'test'], process.env.NODE_ENV)) {
   router.use(controller.handler('apiVersion'));
 }

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
@@ -16,7 +16,7 @@ const instanceRouter = express.Router({
 
 /* Service Broker API Router */
 router.use(middleware.basicAuth(config.username, config.password));
-router.use(middleware.addRequestIdentity());
+router.use(middleware.addRequestIdentityToResponse());
 
 if (_.includes(['production', 'test'], process.env.NODE_ENV)) {
   router.use(controller.handler('apiVersion'));

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
@@ -41,4 +41,5 @@ instanceRouter.route('/last_operation')
 instanceRouter.route('/service_bindings/:binding_id')
   .put([middleware.checkBlockingOperationInProgress(), middleware.validateSchemaForRequest('service_binding', 'create'), controller.handler('putBinding')])
   .delete(middleware.checkBlockingOperationInProgress(), controller.handler('deleteBinding'))
-  .all(middleware.methodNotAllowed(['PUT', 'DELETE']));
+  .get([middleware.minApiVersion('2.14'), controller.handler('getServiceBinding')])
+  .all(middleware.methodNotAllowed(['PUT', 'DELETE', 'GET']));

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
@@ -8,7 +8,6 @@ const { CONST } = require('@sf/common-utils');
 
 
 const camelcaseKeys = require('camelcase-keys');
-
 describe('service-broker-api-enhancement', function () {
   describe('get instance endpoint', function () {
       const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
@@ -81,7 +80,7 @@ describe('service-broker-api-enhancement', function () {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
       return chai.request(app)
         .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .set('X-Broker-API-Version', '2.14')
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
@@ -95,7 +94,7 @@ describe('service-broker-api-enhancement', function () {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, 404);
       return chai.request(app)
         .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .set('X-Broker-API-Version', '2.14')
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
@@ -119,7 +118,7 @@ describe('service-broker-api-enhancement', function () {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
       return chai.request(app)
         .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .set('X-Broker-API-Version', '2.14')
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
@@ -145,7 +144,7 @@ describe('service-broker-api-enhancement', function () {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
       return chai.request(app)
         .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .set('X-Broker-API-Version', '2.14')
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
@@ -171,7 +170,7 @@ describe('service-broker-api-enhancement', function () {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
       return chai.request(app)
         .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .set('X-Broker-API-Version', '2.14')
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
@@ -198,7 +197,7 @@ describe('service-broker-api-enhancement', function () {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
       return chai.request(app)
         .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .set('X-Broker-API-Version', '2.14')
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
@@ -227,7 +226,7 @@ describe('service-broker-api-enhancement', function () {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
       return chai.request(app)
         .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .set('X-Broker-API-Version', '2.14')
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
@@ -253,7 +252,7 @@ describe('service-broker-api-enhancement', function () {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
       return chai.request(app)
         .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .set('X-Broker-API-Version', '2.14')
         .auth(config.username, config.password)
         .then(res => {
           config.services = oldServices;
@@ -284,7 +283,7 @@ describe('service-broker-api-enhancement', function () {
       mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
       return chai.request(app)
         .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .set('X-Broker-API-Version', '2.14')
         .auth(config.username, config.password)
         .then(res => {
           config.services = oldServices;
@@ -296,6 +295,20 @@ describe('service-broker-api-enhancement', function () {
             dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
           })
         });
+    });
+
+    it('returns 412 (PreconditionFailed) error if broker api version is not atleast 2.14', function () {
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.12')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            expect(res).to.have.status(412);
+          });
     });
 
   });

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
@@ -13,585 +13,584 @@ const {
 } = require('@sf/common-utils');
 const camelcaseKeys = require('camelcase-keys');
 
-describe('service-broker-api-enhancement', function () {
-  const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
-  const plan_id = '466c5078-df6e-427d-8fb2-c76af50c0f56';
-  const organization_guid = 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a';
-  const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
-  const instance_id = '951f7a03-df8a-4b75-90be-38abe455568d';
-  const binding_id = 'd336b15c-37d6-4249-b3c7-430d5153a0d8';
-  const protocol = config.external.protocol;
-  const host = config.external.host;
-  const docker_url = parseUrl(config.docker.url);
-  const username = 'user';
-  const password = 'secret';
-
-  afterEach(function () {
-    mocks.reset();
-  });
-  
-  describe('get instance endpoint', function () {
-    const payload2 = {
-      apiVersion: 'osb.servicefabrik.io/v1alpha1',
-      kind: 'SFServiceInstance',
-      metadata: {
-        finalizers: ['broker.servicefabrik.io'],
-        name: instance_id,
-        labels: {
-          'interoperator.servicefabrik.io/lastoperation': 'in_queue',
-          state: 'in_queue'
-        }
-      },
-      spec: {
-        service_id: service_id,
-        plan_id: plan_id,
-        context: {
-          platform: 'cloudfoundry',
-          organization_guid: organization_guid,
-          space_guid: space_guid
-        },
-        organization_guid: organization_guid,
-        space_guid: space_guid,
-        parameters: {
-          foo: 'bar'
-        }
-      },
-      status: {
-        state: 'succeeded'
-      }
-    };
-
-    const payload2K8s = {
-      apiVersion: 'osb.servicefabrik.io/v1alpha1',
-      kind: 'SFServiceInstance',
-      metadata: {
-        finalizers: ['broker.servicefabrik.io'],
-        name: instance_id,
-        labels: {
-          state: 'in_queue'
-        }
-      },
-      spec: {
-        service_id: service_id,
-        plan_id: plan_id,
-        context: {
-          platform: 'kubernetes',
-          namespace: 'default'
-        },
-        organization_guid: organization_guid,
-        space_guid: space_guid,
-      },
-      status: {
-        state: 'succeeded'
-      }
-    };
-
-
+describe('service-broker-api-2.0', function () {
+  describe('instances', function () {
+    const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
+    const plan_id = '466c5078-df6e-427d-8fb2-c76af50c0f56';
+    const organization_guid = 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a';
+    const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
+    const instance_id = '951f7a03-df8a-4b75-90be-38abe455568d';
+    const binding_id = 'd336b15c-37d6-4249-b3c7-430d5153a0d8';
+    const protocol = config.external.protocol;
+    const host = config.external.host;
+    const docker_url = parseUrl(config.docker.url);
+    const username = 'user';
+    const password = 'secret';
     const baseCFUrl = '/cf/v2';
-    it('returns 400 (BadRequest) error if service does not support instance retrieval', function () {
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          expect(res).to.have.status(400);
-          mocks.verify();
-        });
-    });
 
-    it('returns 404 if service instance not found', function () {
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, 404);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          expect(res).to.have.status(404);
-          mocks.verify();
-        });
-    });
-
-    it('returns 404 if status is in_queue', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      if (service) {
-        _.set(service, 'instance_retrievable', true);
-        catalog.reload();
-      }
-
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.status.state = 'in_queue';
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(404);
-          mocks.verify();
-        });
-    });
-
-    it('returns 422 if status is delete', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      if (service) {
-        _.set(service, 'instance_retrievable', true);
-        catalog.reload();
-      }
-
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.status.state = 'delete';
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(422);
-          expect(res.body.error).to.deep.equal('ConcurrencyError');
-          expect(res.body.description).to.deep.equal('Service Instance is being deleted and therefore cannot be fetched at this time');
-          mocks.verify();
-        });
-    });
-
-    it('returns 404 if status is create in progress', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      if (service) {
-        _.set(service, 'instance_retrievable', true);
-        catalog.reload();
-      }
-
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.status.state = 'in progress';
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(404);
-          mocks.verify();
-        });
-    });
-
-    it('returns 422 if status is update in progress', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      if (service) {
-        _.set(service, 'instance_retrievable', true);
-        catalog.reload();
-      }
-
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.status.state = 'in progress';
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      testPayload2.metadata.labels['interoperator.servicefabrik.io/lastoperation'] = 'update'
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(422);
-          expect(res.body.error).to.be.eql('ConcurrencyError');
-          expect(res.body.description).to.be.eql('Service Instance updation is in progress and therefore cannot be fetched at this time');
-          mocks.verify();
-        });
-    });
-
-    it('returns 422 if status is update', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      if (service) {
-        _.set(service, 'instance_retrievable', true);
-        catalog.reload();
-      }
-
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.status.state = 'update';
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(422);
-          expect(res.body.error).to.deep.equal('ConcurrencyError');
-          expect(res.body.description).to.deep.equal('Service Instance is being updated and therefore cannot be fetched at this time');
-          mocks.verify();
-        });
-    });
-
-    it('returns 200 if service instance is successfully returned', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      if (service) {
-        _.set(service, 'instance_retrievable', true);
-        catalog.reload();
-      }
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(200);
-          expect(res.body).to.deep.equal({
-            service_id: service_id,
-            plan_id: plan_id,
-            parameters: {
-              foo: 'bar'
-            },
-            dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
-          })
-          mocks.verify();
-        });
-    });
-
-    it('returns 200 if service instance is successfully returned (k8s)', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      if (service) {
-        _.set(service, 'instance_retrievable', true);
-        catalog.reload();
-      }
-      const testPayload2 = _.cloneDeep(payload2K8s);
-      testPayload2.spec = camelcaseKeys(payload2K8s.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(200);
-          expect(res.body).to.deep.equal({
-            service_id: service_id,
-            plan_id: plan_id,
-            dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
-          })
-        });
-    });
-
-    it('returns 200 if status is failed', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      if (service) {
-        _.set(service, 'instance_retrievable', true);
-        catalog.reload();
-      }
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.status.state = 'failed';
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(200);
-          expect(res.body).to.deep.equal({
-            service_id: service_id,
-            plan_id: plan_id,
-            parameters: {
-              foo: 'bar'
-            },
-            dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
-          })
-          mocks.verify();
-        });
-    });
-
-    it('returns 412 (PreconditionFailed) error if broker api version is not atleast 2.14', function () {
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.12')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          expect(res).to.have.status(412);
-        });
+    afterEach(function () {
+      mocks.reset();
     });
     
-    it('should return X-Broker-API-Request-Identity in response if set in request', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      if (service) {
-        _.set(service, 'instance_retrievable', true);
-        catalog.reload();
-      }
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .set('X-Broker-API-Request-Identity', 'someid')
-        .auth(config.username, config.password)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(200);
-          expect(res).to.have.header('X-Broker-API-Request-Identity', 'someid');
-          expect(res.body).to.deep.equal({
-            service_id: service_id,
-            plan_id: plan_id,
-            parameters: {
-              foo: 'bar'
-            },
-            dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
-          })
-          mocks.verify();
-        });
-    });
-
-    it('should return X-Broker-API-Request-Identity in response if set in request (with precondition failure)', function () {
-      const testPayload2 = _.cloneDeep(payload2);
-      testPayload2.spec = camelcaseKeys(payload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}`)
-        .set('X-Broker-API-Version', '2.12')
-        .set('X-Broker-API-Request-Identity', 'someid')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          expect(res).to.have.status(412);
-          expect(res).to.have.header('X-Broker-API-Request-Identity', 'someid');
-        });
-    });
-
-  });
-
-
-  describe('get binding endpoint', function () {
-    const bindPayload2 = {
-      apiVersion: 'osb.servicefabrik.io/v1alpha1',
-      kind: 'SFServiceBinding',
-      metadata: {
-        finalizers: ['broker.servicefabrik.io'],
-        name: binding_id,
-        labels: {
+    describe('#fetch-instance', function () {
+      const payload2 = {
+        apiVersion: 'osb.servicefabrik.io/v1alpha1',
+        kind: 'SFServiceInstance',
+        metadata: {
+          finalizers: ['broker.servicefabrik.io'],
+          name: instance_id,
+          labels: {
+            'interoperator.servicefabrik.io/lastoperation': 'in_queue',
+            state: 'in_queue'
+          }
+        },
+        spec: {
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          },
+          organization_guid: organization_guid,
+          space_guid: space_guid,
+          parameters: {
+            foo: 'bar'
+          }
+        },
+        status: {
           state: 'succeeded'
         }
-      },
-      spec: {
-        service_id: service_id,
-        plan_id: plan_id,
-        context: {
-          platform: 'cloudfoundry',
-          organization_guid: organization_guid,
-          space_guid: space_guid
+      };
+
+      const payload2K8s = {
+        apiVersion: 'osb.servicefabrik.io/v1alpha1',
+        kind: 'SFServiceInstance',
+        metadata: {
+          finalizers: ['broker.servicefabrik.io'],
+          name: instance_id,
+          labels: {
+            state: 'in_queue'
+          }
         },
-        organization_guid: organization_guid,
-        space_guid: space_guid,
-        parameters: {
-          foo: 'bar'
+        spec: {
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'kubernetes',
+            namespace: 'default'
+          },
+          organization_guid: organization_guid,
+          space_guid: space_guid,
+        },
+        status: {
+          state: 'succeeded'
         }
-      },
-      status: {
-        state: 'succeeded',
-        response: {
-          secretRef: binding_id
-        }
-      }
-    };
-    const secretData = {
-      hostname: docker_url.hostname,
-      username: username,
-      password: password,
-      ports: {
-        '12345/tcp': 12345
-      },
-      uri: `http://${username}:${password}@${docker_url.hostname}`
-    };
+      };
 
-
-    const baseCFUrl = '/cf/v2';
-    it('returns 400 (BadRequest) error if service does not support binding retrieval', function () {
-      const testPayload2 = _.cloneDeep(bindPayload2);
-      testPayload2.spec = camelcaseKeys(bindPayload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          expect(res).to.have.status(400);
-          mocks.verify();
-        });
-    });
-
-    it('returns 400 (BadRequest) error if service plan is not bindable', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      const plan = _.find(service.plans, ['id', plan_id]);
-      if (service) {
-        _.set(service, 'bindings_retrievable', true);
-        _.set(service, 'bindable', true);
-      }
-      if (plan) {
-        _.set(plan, 'bindable', false);
-      }
-      catalog.reload();
-
-      const testPayload2 = _.cloneDeep(bindPayload2);
-      testPayload2.spec = camelcaseKeys(bindPayload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(400);
-          mocks.verify();
-        });
-    });
-
-    it('returns 404 if binding not found', function () {
-      const testPayload2 = _.cloneDeep(bindPayload2);
-      testPayload2.spec = camelcaseKeys(bindPayload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {}, 1, 404);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          expect(res).to.have.status(404);
-          mocks.verify();
-        });
-    });
-
-    it('returns 200 if service binding is successfully returned', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      const plan = _.find(service.plans, ['id', plan_id]);
-      if (service) {
-        _.set(service, 'bindings_retrievable', true);
-        _.set(service, 'bindable', true);
-      }
-      if (plan) {
-        _.set(plan, 'bindable', true);
-      }
-      catalog.reload();
-
-      const testPayload2 = _.cloneDeep(bindPayload2);
-      testPayload2.spec = camelcaseKeys(bindPayload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
-      mocks.apiServerEventMesh.nockGetSecret(binding_id, _.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE), {
-        data: {
-          response: encodeBase64({ credentials: secretData })
-        }
-      });
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(200);
-          expect(res.body).to.eql({
-            parameters: {
-              foo: 'bar'
-            },
-            credentials: {
-              hostname: docker_url.hostname,
-              username: username,
-              password: password,
-              ports: {
-                '12345/tcp': 12345
-              },
-              uri: `http://${username}:${password}@${docker_url.hostname}`
-            }
-          });
-          mocks.verify();
-        });
-    });
-
-    it('returns 404 if service binding status is not succeeded', function () {
-      const oldServices = config.services;
-      const service = _.find(config.services, ['id', service_id]);
-      const plan = _.find(service.plans, ['id', plan_id]);
-      if (service) {
-        _.set(service, 'bindings_retrievable', true);
-        _.set(service, 'bindable', true);
-      }
-      catalog.reload();
-
-      const testPayload2 = _.cloneDeep(bindPayload2);
-      testPayload2.status.state = 'failed';
-      testPayload2.spec = camelcaseKeys(bindPayload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
-      return chai.request(app)
-        .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
-        .set('X-Broker-API-Version', '2.14')
-        .auth(config.username, config.password)
-        .catch(err => err.response)
-        .then(res => {
-          config.services = oldServices;
-          catalog.reload();
-          expect(res).to.have.status(404);
-          mocks.verify();
-        });
-    });
-
-    it('returns 412 (PreconditionFailed) error if broker api version is not atleast 2.14', function () {
-      const testPayload2 = _.cloneDeep(bindPayload2);
-      testPayload2.spec = camelcaseKeys(bindPayload2.spec);
-      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
+      it('returns 400 (BadRequest) error if service does not support instance retrieval', function () {
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
-          .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            expect(res).to.have.status(400);
+            mocks.verify();
+          });
+      });
+
+      it('returns 404 if service instance not found', function () {
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, 404);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            expect(res).to.have.status(404);
+            mocks.verify();
+          });
+      });
+
+      it('returns 404 if status is in_queue', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          catalog.reload();
+        }
+
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.status.state = 'in_queue';
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(404);
+            mocks.verify();
+          });
+      });
+
+      it('returns 422 if status is delete', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          catalog.reload();
+        }
+
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.status.state = 'delete';
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(422);
+            expect(res.body.error).to.deep.equal('ConcurrencyError');
+            expect(res.body.description).to.deep.equal('Service Instance is being deleted and therefore cannot be fetched at this time');
+            mocks.verify();
+          });
+      });
+
+      it('returns 404 if status is create in progress', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          catalog.reload();
+        }
+
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.status.state = 'in progress';
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(404);
+            mocks.verify();
+          });
+      });
+
+      it('returns 422 if status is update in progress', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          catalog.reload();
+        }
+
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.status.state = 'in progress';
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.metadata.labels['interoperator.servicefabrik.io/lastoperation'] = 'update'
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(422);
+            expect(res.body.error).to.be.eql('ConcurrencyError');
+            expect(res.body.description).to.be.eql('Service Instance updation is in progress and therefore cannot be fetched at this time');
+            mocks.verify();
+          });
+      });
+
+      it('returns 422 if status is update', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          catalog.reload();
+        }
+
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.status.state = 'update';
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(422);
+            expect(res.body.error).to.deep.equal('ConcurrencyError');
+            expect(res.body.description).to.deep.equal('Service Instance is being updated and therefore cannot be fetched at this time');
+            mocks.verify();
+          });
+      });
+
+      it('returns 200 if service instance is successfully returned', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          catalog.reload();
+        }
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(200);
+            expect(res.body).to.deep.equal({
+              service_id: service_id,
+              plan_id: plan_id,
+              parameters: {
+                foo: 'bar'
+              },
+              dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
+            })
+            mocks.verify();
+          });
+      });
+
+      it('returns 200 if service instance is successfully returned (k8s)', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          catalog.reload();
+        }
+        const testPayload2 = _.cloneDeep(payload2K8s);
+        testPayload2.spec = camelcaseKeys(payload2K8s.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(200);
+            expect(res.body).to.deep.equal({
+              service_id: service_id,
+              plan_id: plan_id,
+              dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
+            })
+          });
+      });
+
+      it('returns 200 if status is failed', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          catalog.reload();
+        }
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.status.state = 'failed';
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(200);
+            expect(res.body).to.deep.equal({
+              service_id: service_id,
+              plan_id: plan_id,
+              parameters: {
+                foo: 'bar'
+              },
+              dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
+            })
+            mocks.verify();
+          });
+      });
+
+      it('returns 412 (PreconditionFailed) error if broker api version is not atleast 2.14', function () {
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
           .set('X-Broker-API-Version', '2.12')
           .auth(config.username, config.password)
           .catch(err => err.response)
           .then(res => {
             expect(res).to.have.status(412);
           });
+      });
+      
+      it('should return X-Broker-API-Request-Identity in response if set in request', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          catalog.reload();
+        }
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .set('X-Broker-API-Request-Identity', 'someid')
+          .auth(config.username, config.password)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(200);
+            expect(res).to.have.header('X-Broker-API-Request-Identity', 'someid');
+            expect(res.body).to.deep.equal({
+              service_id: service_id,
+              plan_id: plan_id,
+              parameters: {
+                foo: 'bar'
+              },
+              dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
+            })
+            mocks.verify();
+          });
+      });
+
+      it('should return X-Broker-API-Request-Identity in response if set in request (with precondition failure)', function () {
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.spec = camelcaseKeys(payload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.12')
+          .set('X-Broker-API-Request-Identity', 'someid')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            expect(res).to.have.status(412);
+            expect(res).to.have.header('X-Broker-API-Request-Identity', 'someid');
+          });
+      });
+
     });
 
+
+    describe('#fetch-binding', function () {
+      const bindPayload2 = {
+        apiVersion: 'osb.servicefabrik.io/v1alpha1',
+        kind: 'SFServiceBinding',
+        metadata: {
+          finalizers: ['broker.servicefabrik.io'],
+          name: binding_id,
+          labels: {
+            state: 'succeeded'
+          }
+        },
+        spec: {
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          },
+          organization_guid: organization_guid,
+          space_guid: space_guid,
+          parameters: {
+            foo: 'bar'
+          }
+        },
+        status: {
+          state: 'succeeded',
+          response: {
+            secretRef: binding_id
+          }
+        }
+      };
+      const secretData = {
+        hostname: docker_url.hostname,
+        username: username,
+        password: password,
+        ports: {
+          '12345/tcp': 12345
+        },
+        uri: `http://${username}:${password}@${docker_url.hostname}`
+      };
+
+      it('returns 400 (BadRequest) error if service does not support binding retrieval', function () {
+        const testPayload2 = _.cloneDeep(bindPayload2);
+        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            expect(res).to.have.status(400);
+            mocks.verify();
+          });
+      });
+
+      it('returns 400 (BadRequest) error if service plan is not bindable', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        const plan = _.find(service.plans, ['id', plan_id]);
+        if (service) {
+          _.set(service, 'bindings_retrievable', true);
+          _.set(service, 'bindable', true);
+        }
+        if (plan) {
+          _.set(plan, 'bindable', false);
+        }
+        catalog.reload();
+
+        const testPayload2 = _.cloneDeep(bindPayload2);
+        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(400);
+            mocks.verify();
+          });
+      });
+
+      it('returns 404 if binding not found', function () {
+        const testPayload2 = _.cloneDeep(bindPayload2);
+        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {}, 1, 404);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            expect(res).to.have.status(404);
+            mocks.verify();
+          });
+      });
+
+      it('returns 200 if service binding is successfully returned', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        const plan = _.find(service.plans, ['id', plan_id]);
+        if (service) {
+          _.set(service, 'bindings_retrievable', true);
+          _.set(service, 'bindable', true);
+        }
+        if (plan) {
+          _.set(plan, 'bindable', true);
+        }
+        catalog.reload();
+
+        const testPayload2 = _.cloneDeep(bindPayload2);
+        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
+        mocks.apiServerEventMesh.nockGetSecret(binding_id, _.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE), {
+          data: {
+            response: encodeBase64({ credentials: secretData })
+          }
+        });
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(200);
+            expect(res.body).to.eql({
+              parameters: {
+                foo: 'bar'
+              },
+              credentials: {
+                hostname: docker_url.hostname,
+                username: username,
+                password: password,
+                ports: {
+                  '12345/tcp': 12345
+                },
+                uri: `http://${username}:${password}@${docker_url.hostname}`
+              }
+            });
+            mocks.verify();
+          });
+      });
+
+      it('returns 404 if service binding status is not succeeded', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        const plan = _.find(service.plans, ['id', plan_id]);
+        if (service) {
+          _.set(service, 'bindings_retrievable', true);
+          _.set(service, 'bindable', true);
+        }
+        catalog.reload();
+
+        const testPayload2 = _.cloneDeep(bindPayload2);
+        testPayload2.status.state = 'failed';
+        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .catch(err => err.response)
+          .then(res => {
+            config.services = oldServices;
+            catalog.reload();
+            expect(res).to.have.status(404);
+            mocks.verify();
+          });
+      });
+
+      it('returns 412 (PreconditionFailed) error if broker api version is not atleast 2.14', function () {
+        const testPayload2 = _.cloneDeep(bindPayload2);
+        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
+          return chai.request(app)
+            .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
+            .set('X-Broker-API-Version', '2.12')
+            .auth(config.username, config.password)
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(412);
+            });
+      });
+
+    });
   });
 });

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
@@ -85,7 +85,7 @@ describe('service-broker-api-enhancement', function () {
         .auth(config.username, config.password)
         .catch(err => err.response)
         .then(res => {
-          expect(res).to.have.status(403);
+          expect(res).to.have.status(400);
         });
     });
 

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
@@ -1,0 +1,303 @@
+'use strict';
+
+const _ = require('lodash');
+const app = require('../../../../test/test_broker/support/apps').internal;
+const { catalog } = require('@sf/models');
+const config = require('@sf/app-config');
+const { CONST } = require('@sf/common-utils');
+
+
+const camelcaseKeys = require('camelcase-keys');
+
+describe('service-broker-api-enhancement', function () {
+  describe('get instance endpoint', function () {
+      const service_id = '24731fb8-7b84-4f57-914f-c3d55d793dd4';
+      const plan_id = '466c5078-df6e-427d-8fb2-c76af50c0f56';
+      const organization_guid = 'b8cbbac8-6a20-42bc-b7db-47c205fccf9a';
+      const space_guid = 'e7c0a437-7585-4d75-addf-aa4d45b49f3a';
+      const instance_id = '951f7a03-df8a-4b75-90be-38abe455568d';
+      const protocol = config.external.protocol;
+      const host = config.external.host;
+      const payload2 = {
+        apiVersion: 'osb.servicefabrik.io/v1alpha1',
+        kind: 'SFServiceInstance',
+        metadata: {
+          finalizers: ['broker.servicefabrik.io'],
+          name: instance_id,
+          labels: {
+            'interoperator.servicefabrik.io/lastoperation': 'in_queue',
+            state: 'in_queue'
+          }
+        },
+        spec: {
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: organization_guid,
+            space_guid: space_guid
+          },
+          organization_guid: organization_guid,
+          space_guid: space_guid,
+          parameters: {
+            foo: 'bar'
+          }
+        },
+        status: {
+          state: 'succeeded'
+        }
+      };
+
+      const payload2K8s = {
+        apiVersion: 'osb.servicefabrik.io/v1alpha1',
+        kind: 'SFServiceInstance',
+        metadata: {
+          finalizers: ['broker.servicefabrik.io'],
+          name: instance_id,
+          labels: {
+            state: 'in_queue'
+          }
+        },
+        spec: {
+          service_id: service_id,
+          plan_id: plan_id,
+          context: {
+            platform: 'kubernetes',
+            namespace: 'default'
+          },
+          organization_guid: organization_guid,
+          space_guid: space_guid,
+        },
+        status: {
+          state: 'succeeded'
+        }
+      };
+
+
+    const baseCFUrl = '/cf/v2';
+    it('returns 400 (BadRequest) error if service does not support instance retrieval', function () {
+      const testPayload2 = _.cloneDeep(payload2);
+      testPayload2.spec = camelcaseKeys(payload2.spec);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+      return chai.request(app)
+        .get(`${baseCFUrl}/service_instances/${instance_id}`)
+        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          expect(res).to.have.status(403);
+        });
+    });
+
+    it('returns 404 if service instance not found', function () {
+      const testPayload2 = _.cloneDeep(payload2);
+      testPayload2.spec = camelcaseKeys(payload2.spec);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, 404);
+      return chai.request(app)
+        .get(`${baseCFUrl}/service_instances/${instance_id}`)
+        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          expect(res).to.have.status(404);
+        });
+    });
+
+    it('returns 404 if status is in_queue', function () {
+      //enable service instances somehow
+      const oldServices = config.services;
+      // config.services = undefined;
+      const service = _.find(config.services, ['id', service_id]);
+      if(service){
+        _.set(service, 'instance_retrievable', true);
+        catalog.reload();
+      }
+
+      const testPayload2 = _.cloneDeep(payload2);
+      testPayload2.status.state = 'in_queue';
+      testPayload2.spec = camelcaseKeys(payload2.spec);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+      return chai.request(app)
+        .get(`${baseCFUrl}/service_instances/${instance_id}`)
+        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          config.services = oldServices;
+          catalog.reload();
+          expect(res).to.have.status(404);
+        });
+    });
+
+    it('returns 404 if status is delete', function () {
+      //enable service instances somehow
+      const oldServices = config.services;
+      // config.services = undefined;
+      const service = _.find(config.services, ['id', service_id]);
+      if(service){
+        _.set(service, 'instance_retrievable', true);
+        catalog.reload();
+      }
+
+      const testPayload2 = _.cloneDeep(payload2);
+      testPayload2.status.state = 'delete';
+      testPayload2.spec = camelcaseKeys(payload2.spec);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+      return chai.request(app)
+        .get(`${baseCFUrl}/service_instances/${instance_id}`)
+        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          config.services = oldServices;
+          catalog.reload();
+          expect(res).to.have.status(404);
+        });
+    });
+
+    it('returns 404 if status is create in progress', function () {
+      //enable service instances somehow
+      const oldServices = config.services;
+      // config.services = undefined;
+      const service = _.find(config.services, ['id', service_id]);
+      if(service){
+        _.set(service, 'instance_retrievable', true);
+        catalog.reload();
+      }
+      
+      const testPayload2 = _.cloneDeep(payload2);
+      testPayload2.status.state = 'in progress';
+      testPayload2.spec = camelcaseKeys(payload2.spec);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+      return chai.request(app)
+        .get(`${baseCFUrl}/service_instances/${instance_id}`)
+        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          config.services = oldServices;
+          catalog.reload();
+          expect(res).to.have.status(404);
+        });
+    });
+
+    it('returns 422 if status is update in progress', function () {
+      //enable service instances somehow
+      const oldServices = config.services;
+      // config.services = undefined;
+      const service = _.find(config.services, ['id', service_id]);
+      if(service){
+        _.set(service, 'instance_retrievable', true);
+        catalog.reload();
+      }
+      
+      const testPayload2 = _.cloneDeep(payload2);
+      testPayload2.status.state = 'in progress';
+      testPayload2.spec = camelcaseKeys(payload2.spec);
+      testPayload2.metadata.labels['interoperator.servicefabrik.io/lastoperation'] = 'update'
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+      return chai.request(app)
+        .get(`${baseCFUrl}/service_instances/${instance_id}`)
+        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          config.services = oldServices;
+          catalog.reload();
+          expect(res).to.have.status(422);
+          expect(res.body.error).to.be.eql('ConcurrencyError');
+          expect(res.body.description).to.be.eql('Service Instance updation is in progress and therefore cannot be fetched at this time');
+        });
+    });
+
+    it('returns 422 if status is update', function () {
+
+      //enable service instances somehow
+      const oldServices = config.services;
+      // config.services = undefined;
+      const service = _.find(config.services, ['id', service_id]);
+      if(service){
+        _.set(service, 'instance_retrievable', true);
+        catalog.reload();
+      }
+
+      const testPayload2 = _.cloneDeep(payload2);
+      testPayload2.status.state = 'update';
+      testPayload2.spec = camelcaseKeys(payload2.spec);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+      return chai.request(app)
+        .get(`${baseCFUrl}/service_instances/${instance_id}`)
+        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .auth(config.username, config.password)
+        .catch(err => err.response)
+        .then(res => {
+          config.services = oldServices;
+          catalog.reload();
+          expect(res).to.have.status(422);
+          expect(res.body.error).to.deep.equal('ConcurrencyError');
+          expect(res.body.description).to.deep.equal('Service Instance is being updated and therefore cannot be fetched at this time');
+        });
+    });
+
+    it('returns 200 if service instance is successfully returned', function () {
+      //enable service instances somehow
+      const oldServices = config.services;
+      // config.services = undefined;
+      const service = _.find(config.services, ['id', service_id]);
+      if(service){
+        _.set(service, 'instance_retrievable', true);
+        catalog.reload();
+      }
+      const testPayload2 = _.cloneDeep(payload2);
+      testPayload2.spec = camelcaseKeys(payload2.spec);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+      return chai.request(app)
+        .get(`${baseCFUrl}/service_instances/${instance_id}`)
+        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .auth(config.username, config.password)
+        .then(res => {
+          config.services = oldServices;
+          catalog.reload();
+          expect(res).to.have.status(200);
+          expect(res.body).to.deep.equal({
+            service_id: service_id,
+            plan_id: plan_id,
+            parameters: {
+              foo: 'bar'
+            },
+            dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
+          })
+        });
+    });
+
+    it('returns 200 if service instance is successfully returned (k8s)', function () {
+      //enable service instances somehow
+      const oldServices = config.services;
+      // config.services = undefined;
+      const service = _.find(config.services, ['id', service_id]);
+      if(service){
+        _.set(service, 'instance_retrievable', true);
+        catalog.reload();
+      }
+      const testPayload2 = _.cloneDeep(payload2K8s);
+      testPayload2.spec = camelcaseKeys(payload2K8s.spec);
+      mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+      return chai.request(app)
+        .get(`${baseCFUrl}/service_instances/${instance_id}`)
+        .set('X-Broker-API-Version', CONST.SF_BROKER_API_VERSION_MIN)
+        .auth(config.username, config.password)
+        .then(res => {
+          config.services = oldServices;
+          catalog.reload();
+          expect(res).to.have.status(200);
+          expect(res.body).to.deep.equal({
+            service_id: service_id,
+            plan_id: plan_id,
+            dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
+          })
+        });
+    });
+
+  });
+
+});

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
@@ -119,9 +119,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 404 if status is in_queue', function () {
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       if (service) {
         _.set(service, 'instance_retrievable', true);
@@ -146,9 +144,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 422 if status is delete', function () {
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       if (service) {
         _.set(service, 'instance_retrievable', true);
@@ -175,9 +171,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 404 if status is create in progress', function () {
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       if (service) {
         _.set(service, 'instance_retrievable', true);
@@ -202,9 +196,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 422 if status is update in progress', function () {
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       if (service) {
         _.set(service, 'instance_retrievable', true);
@@ -232,10 +224,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 422 if status is update', function () {
-
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       if (service) {
         _.set(service, 'instance_retrievable', true);
@@ -262,9 +251,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 200 if service instance is successfully returned', function () {
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       if (service) {
         _.set(service, 'instance_retrievable', true);
@@ -294,9 +281,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 200 if service instance is successfully returned (k8s)', function () {
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       if (service) {
         _.set(service, 'instance_retrievable', true);
@@ -398,9 +383,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 400 (BadRequest) error if service plan is not bindable', function () {
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       const plan = _.find(service.plans, ['id', plan_id]);
       if (service) {
@@ -444,9 +427,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 200 if service binding is successfully returned', function () {
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       const plan = _.find(service.plans, ['id', plan_id]);
       if (service) {
@@ -493,9 +474,7 @@ describe('service-broker-api-enhancement', function () {
     });
 
     it('returns 404 if service binding status is not succeeded', function () {
-      //enable service instances somehow
       const oldServices = config.services;
-      // config.services = undefined;
       const service = _.find(config.services, ['id', service_id]);
       const plan = _.find(service.plans, ['id', plan_id]);
       if (service) {

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
@@ -145,7 +145,7 @@ describe('service-broker-api-enhancement', function () {
         });
     });
 
-    it('returns 404 if status is delete', function () {
+    it('returns 422 if status is delete', function () {
       //enable service instances somehow
       const oldServices = config.services;
       // config.services = undefined;
@@ -167,7 +167,9 @@ describe('service-broker-api-enhancement', function () {
         .then(res => {
           config.services = oldServices;
           catalog.reload();
-          expect(res).to.have.status(404);
+          expect(res).to.have.status(422);
+          expect(res.body.error).to.deep.equal('ConcurrencyError');
+          expect(res.body.description).to.deep.equal('Service Instance is being deleted and therefore cannot be fetched at this time');
           mocks.verify();
         });
     });

--- a/broker/core/express-commons/src/middleware/index.js
+++ b/broker/core/express-commons/src/middleware/index.js
@@ -58,7 +58,7 @@ exports.error = function (options) {
   if (env !== 'production') {
     properties.push('stack');
   }
-  const formats = options.formats || ['text', 'html', 'json'];
+  const formats = options.formats || ['json', 'text', 'html'];
   const defaultFormat = options.defaultFormat;
   return function (err, req, res, next) {
     /* jshint unused:false */

--- a/broker/core/express-commons/src/middleware/index.js
+++ b/broker/core/express-commons/src/middleware/index.js
@@ -58,7 +58,7 @@ exports.error = function (options) {
   if (env !== 'production') {
     properties.push('stack');
   }
-  const formats = options.formats || ['json', 'text', 'html'];
+  const formats = options.formats || ['text', 'html', 'json'];
   const defaultFormat = options.defaultFormat;
   return function (err, req, res, next) {
     /* jshint unused:false */

--- a/broker/core/utils/src/commonVariables.js
+++ b/broker/core/utils/src/commonVariables.js
@@ -83,6 +83,9 @@ module.exports = Object.freeze({
     ABORTING: 'aborting'
   },
   SF_BROKER_API_VERSION_MIN: '2.12',
+  SF_BROKER_API_HEADERS: {
+    REQUEST_IDENTITY: 'x-broker-api-request-identity'
+  },
   OPERATION_TYPE: {
     LIFECYCLE: ['create', 'update', 'delete'],
     BACKUP: 'backup',

--- a/broker/core/utils/src/commonVariables.js
+++ b/broker/core/utils/src/commonVariables.js
@@ -328,6 +328,7 @@ module.exports = Object.freeze({
     WATCH_TIMEOUT: 600, // in sec (10 minutes)
     VERSION: '1.10',
     NAMESPACE_LABEL_KEY: 'OWNER_INTEROPERATOR_NAMESPACE',
+    LASTOPERATION_LABEL_KEY: 'interoperator.servicefabrik.io/lastoperation',
     DEFAULT_NAMESPACE: 'default',
     NAMESPACE_OBJECT: 'Namespace',
     NAMESPACE_API_VERSION: 'v1',

--- a/broker/data-access-layer/eventmesh/src/ApiServerClient.js
+++ b/broker/data-access-layer/eventmesh/src/ApiServerClient.js
@@ -198,7 +198,8 @@ class ApiServerClient {
         resourceGroup: opts.resourceGroup,
         resourceType: opts.resourceType,
         resourceId: opts.resourceId,
-        namespaceId: opts.namespaceId
+        namespaceId: opts.namespaceId,
+        requestIdentity: opts.requestIdentity
       }))
       .then(resource => {
         const state = _.get(resource, 'status.state');

--- a/broker/data-access-layer/eventmesh/src/ApiServerClient.js
+++ b/broker/data-access-layer/eventmesh/src/ApiServerClient.js
@@ -212,14 +212,14 @@ class ApiServerClient {
           finalState = state;
           if (_.get(resource, 'status.error')) {
             const errorResponse = _.get(resource, 'status.error');
-            logger.info('Operation manager reported error', errorResponse);
+            logger.info('RequestIdentity:', opts.requestIdentity, ',Operation manager reported error', errorResponse);
             return convertToHttpErrorAndThrow(errorResponse);
           }
         } else {
           const duration = (new Date() - opts.started_at) / 1000;
-          logger.debug(`Polling for ${opts.start_state} duration: ${duration} `);
+          logger.debug(`RequestIdentity: ${opts.requestIdentity} , Polling for ${opts.start_state} duration: ${duration} `);
           if (duration > _.get(opts, 'timeout_in_sec', CONST.APISERVER.OPERATION_TIMEOUT_IN_SECS)) {
-            logger.error(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
+            logger.error(`RequestIdentity: ${opts.requestIdentity} , ${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
             throw new Timeout(`${opts.resourceGroup} with guid ${opts.resourceId} not yet processed after ${duration}s`);
           }
           return this.getOSBResourceOperationStatus(opts);
@@ -1068,7 +1068,7 @@ class ApiServerClient {
           labels: opts.labels
         });
       }
-      logger.info(`Updating - Resource ${opts.resourceId} with body - ${JSON.stringify(patchBody)}`);
+      logger.info(`RequestIdentity: ${opts.requestIdentity} , Updating - Resource ${opts.resourceId} with body - ${JSON.stringify(patchBody)}`);
 
       const client = this._getApiClient(group, version);
       // Create Namespace if not default


### PR DESCRIPTION
**HCPCFS-2936**
#### As per the changes introduced by [Openservicebrokerapi](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#changes-since-v213) (since  v2.13) we enhanced our broker to support following two GET endpoints. Changes are listed below:
- Added GET endpoints for fetching a [Service Instance.](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#fetching-a-service-instance)

- Added GET endpoints for fetching a [Service Binding.](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#fetching-a-service-binding)

These endpoints requires at least 2.14 as API version. i.e. `X-Broker-API-Version: 2.14`

---------------------------------------------------------------------------------------------------
**HCPCFS-2939**

**Requirement**: A Platform might wish to uniquely identify a specific request as it flows throughout the system. For example, this might be used for logging for request tracing purposes. In order to facilitate this, Platforms will need to provide identification information to the Service Broker for each request. Platforms MAY support this feature, and if they do, they MUST adhere to the following:
- For any OSBAPI request, there MUST be an associated X-Broker-API-Request-Identity header on the HTTP request.
- The Service Broker MAY include this value in log messages generated as a result of the request.
- The Service Broker SHOULD include this header in the response to the request. The format of the header MUST be:
`X-Broker-API-Request-Identity: value`
value MUST be a non-empty string indicating the identity of the request being sent. The specific value MAY be unique for each request sent to the broker. Using a GUID is RECOMMENDED.

**Changes**
- Added [Request Identity Header.](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#request-identity) The Service Broker SHOULD include this header in the response to the request. i.e.
`X-Broker-API-Request-Identity: value`. [(Commit)](https://github.com/cloudfoundry-incubator/service-fabrik-broker/pull/1239/commits/e79af3283cbc9e3cf667ec7d679a82d8ee8456ff)


