### PR TITLE
Bump Node version in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "14.15"
+        - "14.16"
       env:
         - SETTINGS_PATH="$(pwd)/broker/config/settings.yml"
       script:
@@ -109,7 +109,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "14.15"
+        - "14.16"
       env:
         - SETTINGS_PATH="$(pwd)/broker/config/settings.yml"
       script:
@@ -123,7 +123,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "14.15"
+        - "14.16"
       before_install:
         # - pip install --user truffleHog==2.0.89
         - |


### PR DESCRIPTION
We updated Node version to 14.16 as recommended by protecode scan in #1276 
Updating the Node version in Travis config.