### PR TITLE
Add service_id while getting diff manifest

### DIFF
--- a/broker/applications/extensions/src/api-controllers/ServiceFabrikApiController.js
+++ b/broker/applications/extensions/src/api-controllers/ServiceFabrikApiController.js
@@ -1067,7 +1067,7 @@ class ServiceFabrikApiController extends FabrikBaseController {
         const checkUpdateRequired = _.get(req.query, 'check_update_required');
         logger.info(`Instance Id: ${req.params.instance_id} - check outdated status - ${checkUpdateRequired}`);
         if (checkUpdateRequired) {
-          return apiServerClient.getPlatformOptions({
+          return apiServerClient.getOptions({
             resourceGroup: req.plan.resourceGroup,
             resourceType: req.plan.resourceType,
             resourceId: req.params.instance_id

--- a/broker/applications/extensions/src/api-controllers/ServiceFabrikApiController.js
+++ b/broker/applications/extensions/src/api-controllers/ServiceFabrikApiController.js
@@ -1072,8 +1072,10 @@ class ServiceFabrikApiController extends FabrikBaseController {
             resourceType: req.plan.resourceType,
             resourceId: req.params.instance_id
           })
-            .tap(options => {context = options.context;
-                            service_id = options.service_id})
+            .tap(options => {
+              context = options.context;
+              service_id = options.service_id;
+            })
             .then(options => DirectorService.createInstance(req.params.instance_id, {
               plan_id: req.plan.id,
               context: options.context

--- a/broker/applications/extensions/src/api-controllers/ServiceFabrikApiController.js
+++ b/broker/applications/extensions/src/api-controllers/ServiceFabrikApiController.js
@@ -1059,6 +1059,7 @@ class ServiceFabrikApiController extends FabrikBaseController {
 
   getUpdateSchedule(req, res) {
     let context;
+    let service_id;
     return Promise.try(() => this.setPlan(req))
       .then(() => ScheduleManager
         .getSchedule(req.params.instance_id, CONST.JOB.SERVICE_INSTANCE_UPDATE))
@@ -1066,21 +1067,23 @@ class ServiceFabrikApiController extends FabrikBaseController {
         const checkUpdateRequired = _.get(req.query, 'check_update_required');
         logger.info(`Instance Id: ${req.params.instance_id} - check outdated status - ${checkUpdateRequired}`);
         if (checkUpdateRequired) {
-          return apiServerClient.getPlatformContext({
+          return apiServerClient.getPlatformOptions({
             resourceGroup: req.plan.resourceGroup,
             resourceType: req.plan.resourceType,
             resourceId: req.params.instance_id
           })
-            .tap(ctxt => context = ctxt)
-            .then(platformContext => DirectorService.createInstance(req.params.instance_id, {
+            .tap(options => {context = options.context;
+                            service_id = options.service_id})
+            .then(options => DirectorService.createInstance(req.params.instance_id, {
               plan_id: req.plan.id,
-              context: platformContext
+              context: options.context
             }))
             .then(directorService => {
               return directorService
                 .findDeploymentNameByInstanceId(req.params.instance_id)
                 .then(deploymentName => directorService.diffManifest(deploymentName, {
-                  context: context
+                  context: context,
+                  service_id: service_id
                 }))
                 .then(result => unifyDiffResult(result))
                 .then(result => {

--- a/broker/data-access-layer/eventmesh/src/ApiServerClient.js
+++ b/broker/data-access-layer/eventmesh/src/ApiServerClient.js
@@ -964,15 +964,6 @@ class ApiServerClient {
       .then(resource => _.get(resource, 'spec.options.context'));
   }
 
-  getPlatformOptions(opts) {
-    return this.getResource({
-      resourceGroup: opts.resourceGroup,
-      resourceType: opts.resourceType,
-      resourceId: opts.resourceId
-    })
-      .then(resource => _.get(resource, 'spec.options'));
-  }
-
   /**
    * @description Create OSB Resource in Apiserver with the opts
    * @param {string} opts.resourceGroup - Name of resource group 

--- a/broker/data-access-layer/eventmesh/src/ApiServerClient.js
+++ b/broker/data-access-layer/eventmesh/src/ApiServerClient.js
@@ -964,6 +964,15 @@ class ApiServerClient {
       .then(resource => _.get(resource, 'spec.options.context'));
   }
 
+  getPlatformOptions(opts) {
+    return this.getResource({
+      resourceGroup: opts.resourceGroup,
+      resourceType: opts.resourceType,
+      resourceId: opts.resourceId
+    })
+      .then(resource => _.get(resource, 'spec.options'));
+  }
+
   /**
    * @description Create OSB Resource in Apiserver with the opts
    * @param {string} opts.resourceGroup - Name of resource group 


### PR DESCRIPTION
* While scheduleInfo.update_details service_id was not calculated.
So, in the update_details serviceid field always has serviceid in
diff manifest.
* Because of this even updated deployments were marked as outdated.