### PR TITLE
fix for default empty maintenance_info field

### DIFF
--- a/interoperator/api/osb/v1alpha1/sfplan_types.go
+++ b/interoperator/api/osb/v1alpha1/sfplan_types.go
@@ -85,7 +85,7 @@ type SFPlanSpec struct {
 
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Metadata               *runtime.RawExtension `json:"metadata,omitempty"`
-	MaintenanceInfo        MaintenanceInfo       `json:"maintenance_info,omitempty"`
+	MaintenanceInfo        *MaintenanceInfo       `json:"maintenance_info,omitempty"`
 	MaximumPollingDuration int                   `json:"maximum_polling_duration,omitempty"`
 	Free                   bool                  `json:"free"`
 	Bindable               bool                  `json:"bindable"`

--- a/interoperator/api/osb/v1alpha1/zz_generated.deepcopy.go
+++ b/interoperator/api/osb/v1alpha1/zz_generated.deepcopy.go
@@ -180,7 +180,11 @@ func (in *SFPlanSpec) DeepCopyInto(out *SFPlanSpec) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	out.MaintenanceInfo = in.MaintenanceInfo
+	if in.MaintenanceInfo != nil {
+		in, out := &in.MaintenanceInfo, &out.MaintenanceInfo
+		*out = new(MaintenanceInfo)
+		**out = **in
+	}
 	if in.Schemas != nil {
 		in, out := &in.Schemas, &out.Schemas
 		*out = new(ServiceSchemas)


### PR DESCRIPTION
- This fixes the bug in sfplan_types definition because of which empty maintenance_info field pops up in sfplan CRs.