### PR TITLE
Fix Yarn version as v2.4.1 in Travis and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ matrix:
       script:
         - pushd broker
         - npm install -g yarn
-        - yarn set version berry
+        - yarn set version 2.4.1
         - yarn install
         - "npm run test-coverall"
         - popd
@@ -115,7 +115,7 @@ matrix:
       script:
         - pushd broker
         - npm install -g yarn
-        - yarn set version berry
+        - yarn set version 2.4.1
         - yarn install
         - "yarn run eslint"
         - "yarn run jsdoc"

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ cd ~/workspace
 ```shell
 cd service-fabrik-broker/broker
 npm install -g yarn
-yarn set version berry
+yarn set version 2.4.1
 yarn install
 ```
 * Optional: To locally run all unit test


### PR DESCRIPTION
#### What this PR does / why we need it:
The `yarn set version berry` now installs v3.x of Yarn. Fixing Yarn version as v2.4.1 until compatibility issues with v3.0.0 are resolved.
This PR is a part of #1397