### PR TITLE
Fix Yarn version as v2.4.1 in Dockerfile

### DIFF
--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -24,7 +24,7 @@ COPY broker/core core
 COPY broker/data-access-layer data-access-layer
 RUN mkdir logs
 
-RUN yarn set version berry
+RUN yarn set version 2.4.1
 RUN yarn cache clean
 RUN yarn workspaces focus @sf/osb-broker --production
 RUN yarn workspaces focus @sf/quota-app --production


### PR DESCRIPTION
#### What this PR does / why we need it:

The new v3.0.0 of Yarn package manager has breaking changes from previous version. The `yarn set version berry` now installs v3.x of Yarn. Fixing Yarn version as v2.4.1 until compatibility issues with v3.0.0 are resolved.

This PR will be superseded by #1396