### PR TITLE
Fix json error in Response Error

### DIFF
--- a/broker/applications/extensions/test/acceptance/service-fabrik-api-2.0.backups.director.spec.js
+++ b/broker/applications/extensions/test/acceptance/service-fabrik-api-2.0.backups.director.spec.js
@@ -411,6 +411,11 @@ describe('service-fabrik-api-2.0', function () {
         });
         it('should return 410 Gone - when not found in both blobstore and apiserver', function () {
           const backupPrefix = `${space_guid}/backup`;
+          const expectedResponse = {
+            "description": "Backup does not exist or has already been deleted",
+            "error": "Gone",
+            "status": 410
+          };
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.BACKUP, CONST.APISERVER.RESOURCE_TYPES.DEFAULT_BACKUP,
@@ -425,7 +430,7 @@ describe('service-fabrik-api-2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(410);
-              expect(res.body).to.eql({});
+              expect(_.omit(res.body, 'stack')).to.eql(expectedResponse);
               mocks.verify();
             });
         });

--- a/broker/applications/extensions/test/acceptance/service-fabrik-api-2.0.instances.director.spec.js
+++ b/broker/applications/extensions/test/acceptance/service-fabrik-api-2.0.instances.director.spec.js
@@ -764,6 +764,11 @@ describe('service-fabrik-api-sf2.0', function () {
         });
 
         it('should return 404  - if last backup label is not set in deployment resource', function () {
+          const expectedResponse = {
+            "description": `No backup found for service instance \'${instance_id}\'`,
+            "error": "Not Found",
+            "status": 404
+          };
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, {
@@ -787,12 +792,17 @@ describe('service-fabrik-api-sf2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(404);
-              expect(res.body).to.eql({});
+              expect(_.omit(res.body, 'stack')).to.eql(expectedResponse);
               mocks.verify();
             });
         });
 
         it('should return 404 if Not Found in apiserver', function () {
+          const expectedResponse = {
+            "description": `No backup found for service instance \'${instance_id}\'`,
+            "error": "Not Found",
+            "status": 404
+          };
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
@@ -810,7 +820,7 @@ describe('service-fabrik-api-sf2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(404);
-              expect(res.body).to.eql({});
+              expect(_.omit(res.body, 'stack')).to.eql(expectedResponse);
               mocks.verify();
             });
         });
@@ -1648,6 +1658,11 @@ describe('service-fabrik-api-sf2.0', function () {
         });
 
         it('should return 404 Not Found', function () {
+          const expectedResponse = {
+            "description": `No restore found for service instance \'${instance_id}\'`,
+            "error": "Not Found",
+            "status": 404
+          };
           mocks.uaa.tokenKey();
           mocks.cloudController.getSpaceDevelopers(space_guid);
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource, 2);
@@ -1658,7 +1673,7 @@ describe('service-fabrik-api-sf2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(404);
-              expect(res.body).to.eql({});
+              expect(_.omit(res.body, 'stack')).to.eql(expectedResponse);
               mocks.verify();
             });
         });
@@ -1961,6 +1976,11 @@ describe('service-fabrik-api-sf2.0', function () {
         });
 
         it('should return 400 - Bad request on skipping mandatory params', function () {
+          const expectedResponse = {
+            "description": "repeatInterval | type are mandatory",
+            "error": "Bad Request",
+            "status": 400
+          };
           mocks.uaa.tokenKey();
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
@@ -1971,7 +1991,7 @@ describe('service-fabrik-api-sf2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(400);
-              expect(res.body).to.eql({});
+              expect(_.omit(res.body, 'stack')).to.eql(expectedResponse);
               mocks.verify();
             });
         });
@@ -2155,6 +2175,11 @@ describe('service-fabrik-api-sf2.0', function () {
         });
 
         it('should return 400 - Badrequest on skipping mandatory params', function () {
+          const expectedResponse = {
+            "description": "repeatInterval is mandatory",
+            "error": "Bad Request",
+            "status": 400
+          };
           mocks.uaa.tokenKey();
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
@@ -2165,7 +2190,7 @@ describe('service-fabrik-api-sf2.0', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(400);
-              expect(res.body).to.eql({});
+              expect(_.omit(res.body, 'stack')).to.eql(expectedResponse);
               mocks.verify();
             });
         });

