### PR TITLE
Remaining structural changes to support new osb version

### DIFF
--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -631,8 +631,15 @@ class ServiceBrokerApiController extends FabrikBaseController {
             }
             _.set(body,'service_id',_.get(resource, 'spec.serviceId'));
             _.set(body,'plan_id',_.get(resource, 'spec.planId'));
-            _.set(body,'parameters',_.get(resource, 'spec.parameters'));
-
+            if(!_.isEmpty(_.get(plan, 'metadata.retrievableParametersList', []))) {
+              let paramList = _.get(plan, 'metadata.retrievableParametersList');
+              if(_.isArray(paramList)) {
+                let parameters = _.get(resource, 'spec.parameters');
+                _.set(body,'parameters', _.pick(parameters, paramList));  
+              }
+            } else {
+              _.set(body,'parameters',_.get(resource, 'spec.parameters'));
+            }
             return res.status(CONST.HTTP_STATUS_CODE.OK).send(body);
           }
         })

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -424,6 +424,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function done(bindResponse, state) {
       const response = decodeBase64(bindResponse);
       const statusCode = (state === CONST.APISERVER.RESOURCE_STATE.FAILED) ? CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR : CONST.HTTP_STATUS_CODE.CREATED;
+      if(_.get(config, 'sendBindingMetadata', true) === false) {
+        _.omit(response, 'metadata');
+      }
       res.status(statusCode).send(response);
     }
 

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -424,7 +424,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function done(bindResponse, state) {
       let response = decodeBase64(bindResponse);
       const statusCode = (state === CONST.APISERVER.RESOURCE_STATE.FAILED) ? CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR : CONST.HTTP_STATUS_CODE.CREATED;
-      if(statusCode ===  CONST.HTTP_STATUS_CODE.CREATED && _.get(config, 'sendBindingMetadata', true) === false) {
+      if(statusCode === CONST.HTTP_STATUS_CODE.CREATED && _.get(config, 'sendBindingMetadata', true) === false) {
         response = _.omit(response, 'metadata');
       }
       res.status(statusCode).send(response);

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -356,6 +356,18 @@ class ServiceBrokerApiController extends FabrikBaseController {
         body.state === CONST.APISERVER.RESOURCE_STATE.IN_QUEUE) {
         body.state = CONST.OPERATION.IN_PROGRESS;
       }
+      if(_.get(operation, 'type') === 'update' && body.state === CONST.OPERATION.FAILED) {
+        body.instance_usable = _.get(result, 'instanceUsable') === 'false' ||
+        _.get(result, 'instanceUsable') === false ? false : true;
+
+        body.update_repeatable = _.get(result, 'updateRepeatable') === 'false' ||
+        _.get(result, 'updateRepeatable') === false ? false : true;
+
+      }
+      if(_.get(operation, 'type') === 'delete' && body.state === CONST.OPERATION.FAILED) {
+        body.instance_usable = _.get(result, 'instanceUsable') === 'false' ||
+        _.get(result, 'instanceUsable') === false ? false : true;
+      }
       logger.debug('RequestIdentity:', _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent'), ',returning ..', body);
       return Promise.try(() => {
         if (_.get(operation, 'type') === 'delete' && body.state === CONST.OPERATION.SUCCEEDED && resourceGroup === CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR) {

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -424,7 +424,6 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function done(bindResponse, state) {
       let response = decodeBase64(bindResponse);
       const statusCode = (state === CONST.APISERVER.RESOURCE_STATE.FAILED) ? CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR : CONST.HTTP_STATUS_CODE.CREATED;
-      const statusCode = (state === CONST.APISERVER.RESOURCE_STATE.FAILED) ? CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR : CONST.HTTP_STATUS_CODE.CREATED;
       if(statusCode ===  CONST.HTTP_STATUS_CODE.CREATED && _.get(config, 'sendBindingMetadata', true) === false) {
         response = _.omit(response, 'metadata');
       }

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -422,10 +422,11 @@ class ServiceBrokerApiController extends FabrikBaseController {
       .value();
 
     function done(bindResponse, state) {
-      const response = decodeBase64(bindResponse);
+      let response = decodeBase64(bindResponse);
       const statusCode = (state === CONST.APISERVER.RESOURCE_STATE.FAILED) ? CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR : CONST.HTTP_STATUS_CODE.CREATED;
-      if(_.get(config, 'sendBindingMetadata', true) === false) {
-        _.omit(response, 'metadata');
+      const statusCode = (state === CONST.APISERVER.RESOURCE_STATE.FAILED) ? CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR : CONST.HTTP_STATUS_CODE.CREATED;
+      if(statusCode ===  CONST.HTTP_STATUS_CODE.CREATED && _.get(config, 'sendBindingMetadata', true) === false) {
+        response = _.omit(response, 'metadata');
       }
       res.status(statusCode).send(response);
     }

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -1554,6 +1554,39 @@ describe('service-broker-api-2.0', function () {
               mocks.verify();
             });
         });
+
+        it('update-sf20: returns 200 OK (state = failed) contains instance_usable and update_repeatable if provided', function () {
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {
+            status: {
+              description: `Update deployment ${deployment_name} failed at 2016-07-04T10:58:24.000Z`,
+              state: 'failed',
+              instanceUsable: 'false',
+              updateRepeatable: 'true'
+            }
+          });
+          return chai.request(app)
+            .get(`${base_url}/service_instances/${instance_id}/last_operation`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id,
+              operation: commonFunctions.encodeBase64({
+                'type': 'update'
+              })
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body).to.eql({
+                description: `Update deployment ${deployment_name} failed at 2016-07-04T10:58:24.000Z`,
+                state: 'failed',
+                instance_usable: false,
+                update_repeatable: true
+              });
+              mocks.verify();
+            });
+        });
         it('update-sf20: returns 200 OK (state = in progress): In K8S platform', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {
             status: {
@@ -1604,6 +1637,7 @@ describe('service-broker-api-2.0', function () {
               mocks.verify();
             });
         });
+        
         it('delete-sf20: returns 200 OK (state = in progress)', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {
             status: {
@@ -1665,7 +1699,37 @@ describe('service-broker-api-2.0', function () {
               mocks.verify();
             });
         });
-
+        it('delete-sf20: returns 200 OK (state = failed) contains instance_usable if provided', function () {
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {
+            status: {
+              description: `Delete deployment ${deployment_name} failed at 2016-07-04T10:58:24.000Z`,
+              state: 'failed',
+              instanceUsable: 'true'
+            }
+          });
+          
+          return chai.request(app)
+            .get(`${base_url}/service_instances/${instance_id}/last_operation`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id,
+              operation: commonFunctions.encodeBase64({
+                'type': 'delete'
+              })
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body).to.eql({
+                description: `Delete deployment ${deployment_name} failed at 2016-07-04T10:58:24.000Z`,
+                state: 'failed',
+                instance_usable: true
+              });
+              mocks.verify();
+            });
+        });
         it('delete-sf20: returns 410 GONE', function () {
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, 404);
           return chai.request(app)

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api.GetEndpoints.spec.js
@@ -90,7 +90,7 @@ describe('service-broker-api-2.0', function () {
 
       it('returns 400 (BadRequest) error if service does not support instance retrieval', function () {
         const testPayload2 = _.cloneDeep(payload2);
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -105,7 +105,7 @@ describe('service-broker-api-2.0', function () {
 
       it('returns 404 if service instance not found', function () {
         const testPayload2 = _.cloneDeep(payload2);
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, {}, 1, 404);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -128,7 +128,7 @@ describe('service-broker-api-2.0', function () {
 
         const testPayload2 = _.cloneDeep(payload2);
         testPayload2.status.state = 'in_queue';
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -153,7 +153,7 @@ describe('service-broker-api-2.0', function () {
 
         const testPayload2 = _.cloneDeep(payload2);
         testPayload2.status.state = 'delete';
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -180,7 +180,7 @@ describe('service-broker-api-2.0', function () {
 
         const testPayload2 = _.cloneDeep(payload2);
         testPayload2.status.state = 'in progress';
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -205,7 +205,7 @@ describe('service-broker-api-2.0', function () {
 
         const testPayload2 = _.cloneDeep(payload2);
         testPayload2.status.state = 'in progress';
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         testPayload2.metadata.labels['interoperator.servicefabrik.io/lastoperation'] = 'update'
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
@@ -233,7 +233,7 @@ describe('service-broker-api-2.0', function () {
 
         const testPayload2 = _.cloneDeep(payload2);
         testPayload2.status.state = 'update';
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -258,7 +258,7 @@ describe('service-broker-api-2.0', function () {
           catalog.reload();
         }
         const testPayload2 = _.cloneDeep(payload2);
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -280,6 +280,47 @@ describe('service-broker-api-2.0', function () {
           });
       });
 
+      it('returns 200 if service instance is successfully returned - returns specified list of parameters', function () {
+        const oldServices = config.services;
+        const service = _.find(config.services, ['id', service_id]);
+        let plan;
+        if (service) {
+          _.set(service, 'instance_retrievable', true);
+          plan = _.find(service.plans, ['id', plan_id]);
+          if(plan) {
+            _.set(plan, 'metadata.retrievableParametersList', ['foo1', 'foo', 'foo3']);
+          }
+          catalog.reload();
+        }
+        const testPayload2 = _.cloneDeep(payload2);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
+        testPayload2.spec.parameters.foo1 = "bar1";
+        testPayload2.spec.parameters.foo2 = "bar2";
+        mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
+        return chai.request(app)
+          .get(`${baseCFUrl}/service_instances/${instance_id}`)
+          .set('X-Broker-API-Version', '2.14')
+          .auth(config.username, config.password)
+          .then(res => {
+            config.services = oldServices;
+            if(plan) {
+              _.unset(plan, 'metadata.retrievableParametersList');
+            }
+            catalog.reload();
+            expect(res).to.have.status(200);
+            expect(res.body).to.deep.equal({
+              service_id: service_id,
+              plan_id: plan_id,
+              parameters: {
+                foo: 'bar',
+                foo1: 'bar1'
+              },
+              dashboard_url: `${protocol}://${host}/manage/dashboards/docker/instances/${instance_id}`
+            })
+            mocks.verify();
+          });
+      });
+
       it('returns 200 if service instance is successfully returned (k8s)', function () {
         const oldServices = config.services;
         const service = _.find(config.services, ['id', service_id]);
@@ -288,7 +329,7 @@ describe('service-broker-api-2.0', function () {
           catalog.reload();
         }
         const testPayload2 = _.cloneDeep(payload2K8s);
-        testPayload2.spec = camelcaseKeys(payload2K8s.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -315,7 +356,7 @@ describe('service-broker-api-2.0', function () {
         }
         const testPayload2 = _.cloneDeep(payload2);
         testPayload2.status.state = 'failed';
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -339,7 +380,7 @@ describe('service-broker-api-2.0', function () {
 
       it('returns 412 (PreconditionFailed) error if broker api version is not atleast 2.14', function () {
         const testPayload2 = _.cloneDeep(payload2);
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -359,7 +400,7 @@ describe('service-broker-api-2.0', function () {
           catalog.reload();
         }
         const testPayload2 = _.cloneDeep(payload2);
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -385,7 +426,7 @@ describe('service-broker-api-2.0', function () {
 
       it('should return X-Broker-API-Request-Identity in response if set in request (with precondition failure)', function () {
         const testPayload2 = _.cloneDeep(payload2);
-        testPayload2.spec = camelcaseKeys(payload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEINSTANCES, instance_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}`)
@@ -446,7 +487,7 @@ describe('service-broker-api-2.0', function () {
 
       it('returns 400 (BadRequest) error if service does not support binding retrieval', function () {
         const testPayload2 = _.cloneDeep(bindPayload2);
-        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
@@ -473,7 +514,7 @@ describe('service-broker-api-2.0', function () {
         catalog.reload();
 
         const testPayload2 = _.cloneDeep(bindPayload2);
-        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
@@ -490,7 +531,7 @@ describe('service-broker-api-2.0', function () {
 
       it('returns 404 if binding not found', function () {
         const testPayload2 = _.cloneDeep(bindPayload2);
-        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {}, 1, 404);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
@@ -517,7 +558,7 @@ describe('service-broker-api-2.0', function () {
         catalog.reload();
 
         const testPayload2 = _.cloneDeep(bindPayload2);
-        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
         mocks.apiServerEventMesh.nockGetSecret(binding_id, _.get(config, 'sf_namespace', CONST.APISERVER.DEFAULT_NAMESPACE), {
           data: {
@@ -562,7 +603,7 @@ describe('service-broker-api-2.0', function () {
 
         const testPayload2 = _.cloneDeep(bindPayload2);
         testPayload2.status.state = 'failed';
-        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
         return chai.request(app)
           .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)
@@ -579,7 +620,7 @@ describe('service-broker-api-2.0', function () {
 
       it('returns 412 (PreconditionFailed) error if broker api version is not atleast 2.14', function () {
         const testPayload2 = _.cloneDeep(bindPayload2);
-        testPayload2.spec = camelcaseKeys(bindPayload2.spec);
+        testPayload2.spec = camelcaseKeys(testPayload2.spec);
         mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, testPayload2, 1);
           return chai.request(app)
             .get(`${baseCFUrl}/service_instances/${instance_id}/service_bindings/${binding_id}`)

--- a/broker/core/models/src/Plan.js
+++ b/broker/core/models/src/Plan.js
@@ -90,6 +90,7 @@ class Plan {
       'name',
       'description',
       'metadata',
+      'maintenance_info',
       'schemas',
       'free'
     ];

--- a/helm-charts/interoperator/conf/settings.yaml
+++ b/helm-charts/interoperator/conf/settings.yaml
@@ -16,6 +16,7 @@ defaults: &defaults
   http_timeout: 175000
   allowConcurrentOperations: {{ .Values.broker.allow_concurrent_operations }}
   allowConcurrentBindingOperations: {{ .Values.broker.allow_concurrent_binding_operations }}
+  sendBindingMetadata: {{ .Values.broker.send_binding_metadata }}
   
   ##############################
   # INTERNAL ENDPOINT SETTINGS #

--- a/helm-charts/interoperator/crds/sfplan.yaml
+++ b/helm-charts/interoperator/crds/sfplan.yaml
@@ -56,6 +56,13 @@ spec:
                 type: boolean
               id:
                 type: string
+              maintenance_info:
+                properties:
+                  description:
+                    type: string
+                  version:
+                    type: string
+                type: object                
               manager:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true

--- a/helm-charts/interoperator/crds/sfserviceinstance.yaml
+++ b/helm-charts/interoperator/crds/sfserviceinstance.yaml
@@ -130,6 +130,10 @@ spec:
                 type: array
               state:
                 type: string
+              instanceUsable:
+                type: string
+              updateRepeatable:
+                type: string
             required:
             - state
             type: object

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -17,7 +17,8 @@ broker:
   services_namespace: "services"
   allow_concurrent_operations: true
   allow_concurrent_binding_operations: true
-
+  send_binding_metadata: true
+  
   # override the global replicaCount just for broker
   replicaCount: 4
   resources:

--- a/interoperator/api/osb/v1alpha1/sfplan_types.go
+++ b/interoperator/api/osb/v1alpha1/sfplan_types.go
@@ -71,6 +71,12 @@ type ServiceSchemas struct {
 	Binding  ServiceBindingSchema  `json:"service_binding,omitempty"`
 }
 
+// MaintenanceInfo captures any maintainance related information for give plan
+type MaintenanceInfo struct {
+	Version     string `json:"version"`
+	Description string `json:"description,omitempty"`
+}
+
 // SFPlanSpec defines the desired state of SFPlan
 type SFPlanSpec struct {
 	Name        string `json:"name"`
@@ -79,6 +85,7 @@ type SFPlanSpec struct {
 
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Metadata            *runtime.RawExtension `json:"metadata,omitempty"`
+	MaintenanceInfo     MaintenanceInfo       `json:"maintenance_info,omitempty"`
 	Free                bool                  `json:"free"`
 	Bindable            bool                  `json:"bindable"`
 	PlanUpdatable       bool                  `json:"planUpdatable,omitempty"`

--- a/interoperator/api/osb/v1alpha1/sfserviceinstance_types.go
+++ b/interoperator/api/osb/v1alpha1/sfserviceinstance_types.go
@@ -45,12 +45,14 @@ type SFServiceInstanceSpec struct {
 
 // SFServiceInstanceStatus defines the observed state of SFServiceInstance
 type SFServiceInstanceStatus struct {
-	DashboardURL string                `yaml:"dashboardUrl,omitempty" json:"dashboardUrl,omitempty"`
-	State        string                `yaml:"state" json:"state"`
-	Error        string                `yaml:"error,omitempty" json:"error,omitempty"`
-	Description  string                `yaml:"description,omitempty" json:"description,omitempty"`
-	AppliedSpec  SFServiceInstanceSpec `yaml:"appliedSpec,omitempty" json:"appliedSpec,omitempty"`
-	Resources    []Source              `yaml:"resources,omitempty" json:"resources,omitempty"`
+	DashboardURL     string                `yaml:"dashboardUrl,omitempty" json:"dashboardUrl,omitempty"`
+	State            string                `yaml:"state" json:"state"`
+	Error            string                `yaml:"error,omitempty" json:"error,omitempty"`
+	Description      string                `yaml:"description,omitempty" json:"description,omitempty"`
+	InstanceUsable   string                `yaml:"instanceUsable,omitempty" json:"instanceUsable,omitempty"`
+	UpdateRepeatable string                `yaml:"updateRepeatable,omitempty" json:"updateRepeatable,omitempty"`
+	AppliedSpec      SFServiceInstanceSpec `yaml:"appliedSpec,omitempty" json:"appliedSpec,omitempty"`
+	Resources        []Source              `yaml:"resources,omitempty" json:"resources,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfplans.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfplans.yaml
@@ -56,6 +56,13 @@ spec:
                 type: boolean
               id:
                 type: string
+              maintenance_info:
+                properties:
+                  description:
+                    type: string
+                  version:
+                    type: string
+                type: object
               manager:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true

--- a/interoperator/config/crd/bases/osb.servicefabrik.io_sfserviceinstances.yaml
+++ b/interoperator/config/crd/bases/osb.servicefabrik.io_sfserviceinstances.yaml
@@ -130,6 +130,10 @@ spec:
                 type: array
               state:
                 type: string
+              instanceUsable:
+                type: string
+              updateRepeatable:
+                type: string
             required:
             - state
             type: object

--- a/interoperator/controllers/provisioners/sfserviceinstance/sfserviceinstance_controller.go
+++ b/interoperator/controllers/provisioners/sfserviceinstance/sfserviceinstance_controller.go
@@ -346,6 +346,8 @@ func (r *ReconcileSFServiceInstance) updateDeprovisionStatus(instance *osbv1alph
 	updatedStatus.State = computedStatus.Deprovision.State
 	updatedStatus.Error = computedStatus.Deprovision.Error
 	updatedStatus.Description = computedStatus.Deprovision.Response
+	updatedStatus.InstanceUsable = computedStatus.Deprovision.InstanceUsable
+	updatedStatus.UpdateRepeatable = computedStatus.Deprovision.UpdateRepeatable
 
 	remainingResource := []osbv1alpha1.Source{}
 	for _, subResource := range instance.Status.Resources {
@@ -439,6 +441,8 @@ func (r *ReconcileSFServiceInstance) updateStatus(instance *osbv1alpha1.SFServic
 	updatedStatus.Error = computedStatus.Provision.Error
 	updatedStatus.Description = computedStatus.Provision.Response
 	updatedStatus.DashboardURL = computedStatus.Provision.DashboardURL
+	updatedStatus.InstanceUsable = computedStatus.Provision.InstanceUsable
+	updatedStatus.UpdateRepeatable = computedStatus.Provision.UpdateRepeatable
 
 	if !reflect.DeepEqual(&instance.Status, updatedStatus) {
 		updatedStatus.DeepCopyInto(&instance.Status)

--- a/interoperator/controllers/provisioners/sfserviceinstance/sfserviceinstance_controller_test.go
+++ b/interoperator/controllers/provisioners/sfserviceinstance/sfserviceinstance_controller_test.go
@@ -140,7 +140,7 @@ func TestReconcile(t *testing.T) {
 		Provision: properties.InstanceStatus{
 			State: "succeeded",
 		},
-		Deprovision: properties.GenericStatus{
+		Deprovision: properties.InstanceStatus{
 			State: "succeeded",
 		},
 	}, nil).AnyTimes()

--- a/interoperator/internal/properties/properties.go
+++ b/interoperator/internal/properties/properties.go
@@ -19,10 +19,12 @@ type GenericStatus struct {
 
 // InstanceStatus defines template provided by the service for provision response
 type InstanceStatus struct {
-	State        string `yaml:"state" json:"state"`
-	Error        string `yaml:"error,omitempty" json:"error,omitempty"`
-	Response     string `yaml:"response,omitempty" json:"response,omitempty"`
-	DashboardURL string `yaml:"dashboardUrl,omitempty" json:"dashboardUrl,omitempty"`
+	State            string `yaml:"state" json:"state"`
+	Error            string `yaml:"error,omitempty" json:"error,omitempty"`
+	Response         string `yaml:"response,omitempty" json:"response,omitempty"`
+	DashboardURL     string `yaml:"dashboardUrl,omitempty" json:"dashboardUrl,omitempty"`
+	InstanceUsable   string `yaml:"instanceUsable,omitempty" json:"instanceUsable,omitempty"`
+	UpdateRepeatable string `yaml:"updateRepeatable,omitempty" json:"updateRepeatable,omitempty"`
 }
 
 // Status is all the data to be read by interoperator from
@@ -31,7 +33,7 @@ type Status struct {
 	Provision   InstanceStatus `yaml:"provision" json:"provision"`
 	Bind        GenericStatus  `yaml:"bind" json:"bind"`
 	Unbind      GenericStatus  `yaml:"unbind" json:"unbind"`
-	Deprovision GenericStatus  `yaml:"deprovision" json:"deprovision"`
+	Deprovision InstanceStatus `yaml:"deprovision" json:"deprovision"`
 }
 
 // ParseSources decodes sources yaml into a map

--- a/interoperator/internal/properties/properties_test.go
+++ b/interoperator/internal/properties/properties_test.go
@@ -96,9 +96,11 @@ deprovision:
 				Provision: InstanceStatus{
 					State: "state",
 				},
-				Bind:        status,
-				Unbind:      status,
-				Deprovision: status,
+				Bind:   status,
+				Unbind: status,
+				Deprovision: InstanceStatus{
+					State: "state",
+				},
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Changes in this PR:

- Adding support for `maintainance_info` , `instance_usable`, and `update_repeatable` features of new version in OSB Spec
- Adding config for supporting `metadata` field in binding response
- Adding support for specifying list of parameters returned for get instance endpoint

Feature: HCPCFS-2938