### PR TITLE
Document sample fluentbit configuration

### DIFF
--- a/docs/Interoperator-fluentbit.md
+++ b/docs/Interoperator-fluentbit.md
@@ -1,0 +1,28 @@
+## Fluent Bit as a Log Forwarder
+
+The Interoperator broker prints logs as multi line for better readability.
+These pretty printed JSON logs are treated as separate lines by docker log collector. 
+
+Here is a Fluent Bit configuration to support multi line,
+```yaml
+  input-interoperator.conf: |
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              /var/log/containers/*_interoperator_*.log
+        Parser            docker
+        Ignore_Older      2d  
+        Mem_Buf_Limit     10MB
+        Skip_Long_Lines   On  
+        Refresh_Interval  5
+        Docker_Mode      On  
+        Docker_Mode_Parser multi_line
+```
+
+```yaml
+  parsers.conf: |
+    [PARSER]
+        Name multi_line
+        Format regex
+        Regex (?<log>^{"log":"\d{4}-\d{2}-\d{2}.*)
+ ```


### PR DESCRIPTION
#### What this PR does / why we need it:
The logs in Kubernetes are rotated very often. It is useful to send Interoperator logs to services like Kibana. Fluent-bit can be used as a log forwarder. This PR introduces sample configurations of fluent-bit.

#### Additional documentation
[fluentbit to elastic search manual](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch)
A discussion on multi line logs: fluent/fluent-bit/issues/2581
Feature: HCPCFS-3054