### PR TITLE
Expose Cluster health metrics

### DIFF
--- a/docs/Interoperator-metrics.md
+++ b/docs/Interoperator-metrics.md
@@ -8,6 +8,7 @@ In addition the to the metrics provided by kubebuilder, the some additional cust
 ### Multiclusterdeployer
 Metric | Labels | Description
 --- | --- | ---
+interoperator_cluster_up| cluster | State of the clusters.<br> 0 - down <br> 1 - up
 interoperator_service_instances_state | instance_id | State of the service instance.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
 interoperator_cluster_service_instances | cluster | Number of service instances partitioned by cluster
 interoperator_cluster_allocatable | cluster <br> type | Allocatable resources partitioned by cluster and resource type

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller_test.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/config"
 	mock_clusterRegistry "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/cluster/registry/mock_registry"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/golang/mock/gomock"
 	"github.com/onsi/gomega"
@@ -176,6 +177,11 @@ func TestReconcile(t *testing.T) {
 		}
 		return nil
 	}, timeout).Should(gomega.Succeed())
+
+	// Check if the interoperator_cluster_up metric reports UP after reconcile.
+	clusterID := clusterInstance.GetName()
+	interoperatorClusterUp := testutil.ToFloat64(clusterMetric.WithLabelValues(clusterID))
+	g.Expect(interoperatorClusterUp).To(gomega.Equal(float64(1)))
 
 	// Delete SFCluster
 	g.Expect(c.Delete(context.TODO(), clusterInstance)).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR exposes a new [Interoperator custom metrics](https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/master/docs/Interoperator-metrics.md#custom-metrics) called `interoperator_cluster_up`.
The `interoperator_cluster_up` exposes the reconciliation status of the provisioner in the clusters. This gives an idea of the health of the cluster. The reconciliation fails when the clusters are not accessible or the provisioner is unhealthy.

Metric | Labels | Description
--- | --- | ---
interoperator_cluster_up| cluster | State of the clusters.<br> 0 - down <br> 1 - up

#### Does this PR introduce a user-facing change?

The `interoperator_cluster_up` can be scraped from Prometheus endpoint of the `multiclusterdeployer`.

#### Additional documentation
- [Interoperator Metrics Documentation](https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/master/docs/Interoperator-metrics.md)
- Feature: HCPCFS-3013