### PR TITLE
Expose service_binding_state metrics

### DIFF
--- a/docs/Interoperator-metrics.md
+++ b/docs/Interoperator-metrics.md
@@ -11,6 +11,7 @@ Metric | Labels | Description
 interoperator_service_instances_state | instance_id | State of the service instance.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
 interoperator_cluster_service_instances | cluster | Number of service instances partitioned by cluster
 interoperator_cluster_allocatable | cluster <br> type | Allocatable resources partitioned by cluster and resource type
+interoperator_service_bindings_state | binding_id <br> instance_id | State of the service binding.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete
 
 ## Liveness and Readiness Probe
 The metrics endpoints are exposed regardless of the status of leader election. So the metrics endpoint is used as liveness and readiness probe for the pods. If the metric endpoint is not up, liveness probe will fail and kubernetes will restart the pod.
@@ -22,6 +23,14 @@ An example for adding custom metric can be found in pull request [#983](https://
 * Declare a prometheus [Collector](https://godoc.org/github.com/prometheus/client_golang/prometheus#Collector) as a global variable in the controller. The list of supported collectors can be found in [prometheus client docs](https://godoc.org/github.com/prometheus/client_golang/prometheus).
 * In `SetupWithManager` section of the controller, register the `collector` with the prometheus [Registry](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/metrics) using the `metrics.Registry.MustRegister()` function. `MustRegister()` accepts variable number of arguments and all the `collectors` can be registered together. Import the `"sigs.k8s.io/controller-runtime/pkg/metrics"` package to access the global `Registry`.
 * Anywhere in the reconcile loop, update the metric.
+
+### Sample PromQL queries:
+Query | Output | Comment
+--- | ---- | --- |
+interoperator_service_bindings_state | interoperator_service_bindings_state{binding_id="0abc2107-de86-408d-8617-800935b84028", instance_id="80ca2362b-6561-4673-ad24-111d7ac86cfd"} 1 <br> interoperator_service_bindings_state{binding_id="0abc2107-de86-408d-8617-800935b84038", instance_id="80ca2362b-6561-4673-ad24-111d7ac86cfd"} 1 <br> interoperator_service_bindings_state{binding_id="0ceb2107-de86-408d-8617-800935b84108", instance_id="65ca2362b-6561-4673-ad24-111d7ac86cfd"} 0 <br> interoperator_service_bindings_state{binding_id="1abc2107-de86-408d-8617-800935b84038", instance_id="81ca2362b-6561-4673-ad24-111d7ac86cfd"} 0 | List all the bindings present in the cluster
+sum by (instance_id) (interoperator_service_bindings_state) | {instance_id="81ca2362b-6561-4673-ad24-111d7ac86cfd"} 0 <br> {instance_id="80ca2362b-6561-4673-ad24-111d7ac86cfd"} 2 <br> {instance_id="65ca2362b-6561-4673-ad24-111d7ac86cfd"} 0 | List all the bindings grouped by the instance id
+count(count by (binding_id) (interoperator_service_bindings_state)) | 	4 | List the count of all the bindings in the cluster
+count(count by (binding_id) (interoperator_service_bindings_state == 1)) | 4 | List all the failed bindings in the cluster
 
 
 ## Grafana Dashboard

--- a/docs/grafana.json
+++ b/docs/grafana.json
@@ -739,6 +739,336 @@
             "type": "stat"
         },
         {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${DS_DS_PROMETHEUS}",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 33
+            },
+            "hiddenSeries": false,
+            "id": 21,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [{
+                "expr": "interoperator_service_bindings_state",
+                "legendFormat": "{{instance_id}}",
+                "refId": "A"
+            }],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Total Bindings",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [{
+                "decimals": 0,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "datasource": "${DS_DS_PROMETHEUS}",
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 33
+            },
+            "id": 22,
+            "links": [],
+            "options": {
+                "colorMode": "value",
+                "fieldOptions": {
+                    "calcs": [
+                        "last"
+                    ],
+                    "defaults": {
+                        "mappings": [{
+                            "id": 0,
+                            "op": "=",
+                            "text": "0",
+                            "type": 1,
+                            "value": "null"
+                        }],
+                        "nullValueMode": "connected",
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [{
+                                "color": "green",
+                                "value": null
+                            },
+                                {
+                                    "color": "red",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    },
+                    "overrides": [],
+                    "values": false
+                },
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal"
+            },
+            "pluginVersion": "6.6.1",
+            "targets": [{
+                "expr": "count(count by (binding_id) (interoperator_service_bindings_state == 1))",
+                "refId": "A"
+            }],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Failed Bindings Count",
+            "type": "stat"
+        },
+        {
+            "cacheTimeout": null,
+            "datasource": "${DS_DS_PROMETHEUS}",
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 41
+            },
+            "id": 23,
+            "links": [],
+            "options": {
+                "colorMode": "value",
+                "fieldOptions": {
+                    "calcs": [
+                        "last"
+                    ],
+                    "defaults": {
+                        "mappings": [{
+                            "id": 0,
+                            "op": "=",
+                            "text": "0",
+                            "type": 1,
+                            "value": "null"
+                        }],
+                        "nullValueMode": "connected",
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [{
+                                "color": "green",
+                                "value": null
+                            },
+                                {
+                                    "color": "red",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    },
+                    "overrides": [],
+                    "values": false
+                },
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal"
+            },
+            "pluginVersion": "6.6.1",
+            "targets": [{
+                "expr": "count(count by (binding_id) (interoperator_service_bindings_state==0))",
+                "format": "heatmap",
+                "legendFormat": "succeeded",
+                "refId": "A"
+            },
+                {"expr": "count(count by (binding_id) (interoperator_service_bindings_state==1))",
+                    "legendFormat": "Failed",
+                    "refId": "B"
+                },
+                {"expr": "count(count by (binding_id) (interoperator_service_bindings_state==2))",
+                    "format": "heatmap",
+                    "legendFormat": "in progress",
+                    "refId": "C"},
+                {"expr": "count(count by (binding_id) (interoperator_service_bindings_state==3))",
+                    "format": "heatmap",
+                    "legendFormat": "in_queue/update/delete",
+                    "refId": "D"}
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Binding Count By State",
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [{
+                "decimals": 0,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "datasource": "${DS_DS_PROMETHEUS}",
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 41
+            },
+            "id": 24,
+            "links": [],
+            "options": {
+                "colorMode": "value",
+                "fieldOptions": {
+                    "calcs": [
+                        "last"
+                    ],
+                    "defaults": {
+                        "mappings": [{
+                            "id": 0,
+                            "op": "=",
+                            "text": "0",
+                            "type": 1,
+                            "value": "null"
+                        }],
+                        "nullValueMode": "connected",
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [{
+                                "color": "green",
+                                "value": null
+                            },
+                                {
+                                    "color": "red",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    },
+                    "overrides": [],
+                    "values": false
+                },
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal"
+            },
+            "pluginVersion": "6.6.1",
+            "targets": [{
+                "expr": "sum by (instance_id) (interoperator_service_bindings_state)",
+                "legendFormat": "{{instance_id}}",
+                "refId": "A"
+            }],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Bindings Grouped By Service Instance",
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [{
+                "decimals": 0,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+            },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
             "dashboardFilter": "",
             "dashboardTags": [],
             "datasource": "${DS_DS_PROMETHEUS}",
@@ -747,7 +1077,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 5,
-                "y": 33
+                "y": 49
             },
             "id": 20,
             "limit": 10,

--- a/interoperator/controllers/multiclusterdeploy/sfservicebindingreplicator/sfservicebindingreplicator_controller_test.go
+++ b/interoperator/controllers/multiclusterdeploy/sfservicebindingreplicator/sfservicebindingreplicator_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var c, c2 client.Client
@@ -219,6 +220,7 @@ func TestReconcileMultiClusterBind(t *testing.T) {
 		Log:             ctrlrun.Log.WithName("mcd").WithName("replicator").WithName("binding"),
 		clusterRegistry: mockClusterRegistry,
 	}
+	metrics.Registry.Unregister(bindingsMetric)
 	g.Expect(controller.SetupWithManager(mgr)).NotTo(gomega.HaveOccurred())
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 
@@ -359,6 +361,7 @@ func TestReconcileMultiClusterUnbind(t *testing.T) {
 		Log:             ctrlrun.Log.WithName("mcd").WithName("replicator").WithName("binding"),
 		clusterRegistry: mockClusterRegistry,
 	}
+	metrics.Registry.Unregister(bindingsMetric)
 	g.Expect(controller.SetupWithManager(mgr)).NotTo(gomega.HaveOccurred())
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 


### PR DESCRIPTION
Update the docs for to reflect the exposed binding metrics.

Sample prometheus query output for "interoperator_service_bindings_state":
```
interoperator_service_bindings_state{app_kubernetes_io_managed_by="Helm", binding_id="0abc2107-de86-408d-8617-800935b84028", control_plane="interoperator-multiclusterdeployer-controller-manager", instance="100.96.0.17:8443", instance_id="80ca2362b-6561-4673-ad24-111d7ac86cfd", job="kubernetes-service-endpoints", kubernetes_name="interoperator-multiclusterdeployer-metrics-service", kubernetes_namespace="interoperator", kubernetes_node="shoot--interop--pooja-dev-worker-j5mor-z1-6b645-p2xjs"}
```