### PR TITLE
Create service_namespace via helm  if namespaced_separation is false

### DIFF
--- a/helm-charts/interoperator/templates/namespace.yaml
+++ b/helm-charts/interoperator/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if not .Values.broker.enable_namespaced_separation }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.broker.services_namespace }}
+{{- end }}

--- a/helm-charts/interoperator/templates/namespace.yaml
+++ b/helm-charts/interoperator/templates/namespace.yaml
@@ -1,6 +1,8 @@
 {{- if not .Values.broker.enable_namespaced_separation }}
+{{- if .Values.broker.create_services_namespace }}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.broker.services_namespace }}
+{{- end }}
 {{- end }}

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -14,6 +14,7 @@ broker:
   username: broker
   password: secret
   enable_namespaced_separation: true
+  create_services_namespace: false
   services_namespace: "services"
   allow_concurrent_operations: true
   allow_concurrent_binding_operations: true


### PR DESCRIPTION
*PR Contains*

- Right now, if the namespaced_separation is set to the false service instances created in the namespace mentioned in the `service_namespace` but this namespace should be created manually. This PR creates via helm automatically.
- Added another toggle  `create_services_namespace` to create the namespace. 