### PR TITLE
Refresh Catalog Cache in Quota App

### DIFF
--- a/broker/applications/quota-app/src/QuotaApiController.js
+++ b/broker/applications/quota-app/src/QuotaApiController.js
@@ -8,7 +8,10 @@ const {
 } = require('@sf/common-controllers');
 const {
   CONST,
-  commonFunctions
+  commonFunctions,
+  errors: {
+    ServicePlanNotFound
+  }
 } = require('@sf/common-utils');
 const logger = require('@sf/logger');
 
@@ -41,7 +44,11 @@ class QuotaApiController extends FabrikBaseController {
       await res.status(CONST.HTTP_STATUS_CODE.OK).send({ quotaValidStatus: validStatus });
     } catch (err) {
       logger.error(`[Quota APP] Quota check could not be completed due to following error: ${err}`);
-      await res.status(CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR).send({ error: err });
+      if(err instanceof ServicePlanNotFound) {
+        await res.status(CONST.HTTP_STATUS_CODE.NOT_FOUND).send({ error: err });
+      } else {
+        await res.status(CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR).send({ error: err });
+      }
     }
   }
 }

--- a/broker/applications/quota-app/src/QuotaApiController.js
+++ b/broker/applications/quota-app/src/QuotaApiController.js
@@ -43,7 +43,7 @@ class QuotaApiController extends FabrikBaseController {
       logger.error(`[Quota APP] Quota check could not be completed due to following error: ${err}`);
       await res.status(CONST.HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR).send({ error: err });
     }
-  }  
+  }
 }
 
 module.exports = QuotaApiController;

--- a/broker/applications/quota-app/src/index.js
+++ b/broker/applications/quota-app/src/index.js
@@ -21,6 +21,9 @@ async function init() {
         res.render('index', {
           title: app.get('title')
         });
+        if (config.apiserver.isServiceDefinitionAvailableOnApiserver) {
+          utils.loadCatalogFromAPIServer();
+        }
       });
       app.use('/v1', routes.v1);
     });


### PR DESCRIPTION
In the current code, if the given planId is not found in the catalog of quota_app we return 500- Internal server error which is a generic error. This PR modifies the code to instead return 404 NotFound in such case.
Resolves HCPCFS-3085.
