### PR TITLE
prevent accidental deletion of sfplans by users.

### DIFF
--- a/interoperator/controllers/multiclusterdeploy/setup_multiclusterdeploy.go
+++ b/interoperator/controllers/multiclusterdeploy/setup_multiclusterdeploy.go
@@ -24,6 +24,7 @@ import (
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/multiclusterdeploy/offboarding"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/multiclusterdeploy/sfplanoffboarding"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/multiclusterdeploy/provisioner"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/multiclusterdeploy/sfclusterreplicator"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/controllers/multiclusterdeploy/sfservicebindingreplicator"
@@ -88,6 +89,14 @@ func SetupWithManager(mgr ctrl.Manager) error {
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create cluster offboarding controller", "controller", "SFClusterOffboarding")
 		return err
+	}
+
+	if err = (&sfplanoffboarding.SFPlanOffboarding{
+	    Client: mgr.GetClient(),
+	    Log: ctrl.Log.WithName("mcd").WithName("sfplan_offboarding").WithName("sfplan"),
+	}).SetupWithManager(mgr); err != nil {
+	    setupLog.Error(err, "unable to create sfplan offboarding controller", "controller", "SFPlanOffboarding")
+	    return err
 	}
 
 	_ = mgr.GetFieldIndexer().IndexField(context.Background(), &osbv1alpha1.SFServiceInstance{}, "spec.clusterId", func(o client.Object) []string {

--- a/interoperator/controllers/multiclusterdeploy/sfplanoffboarding/offboarding_sfplan_controller.go
+++ b/interoperator/controllers/multiclusterdeploy/sfplanoffboarding/offboarding_sfplan_controller.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2018 The Service Fabrik Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfplanoffboarding
+
+import (
+	"context"
+
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/utils"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/watches"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// SFPlanOffboarding protects SFPlan from accidental deletion
+type SFPlanOffboarding struct {
+	client.Client
+	Log         logr.Logger
+}
+
+// Reconcile reads that state of the SFPlan object and makes changes based on the state read
+// and what is in the SFPlan.Spec
+// Automatically generate RBAC rules to allow the Controller to read and write Deployments
+func (r *SFPlanOffboarding) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("sfplan", req.NamespacedName)
+
+	// Fetch the SFPlan instance
+	plan := &osbv1alpha1.SFPlan{}
+	err := r.Get(ctx, req.NamespacedName, plan)
+	if err != nil {
+	    if errors.IsNotFound(err) {
+	        // Object not found, return.  Created objects are automatically garbage collected.
+	        // For additional cleanup logic use finalizers.
+	        return ctrl.Result{}, nil
+	    }
+	    // Error reading the object - requeue the request.
+	    return ctrl.Result{}, err
+	}
+
+	updateRequired := false
+	if !plan.GetDeletionTimestamp().IsZero() {
+	    var instances osbv1alpha1.SFServiceInstanceList
+	    err = r.List(context.Background(), &instances, client.MatchingLabels{"plan_id":plan.GetName()})
+	    if err != nil {
+	        log.Error(err, "Failed to fetch sfserviceinstances for the plan");
+            return ctrl.Result{}, err
+        }
+        log.Info("instance", "size", len(instances.Items));
+        if len(instances.Items) <= 0 || r.canBeDeleted(&instances, plan.GetName()) {
+            log.Info("Reconcile: ", "Removing finalizer ", plan.GetDeletionTimestamp().IsZero())
+            controllerutil.RemoveFinalizer(plan, constants.FinalizerName)
+            updateRequired = true
+        } else {
+            log.Info("Not deleting the plan since one or more sfserviceinstances exist for this plan, that are not set to be deleted")
+        }
+    }
+
+    err = r.reconcileFinalizers(plan, 0, updateRequired)
+    if err != nil {
+        if errors.IsNotFound(err) {
+            return ctrl.Result{}, nil
+        }
+        return ctrl.Result{}, err
+    }
+    return ctrl.Result{}, nil
+}
+
+func (r *SFPlanOffboarding) canBeDeleted(instances *osbv1alpha1.SFServiceInstanceList, planID string) (bool) {
+    for _, instance := range instances.Items {
+        if instance.GetDeletionTimestamp().IsZero() {
+            return false
+        }
+    }
+    return true
+}
+
+func (r *SFPlanOffboarding) reconcileFinalizers(plan *osbv1alpha1.SFPlan, retryCount int, updateRequired bool) error {
+	ctx := context.Background()
+	planID := plan.GetName()
+	log := r.Log.WithValues("planID", planID)
+
+	if plan.GetDeletionTimestamp().IsZero() {
+	    if !utils.ContainsString(plan.GetFinalizers(), constants.FinalizerName) {
+	        // The plan is not being deleted, so if it does not have our finalizer,
+	        // then lets add the finalizer and update the plan.
+	        controllerutil.AddFinalizer(plan, constants.FinalizerName)
+	        updateRequired = true
+	    }
+	}
+	if !updateRequired {
+	    log.Info("Update of the plan is not required... returning")
+	    return nil
+	}
+	if err := r.Update(ctx, plan); err != nil {
+        if retryCount < constants.ErrorThreshold {
+            log.Info("Retrying", "function", "reconcileFinalizers", "retryCount", retryCount+1)
+            return r.reconcileFinalizers(plan, retryCount+1, updateRequired)
+        }
+        return err
+    }
+    return nil
+}
+
+// SetupWithManager registers the SFPlan Controller
+func (r *SFPlanOffboarding) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+	    For(&osbv1alpha1.SFPlan{}).
+	    Named("mcd_sfplan_offboarding").
+	    WithEventFilter(watches.NamespaceFilter()).
+	    Complete(r)
+}

--- a/interoperator/controllers/multiclusterdeploy/sfplanoffboarding/offboarding_sfplan_controller_test.go
+++ b/interoperator/controllers/multiclusterdeploy/sfplanoffboarding/offboarding_sfplan_controller_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2019 The Service Fabrik Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package sfplanoffboarding
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/pkg/constants"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+var _ = Describe("SFPlan Offboarding controller", func() {
+
+	// Define utility constants for object names and testing timeouts/durations and intervals.
+	const (
+	    sfPlanName      = "foo"
+	    instanceName         = "bar"
+	    sfPlanNamespace = "default"
+
+	    timeout  = time.Second * 10
+	    duration = time.Second * 10
+	    interval = time.Millisecond * 250
+	)
+
+	Context("When offboarding SFPlan", func() {
+	    var (
+	        ctx                        context.Context
+	        sfPlanLookupKey            types.NamespacedName
+	        sfInstanceLookupKey        types.NamespacedName
+	        planInstance               *osbv1alpha1.SFPlan
+	        sfServiceInstance          *osbv1alpha1.SFServiceInstance
+	        createdSfPlan              *osbv1alpha1.SFPlan
+	        createdSfServiceInstance   *osbv1alpha1.SFServiceInstance
+	    )
+	    BeforeEach(func() {
+	        ctx = context.Background()
+	        sfPlanLookupKey = types.NamespacedName{Name: sfPlanName, Namespace: sfPlanNamespace}
+	        sfInstanceLookupKey = types.NamespacedName{Name: instanceName, Namespace: sfPlanNamespace}
+
+	        var instanceLabel = map[string]string{
+	            "plan_id":    sfPlanName,
+	        }
+
+		    planInstance = &osbv1alpha1.SFPlan{
+		        ObjectMeta: metav1.ObjectMeta{
+		            Name:      sfPlanName,
+		            Namespace: sfPlanNamespace,
+		        },
+		        Spec: osbv1alpha1.SFPlanSpec{
+		            Name:          "plan-name",
+                    ID:            sfPlanName,
+                    Description:   "description",
+                    Metadata:      nil,
+                    Free:          false,
+                    Bindable:      true,
+                    PlanUpdatable: true,
+                    Schemas:       nil,
+                    ServiceID:     "service-id",
+                    RawContext:    nil,
+                    Manager:       nil,
+                    Templates:     []osbv1alpha1.TemplateSpec{},
+		        },
+		    }
+		    sfServiceInstance = &osbv1alpha1.SFServiceInstance{
+		        ObjectMeta: metav1.ObjectMeta{
+		            Name:      instanceName,
+		            Namespace: sfPlanNamespace,
+		            Labels: instanceLabel,
+		        },
+		        Spec: osbv1alpha1.SFServiceInstanceSpec{
+		            ServiceID:        "service-id",
+		            PlanID:           sfPlanName,
+		            RawContext:       nil,
+		            OrganizationGUID: "organization-guid",
+		            SpaceGUID:        "space-guid",
+		            RawParameters:    nil,
+		            PreviousValues:   nil,
+		            ClusterID:        "1",
+		            InstanceID: instanceName,
+		        },
+		        Status: osbv1alpha1.SFServiceInstanceStatus{
+		            State: "in_queue",
+		        },
+		    }
+		})
+        It("Should add finalizers when SFPlan is created", func() {
+            By("Creating SFPlan")
+            Expect(k8sClient.Create(ctx, planInstance)).Should(Succeed())
+            // After creating this SFPlan, let's verify finalizers are added
+            createdSfPlan = &osbv1alpha1.SFPlan{}
+            Eventually(func() bool {
+                err := k8sClient.Get(ctx, sfPlanLookupKey, createdSfPlan)
+                if err != nil {
+                    return false
+                }
+                return len(createdSfPlan.GetFinalizers()) != 0
+            }, timeout, interval).Should(BeTrue())
+
+            Expect(createdSfPlan.Spec.ID).Should(Equal(sfPlanName))
+            Expect(createdSfPlan.GetFinalizers()).Should(ContainElement(constants.FinalizerName))
+        })
+
+        It("Should offboard plan if instance count is zero", func() {
+            By("Deleting SFPlan")
+            Expect(k8sClient.Delete(ctx, createdSfPlan)).Should(Succeed())
+
+            //Verify Sfplan get deleted
+            Eventually(func() bool {
+                err := k8sClient.Get(ctx, sfPlanLookupKey, createdSfPlan)
+                return err != nil
+            }, timeout, interval).Should(BeTrue())
+        })
+
+        It("Should not offboard plan if instance count is not zero", func() {
+            By("Creating SFPlan")
+            Expect(k8sClient.Create(ctx, planInstance)).Should(Succeed())
+            // After creating this SFPlan, let's verify finalizers are added
+            createdSfPlan = &osbv1alpha1.SFPlan{}
+            Eventually(func() bool {
+                err := k8sClient.Get(ctx, sfPlanLookupKey, createdSfPlan)
+                if err != nil {
+                    return false
+                }
+            return len(createdSfPlan.GetFinalizers()) != 0
+            }, timeout, interval).Should(BeTrue())
+            Expect(createdSfPlan.Spec.ID).Should(Equal(sfPlanName))
+            Expect(createdSfPlan.GetFinalizers()).Should(ContainElement(constants.FinalizerName))
+
+            By("Creating SFServiceInstance")
+            err := k8sClient.Create(context.TODO(), sfServiceInstance)
+            if apierrors.IsInvalid(err) {
+                return
+            }
+            Expect(err).NotTo(HaveOccurred())
+
+            // After creating this SFServiceInstance, let's verify finalizers are added
+            createdSfServiceInstance = &osbv1alpha1.SFServiceInstance{}
+            Eventually(func() error {
+                return k8sClient.Get(context.TODO(), sfInstanceLookupKey, createdSfServiceInstance)
+            }, timeout).Should(Succeed())
+
+            By("Deleting SFPlan")
+            Expect(k8sClient.Delete(ctx, createdSfPlan)).Should(Succeed())
+
+            //Verify the sfplan is not deleted
+            Consistently(func() bool {
+            err := k8sClient.Get(ctx, sfPlanLookupKey, createdSfPlan)
+                return err == nil
+            }, duration, interval).Should(BeTrue())
+
+            By("Deleting SFServiceInstance")
+            Expect(k8sClient.Delete(ctx, createdSfServiceInstance)).Should(Succeed())
+        })
+	})
+})

