### PR TITLE
Add error handling to DeepUpdate of resource reconciliation.

### DIFF
--- a/interoperator/internal/resources/resources.go
+++ b/interoperator/internal/resources/resources.go
@@ -139,9 +139,12 @@ func (r resourceManager) ReconcileResources(client kubernetes.Client, expectedRe
 		var updatedResource interface{}
 		log.V(2).Info("reconcile - expectedResource resource", "foundResource", foundResource.Object, "expectedResource", expectedResource.Object)
 		if !force {
-			updatedResource, toBeUpdated = dynamic.DeepUpdate(foundResource.Object, expectedResource.Object)
+			updatedResource, toBeUpdated, err = dynamic.DeepUpdate(foundResource.Object, expectedResource.Object)
+			if err != nil {
+			    log.Error(err, "reconcile- failed to update resource ", "kind ", kind, "namespacedName ", namespacedName)
+			    return nil, err
+			}
 		}
-
 		if toBeUpdated || force {
 			log.Info("reconcile - updating resource", "kind", kind, "namespacedName", namespacedName)
 			if force {


### PR DESCRIPTION
If the deepUpdate fails while converting currentObj to newObj the current code raises a panic causing the service to fail. This commit adds error handling to fail the operation that invokes the deepUpdate instead of failing the service.

Following error message will be shown for the last_operation:
```
{
    "state": "failed",
    "description": "failed to apply new value [groups g2] to the resources due to type mismatch. Type string to []interface {}",
    "instance_usable": true,
    "update_repeatable": true
}
```

The below message will be logged with more details:
```
ERROR	dynamic	Error updating 	{"currentObj ": "groups", " to newObj ": ["groups","g2"], "error": "failed to apply new value [groups g2] to the resources due to type mismatch. Type string to []interface {}"}
```