### PR TITLE
Bump Alpine Linux Version

### DIFF
--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,5 +1,5 @@
 # FROM node:14.16-alpine3.13 also works here for a smaller image
-FROM node:16.3-alpine3.12
+FROM node:16.3-alpine3.13
 
 # set our node environment, either development or production
 # defaults to production, compose overrides this to development on build and run


### PR DESCRIPTION
The Protecode scan reported below vulnerabilities coming from Alpine Linux base image,

- [CVE-2021-28831](https://nvd.nist.gov/vuln/detail/CVE-2021-28831])
    decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.
- [CVE-2020-28928](https://nvd.nist.gov/vuln/detail/CVE-2020-28928)
    In musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).

The mitigation is to upgrade Alpine to latest version.