--- a/broker/applications/extensions/test/acceptance/service-fabrik-api.instances.director.spec.js
+++ b/broker/applications/extensions/test/acceptance/service-fabrik-api.instances.director.spec.js
@@ -267,6 +267,11 @@ describe('service-fabrik-api', function () {
         });
 
         it('should return 400 - Bad request on skipping mandatory params', function () {
+          const expectedResponse = {
+            "description": "repeatInterval | type are mandatory",
+            "status": 400,
+            "error": "Bad Request"
+          };
           mocks.uaa.tokenKey();
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
@@ -277,7 +282,7 @@ describe('service-fabrik-api', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(400);
-              expect(res.body).to.eql({});
+              expect(_.omit(res.body, 'stack')).to.eql(expectedResponse);
               mocks.verify();
             });
         });
@@ -427,6 +432,11 @@ describe('service-fabrik-api', function () {
         });
 
         it('should return 400 - Badrequest on skipping mandatory params', function () {
+          const expectedResponse = {
+            "description": "repeatInterval is mandatory",
+            "status": 400,
+            "error": "Bad Request"
+          };
           mocks.uaa.tokenKey();
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.DEPLOYMENT, CONST.APISERVER.RESOURCE_TYPES.DIRECTOR, instance_id, dummyDeploymentResource);
           mocks.cloudController.getSpaceDevelopers(space_guid);
@@ -437,7 +447,7 @@ describe('service-fabrik-api', function () {
             .catch(err => err.response)
             .then(res => {
               expect(res).to.have.status(400);
-              expect(res.body).to.eql({});
+              expect(_.omit(res.body, 'stack')).to.eql(expectedResponse);
               mocks.verify();
             });
         });

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -366,7 +366,7 @@ describe('service-broker-api-2.0', function () {
             .then(res => {
               config.services[0].plans[4].manager.settings.dashboard_url_template = oldTemp;
               expect(res).to.have.status(CONST.HTTP_STATUS_CODE.UNPROCESSABLE_ENTITY);
-              expect(res.body).to.eql({});
+              expect(res.body.description).to.include("Unable to generate valid dashboard URL with the template");
               mocks.verify();
             });
         });

--- a/broker/core/express-commons/src/middleware/index.js
+++ b/broker/core/express-commons/src/middleware/index.js
@@ -58,7 +58,7 @@ exports.error = function (options) {
   if (env !== 'production') {
     properties.push('stack');
   }
-  const formats = options.formats || ['text', 'html', 'json'];
+  const formats = options.formats || ['json', 'text', 'html'];
   const defaultFormat = options.defaultFormat;
   return function (err, req, res, next) {
     /* jshint unused:false */


### PR DESCRIPTION
HCPCFS-2963

#### Details/Requirements: 
Currently, whenever the schema validation gets failed, an error response will be returned. We have used a error middleware which will return the error response in appropriate format based on the `Accept` header sent in the request.
Currently in the logic of our error response, we are setting the default format for the response to be in `json`.

Whenever any operation like provisioning etc. is initiated by the svcat , and that operation return error as a response, upon describing the instance it shows error like:

```shell
 svcat describe instance demo3
                                                                                                                                                                                                                                                                                                                                      
 Status:      Failed - Error provisioning ServiceInstance of ClusterServiceClass (K8S: "34731fb8- 7b84-5f57-914f-d3d55d793dd4" ExternalName: "postgresql-db") at ClusterServiceBroker "interoperator": Status: 400; ErrorMessage: <nil>; Description: <nil>; ResponseError: invalid character 's' looking for beginning of value @ 2021-02-26 09:35:53 +0000 UTC 
```

Upon debugging the issue it was found that, svcat doesn't send `Accept` header in the request.

According to the documentation of the `res.format(object)` method it was found that whenever the `Accept` header is not present in the request, the formatter invoke the first callback [Documentation.](http://expressjs.com/en/api.html#res.format) In our error response handler the first callback is of type `text`.

#### Findings:
The described error will occur when the expected response is `json` and actual was in `text`.

#### Fix
Changed the order of the formats in our error response handler i.e on [Line61](https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/63464875e8a4b9215ec85b503587b6eb73af14fb/broker/core/express-commons/src/middleware/index.js#L61)

```python
#previous ordering
const formats = options.formats || ['text', 'html', 'json']; 
#changed ordering
const formats = options.formats || ['json', 'text', 'html'];
```

As a result of above changes some of the UT's were getting failed because of mismatched response body.
As a quick fix currently I commented those matching.


 

