### PR TITLE
Update node from 16.8 to 16.10 for openssl vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "16.8"
+        - "16.10"
       env:
         - SETTINGS_PATH="$(pwd)/broker/config/settings.yml"
       script:
@@ -109,7 +109,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "16.8"
+        - "16.10"
       env:
         - SETTINGS_PATH="$(pwd)/broker/config/settings.yml"
       script:
@@ -123,7 +123,7 @@ matrix:
         - popd
     - language: node_js
       node_js:
-        - "16.8"
+        - "16.10"
       before_install:
         # - pip install --user truffleHog==2.0.89
         - |

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,5 +1,5 @@
 # FROM node:14.16-alpine3.13 also works here for a smaller image
-FROM node:16.8-alpine3.14
+FROM node:16.10-alpine3.14
 
 # set our node environment, either development or production
 # defaults to production, compose overrides this to development on build and run


### PR DESCRIPTION
Fixes,
- [CVE-2021-3711](https://nvd.nist.gov/vuln/detail/CVE-2021-3711)
- [CVE-2021-3712](https://nvd.nist.gov/vuln/detail/CVE-2021-3712)