### PR TITLE
Support for asynchronous Service Bindings

### DIFF
--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -348,12 +348,12 @@ class ServiceBrokerApiController extends FabrikBaseController {
     const encodedOp = _.get(req, 'query.operation', undefined);
     const operation = encodedOp === undefined ? {} : decodeBase64(encodedOp);
     const guid = req.params.instance_id;
-    let action, instanceType;
 
     function done(result) {
       const body = _.pick(result, 'state', 'description');
       if (body.state === CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS ||
-        body.state === CONST.APISERVER.RESOURCE_STATE.IN_QUEUE) {
+        body.state === CONST.APISERVER.RESOURCE_STATE.IN_QUEUE ||
+        body.state === CONST.APISERVER.RESOURCE_STATE.DELETE) {
         body.state = CONST.OPERATION.IN_PROGRESS;
       }
       if(_.get(operation, 'type') === 'update' && body.state === CONST.OPERATION.FAILED) {
@@ -385,7 +385,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function failed(err) {
       res.status(CONST.HTTP_STATUS_CODE.OK).send({
         state: CONST.OPERATION.FAILED,
-        description: `${action} ${instanceType} '${guid}' failed because "${err.message}"`
+        description: `'${guid}' failed because "${err.message}"`
       });
     }
 
@@ -423,7 +423,8 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function done(result) {
       const body = _.pick(result, 'state', 'description');
       if (body.state === CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS ||
-        body.state === CONST.APISERVER.RESOURCE_STATE.IN_QUEUE) {
+        body.state === CONST.APISERVER.RESOURCE_STATE.IN_QUEUE ||
+        body.state === CONST.APISERVER.RESOURCE_STATE.DELETE) {
         body.state = CONST.OPERATION.IN_PROGRESS;
       }
 

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -419,7 +419,6 @@ class ServiceBrokerApiController extends FabrikBaseController {
     const operation = encodedOp === undefined ? {} : decodeBase64(encodedOp);
     const guid = req.params.binding_id;
     const namespaceId = eventmesh.apiServerClient.getNamespaceId(req.params.instance_id);
-    let action, instanceType;
 
     function done(result) {
       const body = _.pick(result, 'state', 'description');
@@ -446,7 +445,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
     function failed(err) {
       res.status(CONST.HTTP_STATUS_CODE.OK).send({
         state: CONST.OPERATION.FAILED,
-        description: `${action} ${instanceType} '${guid}' failed because "${err.message}"`
+        description: `'${guid}' failed because "${err.message}"`
       });
     }
 

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -460,9 +460,9 @@ class ServiceBrokerApiController extends FabrikBaseController {
       }
       failed(err);
     }
-    const resourceGroup = operation.serviceflow_id ? CONST.APISERVER.RESOURCE_GROUPS.SERVICE_FLOW : CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR;
-    const resourceType = operation.serviceflow_id ? CONST.APISERVER.RESOURCE_TYPES.SERIAL_SERVICE_FLOW : CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS;
-    const resourceId = getKubernetesName(operation.serviceflow_id ? operation.serviceflow_id : req.params.binding_id);
+    const resourceGroup = CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR;
+    const resourceType = CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS;
+    const resourceId = getKubernetesName(req.params.binding_id);
     return eventmesh.apiServerClient.getLastOperation({
       resourceGroup: resourceGroup,
       resourceType: resourceType,

--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -431,6 +431,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       logger.debug('RequestIdentity:', _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent'), ',returning ..', body);
       return Promise.try(() => {
         if (_.get(operation, 'type') === 'delete' && body.state === CONST.OPERATION.SUCCEEDED && resourceGroup === CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR) {
+          logger.debug(`Remove broker finalizer from ${resourceId}`);
           return this.removeFinalizersFromOSBResource(
             resourceType,
             resourceId,
@@ -469,7 +470,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
       namespaceId: namespaceId,
       requestIdentity: _.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')
     })
-      .tap(() => logger.debug(`RequestIdentity: ${_.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')} , Returning state of operation: ${operation.serviceflow_id}, ${resourceGroup}, ${resourceType}`))
+      .tap(() => logger.debug(`RequestIdentity: ${_.get(req.headers, CONST.SF_BROKER_API_HEADERS.REQUEST_IDENTITY, 'Absent')} , Returning state of operation: ${resourceGroup}, ${resourceType}`))
       .then(done.bind(this))
       .catch(NotFound, notFound);
   }

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -158,12 +158,23 @@ function getPlanFromRequest(req) {
 }
 
   
-exports.validateRequest = function () {
+exports.validateInstanceRequest = function () {
   return function (req, res, next) {
     /* jshint unused:false */
     const plan = getPlanFromRequest(req);
     if (plan.manager.async && (_.get(req, 'query.accepts_incomplete', 'false') !== 'true')) {
       return next(new UnprocessableEntity('This request requires client support for asynchronous service operations.', 'AsyncRequired'));
+    }
+    next();
+  };
+};
+
+exports.validateBindingRequest = function () {
+  return function (req, res, next) {
+    /* jshint unused:false */
+    const plan = getPlanFromRequest(req);
+    if (plan.manager.asyncBinding && (_.get(req, 'query.accepts_incomplete', 'false') !== 'true')) {
+      return next(new UnprocessableEntity('This Service Instance requires client support for asynchronous binding operations.', 'AsyncRequired'));
     }
     next();
   };

--- a/broker/applications/osb-broker/src/api-controllers/middleware/index.js
+++ b/broker/applications/osb-broker/src/api-controllers/middleware/index.js
@@ -180,6 +180,15 @@ exports.validateBindingRequest = function () {
   };
 };
 
+exports.validateLastOperationRequest = function () {
+  return function (req, res, next) {
+    if (_.isEmpty(_.get(req, 'query.operation', ''))) {
+      return next(new BadRequest('This request is missing mandatory operation parameter.'));
+    }
+    next();
+  };
+};
+
 exports.validateSchemaForRequest = function (target, operation) {
   return function (req, res, next) {
     const plan = getPlanFromRequest(req);

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
@@ -45,3 +45,6 @@ instanceRouter.route('/service_bindings/:binding_id')
   .delete(middleware.checkBlockingOperationInProgress(), middleware.validateConcurrentOperations(), middleware.validateConcurrentBindingOperations(),controller.handler('deleteBinding'))
   .get([middleware.minApiVersion('2.14'), controller.handler('getServiceBinding')])
   .all(middleware.methodNotAllowed(['PUT', 'DELETE', 'GET']));
+instanceRouter.route('/service_bindings/:binding_id/last_operation')
+  .get(controller.handler('getLastBindingOperation'))
+  .all(middleware.methodNotAllowed(['GET']));

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
@@ -46,5 +46,5 @@ instanceRouter.route('/service_bindings/:binding_id')
   .get([middleware.minApiVersion('2.14'), controller.handler('getServiceBinding')])
   .all(middleware.methodNotAllowed(['PUT', 'DELETE', 'GET']));
 instanceRouter.route('/service_bindings/:binding_id/last_operation')
-  .get(controller.handler('getLastBindingOperation'))
+  .get(middleware.validateLastOperationRequest(), controller.handler('getLastBindingOperation'))
   .all(middleware.methodNotAllowed(['GET']));

--- a/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
+++ b/broker/applications/osb-broker/src/api-controllers/routes/broker/v2.js
@@ -32,17 +32,17 @@ router.use(middleware.error({
 
 /* Service Instance Router */
 instanceRouter.route('/')
-  .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateCreateRequest(), middleware.validateSchemaForRequest('service_instance', 'create'), middleware.validateMaintenanceInfoInRequest(), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
-  .patch([middleware.injectPlanInRequest(), middleware.checkQuota(), middleware.validateRequest(), middleware.validateSchemaForRequest('service_instance', 'update'), middleware.validateMaintenanceInfoInRequest(), middleware.validateConcurrentOperations(), middleware.validateConcurrentBindingOperations(), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
-  .delete([middleware.validateRequest(), middleware.validateConcurrentOperations(), middleware.validateConcurrentBindingOperations(), controller.handleWithResourceLocking('deleteInstance', CONST.OPERATION_TYPE.DELETE)])
+  .put([middleware.isPlanDeprecated(), middleware.checkQuota(), middleware.validateInstanceRequest(), middleware.validateCreateRequest(), middleware.validateSchemaForRequest('service_instance', 'create'), middleware.validateMaintenanceInfoInRequest(), controller.handleWithResourceLocking('putInstance', CONST.OPERATION_TYPE.CREATE)])
+  .patch([middleware.injectPlanInRequest(), middleware.checkQuota(), middleware.validateInstanceRequest(), middleware.validateSchemaForRequest('service_instance', 'update'), middleware.validateMaintenanceInfoInRequest(), middleware.validateConcurrentOperations(), middleware.validateConcurrentBindingOperations(), controller.handleWithResourceLocking('patchInstance', CONST.OPERATION_TYPE.UPDATE)])
+  .delete([middleware.validateInstanceRequest(), middleware.validateConcurrentOperations(), middleware.validateConcurrentBindingOperations(), controller.handleWithResourceLocking('deleteInstance', CONST.OPERATION_TYPE.DELETE)])
   .get([middleware.minApiVersion('2.14'), controller.handler('getServiceInstance')])
   .all(middleware.methodNotAllowed(['PUT', 'PATCH', 'DELETE', 'GET']));
 instanceRouter.route('/last_operation')
   .get(controller.handler('getLastInstanceOperation'))
   .all(middleware.methodNotAllowed(['GET']));
 instanceRouter.route('/service_bindings/:binding_id')
-  .put([middleware.checkBlockingOperationInProgress(), middleware.validateSchemaForRequest('service_binding', 'create'), middleware.validateConcurrentOperations(), middleware.validateConcurrentBindingOperations(), controller.handler('putBinding')])
-  .delete(middleware.checkBlockingOperationInProgress(), middleware.validateConcurrentOperations(), middleware.validateConcurrentBindingOperations(),controller.handler('deleteBinding'))
+  .put([middleware.validateBindingRequest(), middleware.checkBlockingOperationInProgress(), middleware.validateSchemaForRequest('service_binding', 'create'), middleware.validateConcurrentOperations(), middleware.validateConcurrentBindingOperations(), controller.handler('putBinding')])
+  .delete(middleware.validateBindingRequest(), middleware.checkBlockingOperationInProgress(), middleware.validateConcurrentOperations(), middleware.validateConcurrentBindingOperations(), controller.handler('deleteBinding'))
   .get([middleware.minApiVersion('2.14'), controller.handler('getServiceBinding')])
   .all(middleware.methodNotAllowed(['PUT', 'DELETE', 'GET']));
 instanceRouter.route('/service_bindings/:binding_id/last_operation')

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -1855,6 +1855,8 @@ describe('service-broker-api-2.0', function () {
 
 
       describe('#lastOperationBinding', function () {
+        // plan with manager.asyncBinding = true
+        const plan_id_async = 'gd158c9a-7934-401e-94ab-057082a5073e';
 
         it('createBinding: returns 200 OK (state = in progress)', function () {
           const description = `Create deployment ${deployment_name} is still in progress`;
@@ -1870,7 +1872,10 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .query({
               service_id: service_id,
-              plan_id: plan_id
+              plan_id: plan_id_async,
+              operation: commonFunctions.encodeBase64({
+                'type': 'create'
+              })
             })
             .catch(err => err.response)
             .then(res => {
@@ -1898,7 +1903,7 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .query({
               service_id: service_id,
-              plan_id: plan_id,
+              plan_id: plan_id_async,
               operation: commonFunctions.encodeBase64({
                 'type': 'create'
               })
@@ -1922,7 +1927,7 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .query({
               service_id: service_id,
-              plan_id: plan_id,
+              plan_id: plan_id_async,
               operation: commonFunctions.encodeBase64({
                 'type': 'create'
               })
@@ -1949,7 +1954,10 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .query({
               service_id: service_id,
-              plan_id: plan_id
+              plan_id: plan_id_async,
+              operation: commonFunctions.encodeBase64({
+                'type': 'delete'
+              })
             })
             .catch(err => err.response)
             .then(res => {
@@ -1984,7 +1992,7 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .query({
               service_id: service_id,
-              plan_id: plan_id,
+              plan_id: plan_id_async,
               operation: commonFunctions.encodeBase64({
                 'type': 'delete'
               })
@@ -2015,7 +2023,7 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .query({
               service_id: service_id,
-              plan_id: plan_id,
+              plan_id: plan_id_async,
               operation: commonFunctions.encodeBase64({
                 'type': 'delete'
               })
@@ -2040,7 +2048,7 @@ describe('service-broker-api-2.0', function () {
             .auth(config.username, config.password)
             .query({
               service_id: service_id,
-              plan_id: plan_id,
+              plan_id: plan_id_async,
               operation: commonFunctions.encodeBase64({
                 'type': 'delete'
               })
@@ -2049,6 +2057,25 @@ describe('service-broker-api-2.0', function () {
             .then(res => {
               expect(res).to.have.status(410);
               expect(res.body).to.eql({});
+              mocks.verify();
+            });
+        });
+
+        it('deleteBinding: returns 400 BAD REQUEST when operation missing', function () {
+          return chai.request(app)
+            .get(`${base_url}/service_instances/${instance_id}/service_bindings/${binding_id}/last_operation`)
+            .set('X-Broker-API-Version', api_version)
+            .set('Accept', 'application/json')
+            .auth(config.username, config.password)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id_async
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(400);
+              expect(res.body.error).to.be.eql('Bad Request');
+              expect(res.body.description).to.be.eql('This request is missing mandatory operation parameter.');
               mocks.verify();
             });
         });

--- a/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
+++ b/broker/applications/osb-broker/test/acceptance/service-broker-api-2.0.instances.director.spec.js
@@ -1855,11 +1855,119 @@ describe('service-broker-api-2.0', function () {
 
 
       describe('#lastOperationBinding', function () {
-        it('deleteBinding: returns 200 OK (state = succeeded)', function () {
+
+        it('createBinding: returns 200 OK (state = in progress)', function () {
+          const description = `Create deployment ${deployment_name} is still in progress`;
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {
             status: {
-              description: `Delete deployment ${deployment_name} succeeded at 2016-07-04T10:58:24.000Z`,
-              state: 'succeeded'
+              description: description,
+              state: CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS
+            }
+          });
+          return chai.request(app)
+            .get(`${base_url}/service_instances/${instance_id}/service_bindings/${binding_id}/last_operation`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body).to.eql({
+                description: description,
+                state: 'in progress'
+              });
+              mocks.verify();
+            });
+        });
+
+        it('createBinding: returns 200 OK (state = succeeded)', function () {
+          const description = `Create deployment ${deployment_name} succeeded at 2020-04-04T10:58:24.000Z`;
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {
+            status: {
+              description: description,
+              state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
+            }
+          });
+
+          return chai.request(app)
+            .get(`${base_url}/service_instances/${instance_id}/service_bindings/${binding_id}/last_operation`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id,
+              operation: commonFunctions.encodeBase64({
+                'type': 'create'
+              })
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body).to.eql({
+                description: description,
+                state: 'succeeded'
+              });
+              mocks.verify();
+            });
+        });
+
+        it('createBinding: returns 200 OK (state = failed)', function () {
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {}, 1, 404);
+          return chai.request(app)
+            .get(`${base_url}/service_instances/${instance_id}/service_bindings/${binding_id}/last_operation`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id,
+              operation: commonFunctions.encodeBase64({
+                'type': 'create'
+              })
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body.state).to.eql(CONST.OPERATION.FAILED);
+              mocks.verify();
+            });
+        });
+
+        it('deleteBinding: returns 200 OK (state = in progress)', function () {
+          const description = `Delete deployment ${deployment_name} is still in progress`;
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {
+            status: {
+              description: description,
+              state: CONST.APISERVER.RESOURCE_STATE.IN_PROGRESS
+            }
+          });
+          return chai.request(app)
+            .get(`${base_url}/service_instances/${instance_id}/service_bindings/${binding_id}/last_operation`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body).to.eql({
+                description: description,
+                state: 'in progress'
+              });
+              mocks.verify();
+            });
+        });
+
+        it('deleteBinding: returns 200 OK (state = succeeded)', function () {
+          const description = `Delete deployment ${deployment_name} succeeded at 2020-04-04T10:58:24.000Z`;
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {
+            status: {
+              description: description,
+              state: CONST.APISERVER.RESOURCE_STATE.SUCCEEDED
             }
           });
           mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {
@@ -1885,9 +1993,62 @@ describe('service-broker-api-2.0', function () {
             .then(res => {
               expect(res).to.have.status(200);
               expect(res.body).to.eql({
-                description: `Delete deployment ${deployment_name} succeeded at 2016-07-04T10:58:24.000Z`,
+                description: description,
                 state: 'succeeded'
               });
+              mocks.verify();
+            });
+        });
+
+        it('deleteBinding: returns 200 OK (state = failed)', function () {
+          const description = `Delete deployment ${deployment_name} failed at 2020-04-04T10:58:24.000Z`;
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {
+            status: {
+              description: description,
+              state: CONST.APISERVER.RESOURCE_STATE.FAILED,
+            }
+          });
+
+          return chai.request(app)
+            .get(`${base_url}/service_instances/${instance_id}/service_bindings/${binding_id}/last_operation`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id,
+              operation: commonFunctions.encodeBase64({
+                'type': 'delete'
+              })
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body).to.eql({
+                description: description,
+                state: 'failed',
+
+              });
+              mocks.verify();
+            });
+        });
+
+        it('deleteBinding: returns 410 GONE', function () {
+          mocks.apiServerEventMesh.nockGetResource(CONST.APISERVER.RESOURCE_GROUPS.INTEROPERATOR, CONST.APISERVER.RESOURCE_TYPES.INTEROPERATOR_SERVICEBINDINGS, binding_id, {}, 1, 404);
+          return chai.request(app)
+            .get(`${base_url}/service_instances/${instance_id}/service_bindings/${binding_id}/last_operation`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .query({
+              service_id: service_id,
+              plan_id: plan_id,
+              operation: commonFunctions.encodeBase64({
+                'type': 'delete'
+              })
+            })
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(410);
+              expect(res.body).to.eql({});
               mocks.verify();
             });
         });

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -899,7 +899,10 @@ defaults: &defaults
       free: false
       manager: &manager_plan7
         name: 'director'
+        # sets service instance provisioning operation to asynchronous
         async: true
+        # sets service binding operation to asynchronous
+        asyncBinding: true
         resource_mappings: *director_resource_mappings
         settings: &settings_plan7
           prefix: 'blueprint'


### PR DESCRIPTION
OSB specification 2.14 added support for asynchronous Service Bindings ([PR](https://github.com/openservicebrokerapi/servicebroker/pull/334)) and a new [last operation endpoint for Service Bindings](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#polling-last-operation-for-service-bindings) endpoint.

Currently, Service Instance Provisioning is treated asynchronously based on the `async: true` flag in plan. We can use `asyncBinding: true` for setting  Service  Binding asynchronous.

```yaml
apiVersion: osb.servicefabrik.io/v1alpha1
kind: SFPlan
spec:
  manager:
     async: true   # only makes provisioning async
     asyncBinding: true   # New flag for binding
```


Feature: HCPCFS-2937