### PR TITLE
Fix sample SFService yaml, case issue with redirectURI

### DIFF
--- a/docs/Interoperator.md
+++ b/docs/Interoperator.md
@@ -270,7 +270,7 @@ spec:
   dashboardClient:
     id: postgresql-dashboard-client-id
     secret: postgresql-dashboard-client-secret
-    redirectURI: 'https://sap.com/'
+    redirectUri: 'https://sap.com/'
   planUpdatable: true
 
   # The following details are context input for Service Fabrik and the individual service operators.


### PR DESCRIPTION
CRD defines the field as redirectUri. 

Trying to define a SFService with provided sample fails with `.spec.dashboardClient.redirectURI: field not declared in schema`