### PR TITLE
adding max attempts check in scheduled update job

### DIFF
--- a/broker/core/scheduler-jobs/src/jobs/ServiceInstanceUpdateJob.js
+++ b/broker/core/scheduler-jobs/src/jobs/ServiceInstanceUpdateJob.js
@@ -114,6 +114,7 @@ class ServiceInstanceUpdateJob extends BaseJob {
     const plan = catalog.getPlan(planId);
     logger.info(`Instance Id: ${instanceDetails.instance_id} - manager : ${plan.manager.name} - Force Update: ${plan.service.force_update}`);
     const tenantInfo = _.pick(resourceDetails, ['context', 'organization_guid', 'space_guid']);
+    _.set(tenantInfo, 'service_id', _.get(resourceDetails, 'service_id'));
     return this
       .getOutdatedDiff(instanceDetails, tenantInfo, plan)
       .then(diffResults => {

--- a/broker/core/scheduler-jobs/src/jobs/ServiceInstanceUpdateJob.js
+++ b/broker/core/scheduler-jobs/src/jobs/ServiceInstanceUpdateJob.js
@@ -9,7 +9,8 @@ const {
   errors: {
     BadRequest,
     ServiceUnavailable,
-    NotFound
+    NotFound,
+    InternalServerError
   },
   commonFunctions: {
     unifyDiffResult,
@@ -125,6 +126,13 @@ class ServiceInstanceUpdateJob extends BaseJob {
           return operationResponse;
         }
         let trackAttempts = true;
+        // If job was triggered successfully during the last attempt, and still deployment is outdated and max_attempt is reached, then throw the error
+        const MAX_ATTEMPTS = _.get(instanceDetails, 'max_attempts', config.scheduler.jobs.service_instance_update.max_attempts);
+        if(_.get(instanceDetails, 'prevAttemptTracked', false) == true && _.get(instanceDetails, 'attempt', 0) >= MAX_ATTEMPTS) {
+          logger.error(`Max attempts reached for ${instanceDetails.instance_id}. Attempts : ${_.get(instanceDetails, 'attempt', 0)}, maxAttempts: ${MAX_ATTEMPTS}}`);
+          operationResponse.update_init = CONST.OPERATION.FAILED;
+          throw new InternalServerError(`Max attempts reached. Attempts: ${_.get(instanceDetails, 'attempt', 0)}, maxAttempts: ${MAX_ATTEMPTS}`);
+        }
         return this
           .updateServiceInstance(
             instanceDetails.instance_id,
@@ -218,8 +226,10 @@ class ServiceInstanceUpdateJob extends BaseJob {
     return Promise.try(() => {
       const jobData = _.cloneDeep(instanceDetails);
       jobData.attempt = jobData.attempt + 1;
+      jobData.prevAttemptTracked = false;
       if (trackAttempts) {
         const MAX_ATTEMPTS = _.get(instanceDetails, 'max_attempts', config.scheduler.jobs.service_instance_update.max_attempts);
+        jobData.prevAttemptTracked = true;
         if (jobData.attempt > MAX_ATTEMPTS) {
           logger.error(`Auto udpate for instance ${instanceDetails.instance_id}  has exceeded max configured attempts : ${MAX_ATTEMPTS}}`);
           return;


### PR DESCRIPTION
- Currently, during the ServiceInstanceUpdate job, before triggering the actual update call, it is checked whether the instance is outdated or not. If it's not outdated the update is not triggered. 
- Once the actual update is triggered, the scheduled update job is rescheduled after some time(~30 mins). This can be seen as a retry mechanism. If the actual update didn't go through in earlier attempt, it will again be retried by this rescheduled job.
- This retrying stops after predefined threshold is reached. If this situation is reached, it would mean that, earlier updates did not go through successfully (as the deployment is still outdated).
- However, even in this case, the scheduled update is marked successful as the update trigger was successful. This PR handles this issue.
- If attempts exceed threshold, new update is not triggered and error is thrown.