### PR TITLE
Remove --force option from upgrade instructions

### DIFF
--- a/docs/interoperator-upgrades.md
+++ b/docs/interoperator-upgrades.md
@@ -2,7 +2,7 @@
 
 If no special handling is required, to upgrade to a newer version use
 ```shell
-helm --namespace interoperator upgrade -i --force --wait --set cluster.host=sf.ingress.< clusterdomain > --version < version > interoperator interoperator-charts/interoperator
+helm --namespace interoperator upgrade -i --wait --set cluster.host=sf.ingress.< clusterdomain > --version < version > interoperator interoperator-charts/interoperator
 ```
 This assumes interoperator is deployed in namespace `interoperator` with release name `interoperator` and the interoperator helm repo is added as `interoperator-charts`.
 


### PR DESCRIPTION
Helm throws errors when upgrading interoperator with `--force` option. However the upgrade is successful.

```
$ helm --namespace interoperator upgrade -i --force --wait --set cluster.host=xxxxx --version 0.12.1 interoperator interoperator-charts/interoperator

Error: UPGRADE FAILED: failed to replace object: Service "interoperator-broker-service" is invalid: spec.clusterIP: Invalid value: "": field is immutable 
&& failed to replace object: Service "interoperator-multiclusterdeployer-metrics-service" is invalid: spec.clusterIP: Invalid value: "": field is immutable 
&& failed to replace object: Service "interoperator-op-apis-service" is invalid: spec.clusterIP: Invalid value: "": field is immutable 
&& failed to replace object: Service "interoperator-controller-manager-metrics-service" is invalid: spec.clusterIP: Invalid value: "": field is immutable 
&& failed to replace object: Service "interoperator-quota-service" is invalid: spec.clusterIP: Invalid value: "": field is immutable 
&& failed to replace object: Service "interoperator-scheduler-metrics-service" is invalid: spec.clusterIP: Invalid value: "": field is immutable
```

This is a known behavior from helm3. More  information is here in https://github.com/helm/helm/issues/6378#issuecomment-735287919
Detailed information is here in this bug report https://github.com/helm/helm/issues/6378#issuecomment-557746499

The interoperator upgrade is successful without the `--force` option.

A good discussion on this topic is in https://github.com/helm/helm/issues/7082