### PR TITLE
[HCPCFS-3121] support for kubeconfig secret rotation

### DIFF
--- a/interoperator/controllers/multiclusterdeploy/offboarding/offboarding_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/offboarding/offboarding_controller.go
@@ -166,6 +166,7 @@ func (r *SFClusterOffboarding) reconcileFinalizers(ctx context.Context, obj cont
 func (r *SFClusterOffboarding) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&resourcev1alpha1.SFCluster{}).
+		Named("mcd_offboarding").
 		Watches(&source.Kind{Type: &corev1.Secret{}},
 			&handler.EnqueueRequestForOwner{
 				IsController: false,

--- a/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/provisioner/provisioner_controller.go
@@ -42,7 +42,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var (
@@ -579,6 +581,11 @@ func (r *ReconcileProvisioner) SetupWithManager(mgr ctrl.Manager) error {
 			MaxConcurrentReconciles: interoperatorCfg.ProvisionerWorkerCount,
 		}).
 		For(&resourcev1alpha1.SFCluster{}).
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			&handler.EnqueueRequestForOwner{
+				IsController: false,
+				OwnerType:    &resourcev1alpha1.SFCluster{},
+			}).
 		WithEventFilter(watches.NamespaceFilter())
 
 	return builder.Complete(r)


### PR DESCRIPTION
provisoner controller extends watch on cluster-secret