### PR TITLE
Broker logging enhancements

### DIFF
--- a/broker/core/utils/src/HttpClient.js
+++ b/broker/core/utils/src/HttpClient.js
@@ -256,7 +256,9 @@ class HttpClient {
 
   invoke(options, expectedStatusCode) {
     expectedStatusCode = expectedStatusCode || options.expectedStatusCode;
-    logger.debug('Sending HTTP request with options :', options);
+    // removes auth tokens before logging the http request options.
+    logger.debug('Sending HTTP request with options :',
+      _.omit(options, ['headers.authorization', 'headers.Authorization']));
     let enhanced_options = this.enhanceOptions(options);
 
     // validateStatus defines whether to resolve or reject the promise


### PR DESCRIPTION
In the HTTPClient, a debug logger logs the options used in the HTTP request. This log statement may expose tokens if the options has authorization header. This change omits the authorization header while logging.