### PR TITLE
Added multiple region support for quota

### DIFF
--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -74,10 +74,12 @@ exports.checkQuota = function () {
             previousPlanId: _.get(req, 'body.previous_values.plan_id'),
             useAPIServerForConsumedQuotaCheck: useAPIServerForConsumedQuotaCheck,
             orgId: orgId,
-            region: req.params.region,
             reqMethod: req.method
           }
         };
+        if(_.get(req.params, 'region') !== undefined) {
+          _.set(quotaClientOptions.queryParams, 'region', req.params.region);
+        }
         const instanceBasedQuota = supportsInstanceBasedQuota(req.body.service_id);
         if(!instanceBasedQuota) {
           quotaClientOptions.data = _.cloneDeep(req.body);

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -74,6 +74,7 @@ exports.checkQuota = function () {
             previousPlanId: _.get(req, 'body.previous_values.plan_id'),
             useAPIServerForConsumedQuotaCheck: useAPIServerForConsumedQuotaCheck,
             orgId: orgId,
+            region: req.params.region,
             reqMethod: req.method
           }
         };

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/index.js
@@ -6,3 +6,4 @@ const router = module.exports = express.Router({
   mergeParams: true
 });
 router.use('/v2', require('./v2'));
+router.use('/region/:region/v2',require('./v2'));

