### PR TITLE
Document behavior of the SFPlan offboarding controller

### DIFF
--- a/docs/Interoperator.md
+++ b/docs/Interoperator.md
@@ -770,6 +770,11 @@ metadata:
 data:
   kubeconfig: <REDACTED_KUBECONFIG>
 ```
+
+In order to prevent accidental deletion of an `SFCluster` resource, the OffBoarding controller would prevent the removal of the cluster resource if:
+* the corresponding secret resource is available
+* the `status.serviceInstanceCount` is greater than zero
+
 ## Components within Interoperator
 Below, we discuss about the components of Service Fabrik Interoperator. Some components like the broker and the provisioner were already introduced earlier. With Multi-Cluster deploy support, we bring in two new components, `MultiClusterDeployer` and `Scheduler` which are also described below.
 ### Broker


### PR DESCRIPTION
From behavior documented into https://github.com/cloudfoundry-incubator/service-fabrik-broker/blob/552fe7de49b067e63ce0bc07ae5f3506eb23fd11/interoperator/controllers/multiclusterdeploy/offboarding/offboarding_controller_test.go#L136-L170