### PR TITLE
Set  'instance' in the context to be used by dashboard url.

### DIFF
--- a/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
+++ b/broker/applications/osb-broker/src/api-controllers/ServiceBrokerApiController.js
@@ -797,6 +797,7 @@ class ServiceBrokerApiController extends FabrikBaseController {
             const plan = catalog.getPlan(_.get(resource, 'spec.planId'));
             _.set(context,'plan',plan);
             _.set(context,'instance_id',req.params.instance_id);
+            _.set(context,'instance',resource);
             const dashboardUrl = this.getDashboardUrl(context);
             if (dashboardUrl) {
               body.dashboard_url = dashboardUrl;


### PR DESCRIPTION
If the plan contains dashboard url, it may refer to the sfserviceinstance for reading the name & cluster id properties. If the instance is not present it throws an exception and the GET call fails.
Fix for: https://jtrack.wdf.sap.corp/browse/NGPBUG-181387