--- a/broker/applications/osb-broker/test/broker.middleware.spec.js
+++ b/broker/applications/osb-broker/test/broker.middleware.spec.js
@@ -241,7 +241,6 @@ describe('#checkQuota', () => {
   });
   it('K8S platform, should call next', () => {
     req.body = k8sContextBody;
-    req.region= undefined;
     process.env.POD_NAMESPACE = 'default';
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
     checkQuota(req, res, next);
@@ -254,7 +253,6 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: true,
         reqMethod: 'PATCH',
-        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -266,7 +264,6 @@ describe('#checkQuota', () => {
   });
   it('Quota not entitled, should call next with Forbidden', () => {
     req.body = notEntitledBody;
-    req.region= undefined;
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.NOT_ENTITLED });
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
@@ -278,7 +275,6 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
-        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -290,7 +286,6 @@ describe('#checkQuota', () => {
   });
   it('Quota invalid, should call next with Forbidden', () => {
     req.body = invalidQuotaBody;
-    req.region= undefined;
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.INVALID_QUOTA });
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
@@ -302,7 +297,6 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
-        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -314,7 +308,6 @@ describe('#checkQuota', () => {
   });
   it('Quota invalid, should call next with Forbidden and keep message', () => {
     req.body = invalidQuotaBody;
-    req.region= undefined;
     checkQuotaValidityStub.resolves({
       quotaValid: CONST.QUOTA_API_RESPONSE_CODES.INVALID_QUOTA,
       message: 'Custom error message',
@@ -329,7 +322,6 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
-        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -342,7 +334,6 @@ describe('#checkQuota', () => {
   });
   it('Quota valid, should call next', () => {
     req.body = validQuotaBody;
-    req.region= undefined;
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
@@ -354,7 +345,6 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
-        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -363,7 +353,6 @@ describe('#checkQuota', () => {
   });
   it('Non instance based quota, Quota valid, should call next', () => {
     req.body = validQuotaBody;
-    req.region= undefined;
     let getServiceStub = sinon.stub(catalog, 'getService');
     getServiceStub.returns({quota_check_type: 'composite'});
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
@@ -377,7 +366,6 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
-        region: undefined,
         orgId: organization_guid
       },
       data: req.body
@@ -390,7 +378,6 @@ describe('#checkQuota', () => {
   });
   it('SMCF platform, Quota valid, should call next', () => {
     req.body = SMCFContextBody;
-    req.region= undefined;
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
@@ -402,7 +389,6 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
-        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -412,7 +398,6 @@ describe('#checkQuota', () => {
 
   it('SMK8S platform, Quota valid, should call next', () => {
     req.body = SMK8SContextBody;
-    req.region= undefined;
     process.env.POD_NAMESPACE = 'default';
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
     checkQuota(req, res, next);
@@ -425,7 +410,6 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: true,
         reqMethod: 'PATCH',
-        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -439,7 +423,6 @@ describe('#checkQuota', () => {
   it('Quota funtion throws error, should call next with error', () => {
     checkQuotaValidityStub.returns(Promise.reject(err));
     req.body = errQuotaBody;
-    req.region= undefined;
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
     expect(checkQuotaValidityStub).to.have.been.calledWithExactly({
@@ -449,7 +432,6 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
-        region: undefined,
         orgId: organization_guid
       }
     }, true);

--- a/broker/applications/osb-broker/test/broker.middleware.spec.js
+++ b/broker/applications/osb-broker/test/broker.middleware.spec.js
@@ -241,6 +241,7 @@ describe('#checkQuota', () => {
   });
   it('K8S platform, should call next', () => {
     req.body = k8sContextBody;
+    req.region= undefined;
     process.env.POD_NAMESPACE = 'default';
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
     checkQuota(req, res, next);
@@ -253,6 +254,7 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: true,
         reqMethod: 'PATCH',
+        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -264,6 +266,7 @@ describe('#checkQuota', () => {
   });
   it('Quota not entitled, should call next with Forbidden', () => {
     req.body = notEntitledBody;
+    req.region= undefined;
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.NOT_ENTITLED });
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
@@ -275,6 +278,7 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
+        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -286,6 +290,7 @@ describe('#checkQuota', () => {
   });
   it('Quota invalid, should call next with Forbidden', () => {
     req.body = invalidQuotaBody;
+    req.region= undefined;
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.INVALID_QUOTA });
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
@@ -297,6 +302,7 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
+        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -308,6 +314,7 @@ describe('#checkQuota', () => {
   });
   it('Quota invalid, should call next with Forbidden and keep message', () => {
     req.body = invalidQuotaBody;
+    req.region= undefined;
     checkQuotaValidityStub.resolves({
       quotaValid: CONST.QUOTA_API_RESPONSE_CODES.INVALID_QUOTA,
       message: 'Custom error message',
@@ -322,6 +329,7 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
+        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -334,6 +342,7 @@ describe('#checkQuota', () => {
   });
   it('Quota valid, should call next', () => {
     req.body = validQuotaBody;
+    req.region= undefined;
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
@@ -345,6 +354,7 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
+        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -353,6 +363,7 @@ describe('#checkQuota', () => {
   });
   it('Non instance based quota, Quota valid, should call next', () => {
     req.body = validQuotaBody;
+    req.region= undefined;
     let getServiceStub = sinon.stub(catalog, 'getService');
     getServiceStub.returns({quota_check_type: 'composite'});
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
@@ -366,6 +377,7 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
+        region: undefined,
         orgId: organization_guid
       },
       data: req.body
@@ -378,6 +390,7 @@ describe('#checkQuota', () => {
   });
   it('SMCF platform, Quota valid, should call next', () => {
     req.body = SMCFContextBody;
+    req.region= undefined;
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
@@ -389,6 +402,7 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
+        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -398,6 +412,7 @@ describe('#checkQuota', () => {
 
   it('SMK8S platform, Quota valid, should call next', () => {
     req.body = SMK8SContextBody;
+    req.region= undefined;
     process.env.POD_NAMESPACE = 'default';
     checkQuotaValidityStub.resolves({ quotaValid: CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA });
     checkQuota(req, res, next);
@@ -410,6 +425,7 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: true,
         reqMethod: 'PATCH',
+        region: undefined,
         orgId: organization_guid
       }
     }, true);
@@ -423,6 +439,7 @@ describe('#checkQuota', () => {
   it('Quota funtion throws error, should call next with error', () => {
     checkQuotaValidityStub.returns(Promise.reject(err));
     req.body = errQuotaBody;
+    req.region= undefined;
     checkQuota(req, res, next);
     expect(isServiceFabrikOperationStub).to.have.been.calledOnce;
     expect(checkQuotaValidityStub).to.have.been.calledWithExactly({
@@ -432,6 +449,7 @@ describe('#checkQuota', () => {
         previousPlanId: undefined,
         useAPIServerForConsumedQuotaCheck: false,
         reqMethod: 'PATCH',
+        region: undefined,
         orgId: organization_guid
       }
     }, true);

--- a/broker/applications/quota-app/src/QuotaApiController.js
+++ b/broker/applications/quota-app/src/QuotaApiController.js
@@ -24,9 +24,10 @@ class QuotaApiController extends FabrikBaseController {
       case 4 : K8S + SM (CF + K8S) => subaccount based API and apiserver
     */
     try {
+      const region = _.get(req, 'query.region');
       const quotaManager = commonFunctions.isBrokerBoshDeployment() ?
-        quota.getQuotaManagerInstance(CONST.PLATFORM.CF) : 
-        quota.getQuotaManagerInstance(CONST.PLATFORM.K8S);
+        quota.getQuotaManagerInstance(CONST.PLATFORM.CF, region) :
+        quota.getQuotaManagerInstance(CONST.PLATFORM.K8S, region);
       const subaccountId = req.params.accountId;
       const planId = _.get(req, 'query.planId');
       const previousPlanId = _.get(req, 'query.previousPlanId');

--- a/broker/applications/quota-app/src/QuotaApiController.js
+++ b/broker/applications/quota-app/src/QuotaApiController.js
@@ -36,7 +36,7 @@ class QuotaApiController extends FabrikBaseController {
       const useAPIServerForConsumedQuotaCheck = _.get(req, 'query.useAPIServerForConsumedQuotaCheck');
       const useAPIServerForConsumedQuotaCheckFlag = (useAPIServerForConsumedQuotaCheck === 'true');
       logger.info(`[Quota APP] subaccountId: ${subaccountId}, orgId: ${orgId}, planId: ${planId}, previousPlanId: ${previousPlanId}, reqMethod: ${reqMethod}, useAPIServerForConsumedQuotaCheckFlag: ${useAPIServerForConsumedQuotaCheckFlag}`);
-      const validStatus = await quotaManager.checkQuota(subaccountId, orgId, planId, previousPlanId, reqMethod, useAPIServerForConsumedQuotaCheckFlag);
+      const validStatus = await quotaManager.checkQuota(subaccountId, orgId, planId, previousPlanId, reqMethod, useAPIServerForConsumedQuotaCheckFlag, region);
       await res.status(CONST.HTTP_STATUS_CODE.OK).send({ quotaValidStatus: validStatus });
     } catch (err) {
       logger.error(`[Quota APP] Quota check could not be completed due to following error: ${err}`);

--- a/broker/applications/quota-app/test/controllers.QuotaApiController.spec.js
+++ b/broker/applications/quota-app/test/controllers.QuotaApiController.spec.js
@@ -310,7 +310,7 @@ describe('#getQuotaValidStatus', () => {
     expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR);
     expect(res.send).to.have.been.calledWith({ error: err });
   });
-  it('Quota valid, should return valid status using default quota, when region not found', async () => {
+  it('Quota assertion error, when region mapping is not found', async () => {
     const req = {
       params: {
         accountId: subaccount_id
@@ -325,9 +325,7 @@ describe('#getQuotaValidStatus', () => {
       }
     };
     await quotaApiController.getQuotaValidStatus(req, res);
-    expect(checkCFQuotaStub).to.have.been.called;
-    expect(res.status).to.have.been.calledOnce;
-    expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
-    expect(res.send).to.have.been.calledWith({quotaValidStatus: 0});
+    expect(checkCFQuotaStub).to.have.been.not.called;
+    expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR);
   });
 });

--- a/broker/applications/quota-app/test/controllers.QuotaApiController.spec.js
+++ b/broker/applications/quota-app/test/controllers.QuotaApiController.spec.js
@@ -34,13 +34,15 @@ describe('#getQuotaValidStatus', () => {
   const validQuotaPlanId = 'bc158c9a-7934-401e-94ab-057082a5073f';
   const invalidQuotaPlanId = 'd616b00a-5949-4b1c-bc73-0d3c59f3954a';
   const cfQuotaManager = getQuotaManagerInstance(CONST.PLATFORM.CF);
+  const cfQuotaManagerEU10 = getQuotaManagerInstance(CONST.PLATFORM.CF,'eu10');
   const k8squotaManager = getQuotaManagerInstance(CONST.PLATFORM.K8S);
   const k8squotaManagerEU10 = getQuotaManagerInstance(CONST.PLATFORM.K8S,'eu10');
-  let checkCFQuotaStub, checkK8SQuotaStub, checkK8SQuotaStubEU10;
+  let checkCFQuotaStub, checkK8SQuotaStub, checkK8SQuotaStubEU10, checkCFQuotaStubEU10;
   const quotaApiController = new QuotaApiController();
   const res = new Response();
   beforeEach(function () {
     checkCFQuotaStub = sinon.stub(cfQuotaManager, 'checkQuota');
+    checkCFQuotaStubEU10 = sinon.stub(cfQuotaManagerEU10, 'checkQuota');
     checkK8SQuotaStub = sinon.stub(k8squotaManager, 'checkQuota');
     checkK8SQuotaStubEU10 = sinon.stub(k8squotaManagerEU10, 'checkQuota');
     checkCFQuotaStub.withArgs(subaccount_id, organization_guid, notEntitledPlanId, previous_plan_id, 'PATCH').returns(Promise.resolve(CONST.QUOTA_API_RESPONSE_CODES.NOT_ENTITLED));
@@ -50,10 +52,14 @@ describe('#getQuotaValidStatus', () => {
     checkK8SQuotaStub.withArgs(subaccount_id, organization_guid, validQuotaPlanId, previous_plan_id, 'PATCH', true).returns(Promise.resolve(CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA));
     checkK8SQuotaStubEU10.withArgs(subaccount_id, organization_guid, validQuotaPlanId, previous_plan_id, 'PATCH').returns(Promise.resolve(CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA));
     checkK8SQuotaStubEU10.withArgs(subaccount_id, organization_guid, validQuotaPlanId, previous_plan_id, 'PATCH', true).returns(Promise.resolve(CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA));
+    checkCFQuotaStubEU10.withArgs(subaccount_id, organization_guid, notEntitledPlanId, previous_plan_id, 'PATCH').returns(Promise.resolve(CONST.QUOTA_API_RESPONSE_CODES.NOT_ENTITLED));
+    checkCFQuotaStubEU10.withArgs(subaccount_id, organization_guid, invalidQuotaPlanId, previous_plan_id, 'PATCH').returns(Promise.resolve(CONST.QUOTA_API_RESPONSE_CODES.INVALID_QUOTA));
+    checkCFQuotaStubEU10.withArgs(subaccount_id, organization_guid, validQuotaPlanId, previous_plan_id, 'PATCH').returns(Promise.resolve(CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA));
   });
   afterEach(function () {
     res.reset();
     checkCFQuotaStub.restore();
+    checkCFQuotaStubEU10.restore();
     checkK8SQuotaStub.restore();
     checkK8SQuotaStubEU10.restore();
   });
@@ -121,6 +127,28 @@ describe('#getQuotaValidStatus', () => {
     expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
     expect(res.send).to.have.been.calledWith({quotaValidStatus: 0});
   });
+  it('K8S deployment, org based check, should return valid (EU10)', async () => {
+    const req = {
+      params: {
+        accountId: subaccount_id
+      },
+      query: {
+        planId: validQuotaPlanId,
+        previousPlanId: previous_plan_id,
+        reqMethod: 'PATCH',
+        useAPIServerForConsumedQuotaCheck: 'false',
+        region: 'eu10',
+        orgId: organization_guid
+      }
+    };
+    process.env.POD_NAMESPACE = 'default';
+    await quotaApiController.getQuotaValidStatus(req, res);
+    delete process.env.POD_NAMESPACE;
+    expect(checkK8SQuotaStubEU10).to.have.been.called;
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
+    expect(res.send).to.have.been.calledWith({quotaValidStatus: 0});
+  });
   it('Quota not entitled, return not entitled status', async () => {
     const req = {
       params: {
@@ -136,6 +164,26 @@ describe('#getQuotaValidStatus', () => {
     };
     await quotaApiController.getQuotaValidStatus(req, res);
     expect(checkCFQuotaStub).to.have.been.called;
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
+    expect(res.send).to.have.been.calledWith({quotaValidStatus: 2});    
+  });
+  it('Quota not entitled, return not entitled status (Region EU10)', async () => {
+    const req = {
+      params: {
+        accountId: subaccount_id
+      },
+      query: {
+        planId: notEntitledPlanId,
+        previousPlanId: previous_plan_id,
+        reqMethod: 'PATCH',
+        useAPIServerForConsumedQuotaCheck: 'false',
+        region: 'eu10',
+        orgId: organization_guid
+      }
+    };
+    await quotaApiController.getQuotaValidStatus(req, res);
+    expect(checkCFQuotaStubEU10).to.have.been.called;
     expect(res.status).to.have.been.calledOnce;
     expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
     expect(res.send).to.have.been.calledWith({quotaValidStatus: 2});    
@@ -159,6 +207,26 @@ describe('#getQuotaValidStatus', () => {
     expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
     expect(res.send).to.have.been.calledWith({quotaValidStatus: 1});     
   });
+  it('Quota invalid, return invalid status (Region EU10)', async () => {
+    const req = {
+      params: {
+        accountId: subaccount_id
+      },
+      query: {
+        planId: invalidQuotaPlanId,
+        previousPlanId: previous_plan_id,
+        reqMethod: 'PATCH',
+        useAPIServerForConsumedQuotaCheck: 'false',
+        region: 'eu10',
+        orgId: organization_guid
+      }
+    };
+    await quotaApiController.getQuotaValidStatus(req, res);
+    expect(checkCFQuotaStubEU10).to.have.been.called;
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
+    expect(res.send).to.have.been.calledWith({quotaValidStatus: 1});
+  });
   it('Quota valid, should return valid status', async () => {
     const req = {
       params: {
@@ -174,6 +242,26 @@ describe('#getQuotaValidStatus', () => {
     };
     await quotaApiController.getQuotaValidStatus(req, res);
     expect(checkCFQuotaStub).to.have.been.called;
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
+    expect(res.send).to.have.been.calledWith({quotaValidStatus: 0});      
+  });
+  it('Quota valid, should return valid status (Region EU10)', async () => {
+    const req = {
+      params: {
+        accountId: subaccount_id
+      },
+      query: {
+        planId: validQuotaPlanId,
+        previousPlanId: previous_plan_id,
+        reqMethod: 'PATCH',
+        useAPIServerForConsumedQuotaCheck: 'false',
+        region: 'eu10',
+        orgId: organization_guid
+      }
+    };
+    await quotaApiController.getQuotaValidStatus(req, res);
+    expect(checkCFQuotaStubEU10).to.have.been.called;
     expect(res.status).to.have.been.calledOnce;
     expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
     expect(res.send).to.have.been.calledWith({quotaValidStatus: 0});      
@@ -199,5 +287,47 @@ describe('#getQuotaValidStatus', () => {
     expect(res.status).to.have.been.calledOnce;
     expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR);
     expect(res.send).to.have.been.calledWith({ error: err });    
+  });
+  it('Quota funtion throws error, should return error (Region EU10)', async () => {
+    const err = 'Error in calculating quota';
+    const req = {
+      params: {
+        accountId: organization_guid
+      },
+      query: {
+        planId: validQuotaPlanId,
+        previousPlanId: previous_plan_id,
+        reqMethod: 'PATCH',
+        region: 'eu10',
+        isSubaccountFlag: 'false'
+      }
+    };
+    checkCFQuotaStubEU10.reset();
+    checkCFQuotaStubEU10.returns(Promise.reject(err));
+    await quotaApiController.getQuotaValidStatus(req, res);
+    expect(checkCFQuotaStubEU10).to.have.been.called;
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR);
+    expect(res.send).to.have.been.calledWith({ error: err });
+  });
+  it('Quota valid, should return valid status using default quota, when region not found', async () => {
+    const req = {
+      params: {
+        accountId: subaccount_id
+      },
+      query: {
+        planId: validQuotaPlanId,
+        previousPlanId: previous_plan_id,
+        reqMethod: 'PATCH',
+        useAPIServerForConsumedQuotaCheck: 'false',
+        region: 'test',
+        orgId: organization_guid
+      }
+    };
+    await quotaApiController.getQuotaValidStatus(req, res);
+    expect(checkCFQuotaStub).to.have.been.called;
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(CONST.HTTP_STATUS_CODE.OK);
+    expect(res.send).to.have.been.calledWith({quotaValidStatus: 0});
   });
 });

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -394,6 +394,17 @@ defaults: &defaults
     serviceDomain: https://my-tenant-onboarding.com
     username: sb-service-client!t1
     password: quota_password
+    regions:
+      eu10:
+        oauthDomain: https://myauth-domain.com
+        serviceDomain: https://my-tenant-onboarding.com
+        username: sb-service-client!t1
+        password: quota_password
+      eu20:
+        oauthDomain: https://myauth-domain.com
+        serviceDomain: https://my-tenant-onboarding.com
+        username: sb-service-client!t1
+        password: quota_password
   #####################
   # METERING SETTINGS #
   #####################

--- a/broker/data-access-layer/eventmesh/src/ApiServerClient.js
+++ b/broker/data-access-layer/eventmesh/src/ApiServerClient.js
@@ -1062,6 +1062,11 @@ class ApiServerClient {
         });
         patchBody.status = opts.status;
       }
+      if (opts.labels) {
+        patchBody.metadata = _.merge(patchBody.metadata, {
+          labels: opts.labels
+        });
+      }
       logger.info(`Updating - Resource ${opts.resourceId} with body - ${JSON.stringify(patchBody)}`);
 
       const client = this._getApiClient(group, version);
@@ -1100,7 +1105,7 @@ class ApiServerClient {
     return Promise.try(() => {
       if (_.get(opts, 'status.state') === CONST.APISERVER.RESOURCE_STATE.UPDATE) {
         // set parameters field to null
-        const clearParamsReqOpts = _.pick(opts, ['resourceGroup', 'resourceType', 'resourceId']);
+        const clearParamsReqOpts = _.pick(opts, ['resourceGroup', 'resourceType', 'resourceId', 'labels']);
         return this.updateOSBResource(_.extend(clearParamsReqOpts, {
           'spec': {
             'parameters': null

--- a/broker/data-access-layer/quota/src/BaseQuotaManager.js
+++ b/broker/data-access-layer/quota/src/BaseQuotaManager.js
@@ -14,7 +14,7 @@ class BaseQuotaManager {
     this.platform = platform;
   }
 
-  async checkQuota(subaccountId, orgId, planId, previousPlanId, reqMethod, useAPIServerForConsumedQuotaCheck) {
+  async checkQuota(subaccountId, orgId, planId, previousPlanId, reqMethod, useAPIServerForConsumedQuotaCheck, region) {
     if (CONST.HTTP_METHOD.PATCH === reqMethod && this.isSamePlanOrSkuUpdate(planId, previousPlanId)) {
       logger.debug('Quota check skipped as it is a normal instance update or plan update with same sku.');
       return CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA;
@@ -45,14 +45,14 @@ class BaseQuotaManager {
           return CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA;
         } else {
           const planIdsWithSameSKU = this.getAllPlanIdsWithSameSKU(planName, serviceName, catalog);
-          const instanceCount = await this.getInstanceCountonPlatform(useAPIServerForConsumedQuotaCheck ? subaccountId : orgId, planIdsWithSameSKU);
+          const instanceCount = await this.getInstanceCountonPlatform(useAPIServerForConsumedQuotaCheck ? subaccountId : orgId, planIdsWithSameSKU, region);
           logger.debug(`Number of instances are ${instanceCount} & Quota number for current org space and service_plan is ${quota}`);
           return instanceCount >= quota ? CONST.QUOTA_API_RESPONSE_CODES.INVALID_QUOTA : CONST.QUOTA_API_RESPONSE_CODES.VALID_QUOTA;
         }
       }
     }
   }
-  async getInstanceCountonPlatform(orgOrSubaccountId, planGuids) {
+  async getInstanceCountonPlatform(orgOrSubaccountId, planGuids, region) {
     throw new NotImplementedBySubclass(`getInstanceCountonPlatform - ${orgOrSubaccountId}, ${planGuids}`);
   }
   getAllPlanIdsWithSameSKU(planName, serviceName, serviceCatalog) {

--- a/broker/data-access-layer/quota/src/QuotaAPIAuthClient.js
+++ b/broker/data-access-layer/quota/src/QuotaAPIAuthClient.js
@@ -13,11 +13,11 @@ class QuotaAPIAuthClient extends HttpClient {
       },
       maxRedirects: 0,
       auth: {
-        username: (options == undefined || options.region == undefined) ? config.quota.username : config.quota.regions[options.region].username,
-        password: (options == undefined || options.region == undefined) ? config.quota.password : config.quota.regions[options.region].password
+        username: (_.get(options, 'region')) ? (_.get(config.quota, ['regions', options.region, 'username'])) : config.quota.username,
+        password: (_.get(options, 'region')) ? (_.get(config.quota, ['regions', options.region, 'password'])) : config.quota.password
       }
     }, options, {
-      baseURL: (options == undefined || options.region == undefined) ? config.quota.oauthDomain : config.quota.regions[options.region].oauthDomain,
+      baseURL: (_.get(options, 'region')) ? (_.get(config.quota, ['regions', options.region, 'oauthDomain'])) : config.quota.oauthDomain,
       rejectUnauthorized: !config.skip_ssl_validation
     }));
   }

--- a/broker/data-access-layer/quota/src/QuotaAPIAuthClient.js
+++ b/broker/data-access-layer/quota/src/QuotaAPIAuthClient.js
@@ -13,11 +13,11 @@ class QuotaAPIAuthClient extends HttpClient {
       },
       maxRedirects: 0,
       auth: {
-        username: config.quota.username,
-        password: config.quota.password
+        username: (options == undefined || options.region == undefined) ? config.quota.username : config.quota.regions[options.region].username,
+        password: (options == undefined || options.region == undefined) ? config.quota.password : config.quota.regions[options.region].password
       }
     }, options, {
-      baseURL: config.quota.oauthDomain,
+      baseURL: (options == undefined || options.region == undefined) ? config.quota.oauthDomain : config.quota.regions[options.region].oauthDomain,
       rejectUnauthorized: !config.skip_ssl_validation
     }));
   }

--- a/broker/data-access-layer/quota/src/QuotaAPIClient.js
+++ b/broker/data-access-layer/quota/src/QuotaAPIClient.js
@@ -5,9 +5,9 @@ const config = require('@sf/app-config');
 const { HttpClient } = require('@sf/common-utils');
 
 class QuotaAPIClient extends HttpClient {
-  constructor(tokenIssuer) {
+  constructor(tokenIssuer, region) {
     super({
-      baseURL: config.quota.serviceDomain,
+      baseURL: (region == undefined) ? config.quota.serviceDomain : config.quota.regions[region].serviceDomain,
       maxRedirects: 0,
       rejectUnauthorized: !config.skip_ssl_validation
     });

--- a/broker/data-access-layer/quota/src/QuotaAPIClient.js
+++ b/broker/data-access-layer/quota/src/QuotaAPIClient.js
@@ -1,13 +1,14 @@
 'use strict';
 
+const _ = require('lodash');
 const Promise = require('bluebird');
 const config = require('@sf/app-config');
 const { HttpClient } = require('@sf/common-utils');
 
 class QuotaAPIClient extends HttpClient {
-  constructor(tokenIssuer, region) {
+  constructor(tokenIssuer, options) {
     super({
-      baseURL: (region == undefined) ? config.quota.serviceDomain : config.quota.regions[region].serviceDomain,
+      baseURL: (_.get(options, 'region')) ? (_.get(config.quota, ['regions', options.region, 'serviceDomain'])) : config.quota.serviceDomain,
       maxRedirects: 0,
       rejectUnauthorized: !config.skip_ssl_validation
     });

--- a/broker/data-access-layer/quota/src/cf-platform-quota-manager/CFPlatformQuotaManager.js
+++ b/broker/data-access-layer/quota/src/cf-platform-quota-manager/CFPlatformQuotaManager.js
@@ -13,7 +13,7 @@ class CFPlatformQuotaManager extends BaseQuotaManager {
     super(quotaAPIClient, CONST.PLATFORM.CF);
   }
 
-  async getInstanceCountonPlatform(orgId, planIds) {
+  async getInstanceCountonPlatform(orgId, planIds, region) {
     const planGuids = await this.getAllPlanGuidsFromPlanIDs(planIds);
     logger.debug('planguids are ', planGuids);
     const instances = await cloudController.getServiceInstancesInOrgWithPlansGuids(orgId, planGuids);

--- a/broker/data-access-layer/quota/src/cf-platform-quota-manager/index.js
+++ b/broker/data-access-layer/quota/src/cf-platform-quota-manager/index.js
@@ -1,4 +1,11 @@
 'use strict';
 
 const CFPlatformQuotaManager = require('./CFPlatformQuotaManager');
+
+const cfPlatformQuotaManagersRegional = {};
+for(let reg in require('..').regionalQuotaAPIClients) {
+  cfPlatformQuotaManagersRegional[reg] = new CFPlatformQuotaManager(require('..').regionalQuotaAPIClients[reg]);
+}
+
 exports.cfPlatformQuotaManager = new CFPlatformQuotaManager(require('..').quotaAPIClient);
+exports.cfPlatformQuotaManagersRegional = cfPlatformQuotaManagersRegional;

--- a/broker/data-access-layer/quota/src/index.js
+++ b/broker/data-access-layer/quota/src/index.js
@@ -18,7 +18,7 @@ const regionalQuotaAPIClients = {};
 for (let reg in config.quota.regions) {
   let quotaAPIAuthClientRegional = new QuotaAPIAuthClient({ region:reg });
   let tokenIssuerRegional = new TokenIssuer(quotaAPIAuthClientRegional);
-  let regionalQuotaAPIClient = new QuotaAPIClient(tokenIssuerRegional, reg);
+  let regionalQuotaAPIClient = new QuotaAPIClient(tokenIssuerRegional, { region:reg });
   regionalQuotaAPIClients[reg] = regionalQuotaAPIClient;
 }
 

--- a/broker/data-access-layer/quota/src/index.js
+++ b/broker/data-access-layer/quota/src/index.js
@@ -25,17 +25,19 @@ for (let reg in config.quota.regions) {
 const getQuotaManagerInstance = function(platform, region) {
   assert.ok(platform === CONST.PLATFORM.CF || platform === CONST.PLATFORM.K8S, `Platform can be only ${CONST.PLATFORM.CF} or ${CONST.PLATFORM.K8S}`);
   if(platform === CONST.PLATFORM.CF) {
-    if(region == undefined || require('./cf-platform-quota-manager').cfPlatformQuotaManagersRegional[region] == undefined) {
+    if(region == undefined) {
       const cfQuotaPlatformManager = require('./cf-platform-quota-manager').cfPlatformQuotaManager;
       return cfQuotaPlatformManager;
     }
+    assert.ok(require('./cf-platform-quota-manager').cfPlatformQuotaManagersRegional[region] !== undefined, `No LPS service credentials found for region: ${region}`);
     const cfQuotaPlatformManager = require('./cf-platform-quota-manager').cfPlatformQuotaManagersRegional[region];
     return cfQuotaPlatformManager;
   } else{
-    if(region == undefined || require('./k8s-platform-quota-manager').k8sPlatformQuotaManagersRegional[region] == undefined) {
+    if(region == undefined) {
       const k8sQuotaPlatformManager = require('./k8s-platform-quota-manager').k8sPlatformQuotaManager;
       return k8sQuotaPlatformManager;
     }
+    assert.ok(require('./k8s-platform-quota-manager').k8sPlatformQuotaManagersRegional[region] !== undefined, `No LPS service credentials found for region: ${region}`);
     const k8sQuotaPlatformManager = require('./k8s-platform-quota-manager').k8sPlatformQuotaManagersRegional[region];
     return k8sQuotaPlatformManager;
   }

--- a/broker/data-access-layer/quota/src/index.js
+++ b/broker/data-access-layer/quota/src/index.js
@@ -3,20 +3,40 @@
 const { CONST } = require('@sf/common-utils');
 const assert = require('assert');
 
+const config = require('@sf/app-config');
+
 const QuotaAPIClient = require('./QuotaAPIClient');
 const QuotaAPIAuthClient = require('./QuotaAPIAuthClient');
 const TokenIssuer = require('./TokenIssuer');
 const TokenInfo = require('./TokenInfo');
+
 const quotaAPIAuthClient = new QuotaAPIAuthClient();
 const tokenIssuer = new TokenIssuer(quotaAPIAuthClient);
 const quotaAPIClient = new QuotaAPIClient(tokenIssuer);
-const getQuotaManagerInstance = function(platform) {
+
+const regionalQuotaAPIClients = {};
+for (let reg in config.quota.regions) {
+  let quotaAPIAuthClientRegional = new QuotaAPIAuthClient({ region:reg });
+  let tokenIssuerRegional = new TokenIssuer(quotaAPIAuthClientRegional);
+  let regionalQuotaAPIClient = new QuotaAPIClient(tokenIssuerRegional, reg);
+  regionalQuotaAPIClients[reg] = regionalQuotaAPIClient;
+}
+
+const getQuotaManagerInstance = function(platform, region) {
   assert.ok(platform === CONST.PLATFORM.CF || platform === CONST.PLATFORM.K8S, `Platform can be only ${CONST.PLATFORM.CF} or ${CONST.PLATFORM.K8S}`);
   if(platform === CONST.PLATFORM.CF) {
-    const cfQuotaPlatformManager = require('./cf-platform-quota-manager').cfPlatformQuotaManager;
+    if(region == undefined || require('./cf-platform-quota-manager').cfPlatformQuotaManagersRegional[region] == undefined) {
+      const cfQuotaPlatformManager = require('./cf-platform-quota-manager').cfPlatformQuotaManager;
+      return cfQuotaPlatformManager;
+    }
+    const cfQuotaPlatformManager = require('./cf-platform-quota-manager').cfPlatformQuotaManagersRegional[region];
     return cfQuotaPlatformManager;
   } else{
-    const k8sQuotaPlatformManager = require('./k8s-platform-quota-manager').k8sPlatformQuotaManager;
+    if(region == undefined || require('./k8s-platform-quota-manager').k8sPlatformQuotaManagersRegional[region] == undefined) {
+      const k8sQuotaPlatformManager = require('./k8s-platform-quota-manager').k8sPlatformQuotaManager;
+      return k8sQuotaPlatformManager;
+    }
+    const k8sQuotaPlatformManager = require('./k8s-platform-quota-manager').k8sPlatformQuotaManagersRegional[region];
     return k8sQuotaPlatformManager;
   }
 };
@@ -25,5 +45,6 @@ module.exports = {
   tokenIssuer,
   quotaAPIClient,
   TokenInfo,
-  getQuotaManagerInstance
+  getQuotaManagerInstance,
+  regionalQuotaAPIClients
 };

--- a/broker/data-access-layer/quota/src/k8s-platform-quota-manager/K8SPlatformQuotaManager.js
+++ b/broker/data-access-layer/quota/src/k8s-platform-quota-manager/K8SPlatformQuotaManager.js
@@ -10,8 +10,8 @@ class K8SPlatformQuotaManager extends BaseQuotaManager {
     super(quotaAPIClient, CONST.PLATFORM.K8S);
   }
   
-  async getInstanceCountonPlatform(subaccountId, planIds) {
-    const labelString = `subaccount_id in (${subaccountId}),plan_id in (${planIds.toString()})`;
+  async getInstanceCountonPlatform(subaccountId, planIds, region) {
+    const labelString = (region == undefined) ? `subaccount_id in (${subaccountId}),plan_id in (${planIds.toString()})` : `subaccount_id in (${subaccountId}),plan_id in (${planIds.toString()}), region in (${region})`;
     const instances = await apiServerClient.getResources({
       resourceGroup: CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR,
       resourceType: CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES,

--- a/broker/data-access-layer/quota/src/k8s-platform-quota-manager/index.js
+++ b/broker/data-access-layer/quota/src/k8s-platform-quota-manager/index.js
@@ -1,4 +1,11 @@
 'use strict';
 
 const K8SPlatformQuotaManager = require('./K8SPlatformQuotaManager');
+
+const k8sPlatformQuotaManagersRegional = {};
+for(let reg in require('..').regionalQuotaAPIClients) {
+  k8sPlatformQuotaManagersRegional[reg] = new K8SPlatformQuotaManager(require('..').regionalQuotaAPIClients[reg]);
+}
+
 exports.k8sPlatformQuotaManager = new K8SPlatformQuotaManager(require('..').quotaAPIClient);
+exports.k8sPlatformQuotaManagersRegional = k8sPlatformQuotaManagersRegional;

--- a/helm-charts/interoperator/conf/settings.yaml
+++ b/helm-charts/interoperator/conf/settings.yaml
@@ -94,17 +94,10 @@ defaults: &defaults
     enabled: {{ .Values.broker.quota.enabled }}
     oauthDomain: {{ .Values.broker.quota.oauthDomain }}
     serviceDomain: {{ .Values.broker.quota.serviceDomain }}
+    {{- with .Values.broker.quota.regions }}
     regions:
-      eu10:
-        oauthDomain: {{ .Values.broker.quota.regions.eu10.oauthDomain }}
-        serviceDomain: {{ .Values.broker.quota.regions.eu10.serviceDomain }}
-        username: {{ .Values.broker.quota.regions.eu10.username }}
-        password: {{ .Values.broker.quota.regions.eu10.password }}
-      eu20:
-        oauthDomain: {{ .Values.broker.quota.regions.eu20.oauthDomain }}
-        serviceDomain: {{ .Values.broker.quota.regions.eu20.serviceDomain }}
-        username: {{ .Values.broker.quota.regions.eu20.username }}
-        password: {{ .Values.broker.quota.regions.eu20.password }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 
 development: &development
   <<: *defaults

--- a/helm-charts/interoperator/conf/settings.yaml
+++ b/helm-charts/interoperator/conf/settings.yaml
@@ -94,6 +94,17 @@ defaults: &defaults
     enabled: {{ .Values.broker.quota.enabled }}
     oauthDomain: {{ .Values.broker.quota.oauthDomain }}
     serviceDomain: {{ .Values.broker.quota.serviceDomain }}
+    regions:
+      eu10:
+        oauthDomain: {{ .Values.broker.quota.regions.eu10.oauthDomain }}
+        serviceDomain: {{ .Values.broker.quota.regions.eu10.serviceDomain }}
+        username: {{ .Values.broker.quota.regions.eu10.username }}
+        password: {{ .Values.broker.quota.regions.eu10.password }}
+      eu20:
+        oauthDomain: {{ .Values.broker.quota.regions.eu20.oauthDomain }}
+        serviceDomain: {{ .Values.broker.quota.regions.eu20.serviceDomain }}
+        username: {{ .Values.broker.quota.regions.eu20.username }}
+        password: {{ .Values.broker.quota.regions.eu20.password }}
 
 development: &development
   <<: *defaults

--- a/helm-charts/interoperator/templates/broker.yaml
+++ b/helm-charts/interoperator/templates/broker.yaml
@@ -110,16 +110,20 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-creds
               key: quota_app_password
+        {{- if .Values.broker.quota.username }}
         - name: QUOTA_USERNAME
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-creds
               key: quota_username
+        {{- end }}
+        {{- if .Values.broker.quota.password }}
         - name: QUOTA_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-creds
               key: quota_password
+        {{- end }}
         volumeMounts:
         - name: settings
           mountPath: /opt/sf-config

--- a/helm-charts/interoperator/templates/quota_app.yaml
+++ b/helm-charts/interoperator/templates/quota_app.yaml
@@ -71,16 +71,20 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-creds
               key: quota_app_password
+        {{- if .Values.broker.quota.username }}
         - name: QUOTA_USERNAME
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-creds
               key: quota_username
+        {{- end }}
+        {{- if .Values.broker.quota.password }}
         - name: QUOTA_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-creds
               key: quota_password
+        {{- end }}
         volumeMounts:
         - name: settings
           mountPath: /opt/sf-config

--- a/helm-charts/interoperator/templates/secret.yaml
+++ b/helm-charts/interoperator/templates/secret.yaml
@@ -9,7 +9,11 @@ data:
   broker_password: {{ .Values.broker.password | b64enc }}
   quota_app_username: {{ .Values.quota_app.username | b64enc }}
   quota_app_password: {{ .Values.quota_app.password | b64enc }}
+  {{- if .Values.broker.quota.username }}
   quota_username: {{ .Values.broker.quota.username | b64enc }}
+  {{- end }}
+  {{- if .Values.broker.quota.password }}
   quota_password: {{ .Values.broker.quota.password | b64enc }}
+  {{- end }}
   operator_apis_username: {{ .Values.operator_apis.username | b64enc }}
   operator_apis_password: {{ .Values.operator_apis.password | b64enc }}

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -28,6 +28,17 @@ broker:
     serviceDomain: https://my-tenant-onboarding.com
     username: quota_user
     password: quota_password
+    regions:
+      eu10:
+        oauthDomain: https://myauth-domain.com
+        serviceDomain: https://my-tenant-onboarding.com
+        username: quota_user
+        password: quota_password
+      eu20:
+        oauthDomain: https://myauth-domain.com
+        serviceDomain: https://my-tenant-onboarding.com
+        username: quota_user
+        password: quota_password
   image:
     repository: servicefabrikjenkins/service-fabrik-broker
     tag: 0.12.3

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -28,17 +28,17 @@ broker:
     serviceDomain: https://my-tenant-onboarding.com
     username: quota_user
     password: quota_password
-    regions:
-      eu10:
-        oauthDomain: https://myauth-domain.com
-        serviceDomain: https://my-tenant-onboarding.com
-        username: quota_user
-        password: quota_password
-      eu20:
-        oauthDomain: https://myauth-domain.com
-        serviceDomain: https://my-tenant-onboarding.com
-        username: quota_user
-        password: quota_password
+    # regions:
+    #   eu10:
+    #     oauthDomain: https://myauth-domain.com
+    #     serviceDomain: https://my-tenant-onboarding.com
+    #     username: quota_user
+    #     password: quota_password
+    #   eu20:
+    #     oauthDomain: https://myauth-domain.com
+    #     serviceDomain: https://my-tenant-onboarding.com
+    #     username: quota_user
+    #     password: quota_password
   image:
     repository: servicefabrikjenkins/service-fabrik-broker
     tag: 0.12.3


### PR DESCRIPTION
Feature: HCPCFS-2886

This PR enhance the broker to support multiple regions. Enhancements are listed below:

- Extending the broker routes to support the region as a url parameter. 
   Example: `https://example-broker.com/region/eu10/v2/...`
- Based on the region provided as a part of url,  we extract the particular credential for quota validations.
- Tagging each sfserviceinstance based the the region so that it could be determined which region the service instance is from.