--- a/interoperator/controllers/multiclusterdeploy/sfplanoffboarding/suite_test.go
+++ b/interoperator/controllers/multiclusterdeploy/sfplanoffboarding/suite_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2019 The Service Fabrik Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfplanoffboarding
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
+	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	cfg        *rest.Config
+	k8sManager ctrl.Manager
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	cancelMgr  context.CancelFunc
+	mgrStopped *sync.WaitGroup
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+    err = osbv1alpha1.AddToScheme(scheme.Scheme)
+    Expect(err).NotTo(HaveOccurred())
+
+	err = resourcev1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0",
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&SFPlanOffboarding{
+		Client: k8sManager.GetClient(),
+		Log:    ctrl.Log.WithName("mcd").WithName("sfplan_offboarding").WithName("sfplan"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	cancelMgr, mgrStopped = startTestManager(k8sManager)
+
+	k8sClient = k8sManager.GetClient()
+	Expect(k8sClient).ToNot(BeNil())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func(done Done) {
+	By("tearing down the test environment")
+
+	cancelMgr()
+	mgrStopped.Wait()
+
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+	close(done)
+})
+
+// startTestManager starts the manager and returns the stop channel
+func startTestManager(k8sManager ctrl.Manager) (context.CancelFunc, *sync.WaitGroup) {
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		Expect(k8sManager.Start(ctx)).NotTo(HaveOccurred())
+	}()
+	return cancel, wg
+}

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -17,6 +17,7 @@ const (
 	PrimaryClusterKey                     = "interoperator.servicefabrik.io/primarycluster"
 	PlanHashKey                           = "interoperator.servicefabrik.io/planhash"
 	ErrorThreshold                        = 10
+	PlanDeleteAttempts                    = "interoperator.servicefabrik.io/deleteattempts"
 
 	ConfigMapName           = "interoperator-config"
 	ConfigMapKey            = "config"


### PR DESCRIPTION
An sfplan for which there are 1 or more sfserviceinstances existing (that are not set to be deleted by the user), should not get deleted until all the corresponding instances either get deleted or have deletion timestamp set.

We add a new reconciler to add finalizer to the plan whose deletion ts is not set. Since this reconciler is not watching on instances, there is no way to delete the plan when all its corresponding instances have been deleted, once the deletion ts is set for the plan. Hence we added a logic to update a plan whose deletion ts is set, everytime any instance created using this plan is attempted to be deleted. This update will force trigger the reconciliation, hence deleting the plan when all the instances created using this plan have been deleted or set to be deleted.