### PR TITLE
Adding event filter to reduce provisioner logs.

### DIFF
--- a/interoperator/controllers/provisioners/sfclusterusage/sfclusterusage_controller.go
+++ b/interoperator/controllers/provisioners/sfclusterusage/sfclusterusage_controller.go
@@ -145,7 +145,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named("scheduler_helper_sfclusterusage").
 		For(&resourcev1alpha1.SFCluster{}).
 		Watches(&source.Kind{Type: &corev1.Node{}}, watchMapper).
-		WithEventFilter(watches.NamespaceFilter())
+		WithEventFilter(watches.NodeFilter())
 
 	return builder.Complete(r)
 }

--- a/interoperator/controllers/provisioners/sfclusterusage/sfclusterusage_controller.go
+++ b/interoperator/controllers/provisioners/sfclusterusage/sfclusterusage_controller.go
@@ -39,7 +39,8 @@ import (
 // Reconciler reconciles a Node objects and computes the capacity of cluster
 type Reconciler struct {
 	client.Client
-	Log logr.Logger
+	Log            logr.Logger
+	uncachedClient client.Client
 }
 
 // Reconcile iterates through all nodes and computes requested resources
@@ -68,7 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	currentCapacity := make(corev1.ResourceList)
 	// TODO: Verify pagination works
 	for more := true; more; more = (nodes.Continue != "") {
-		err = r.List(ctx, nodes, client.Limit(constants.ListPaginationLimit), client.Continue(nodes.Continue))
+		err = r.uncachedClient.List(ctx, nodes, client.Limit(constants.ListPaginationLimit), client.Continue(nodes.Continue))
 		if err != nil {
 			log.Error(err, "error while fetching nodes")
 			return ctrl.Result{}, err
@@ -84,7 +85,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// TODO: Verify pagination works
 	for more := true; more; more = (pods.Continue != "") {
-		err = r.List(ctx, pods, client.Limit(constants.ListPaginationLimit), client.Continue(pods.Continue))
+		err = r.uncachedClient.List(ctx, pods, client.Limit(constants.ListPaginationLimit), client.Continue(pods.Continue))
 		if err != nil {
 			log.Error(err, "error while fetching pods")
 			return ctrl.Result{}, err
@@ -131,6 +132,17 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	_, ok := os.LookupEnv(constants.NamespaceEnvKey)
 	if !ok {
 		return nil
+	}
+
+	if r.uncachedClient == nil {
+		uncachedClient, err := client.New(mgr.GetConfig(), client.Options{
+			Scheme: mgr.GetScheme(),
+			Mapper: mgr.GetRESTMapper(),
+		})
+		if err != nil {
+			return err
+		}
+		r.uncachedClient = uncachedClient
 	}
 
 	watchMapper := handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {

--- a/interoperator/internal/resources/resources.go
+++ b/interoperator/internal/resources/resources.go
@@ -141,8 +141,8 @@ func (r resourceManager) ReconcileResources(client kubernetes.Client, expectedRe
 		if !force {
 			updatedResource, toBeUpdated, err = dynamic.DeepUpdate(foundResource.Object, expectedResource.Object)
 			if err != nil {
-			    log.Error(err, "reconcile- failed to update resource ", "kind ", kind, "namespacedName ", namespacedName)
-			    return nil, err
+				log.Error(err, "reconcile- failed to update resource ", "kind ", kind, "namespacedName ", namespacedName)
+				return nil, err
 			}
 		}
 		if toBeUpdated || force {
@@ -152,7 +152,8 @@ func (r resourceManager) ReconcileResources(client kubernetes.Client, expectedRe
 				err = client.Update(context.TODO(), expectedResource)
 			} else {
 				foundResource.Object = updatedResource.(map[string]interface{})
-				log.Info("reconcile - updating resource", "resource", foundResource.Object)
+				// Printing the object leaks credentialsstores in subresources. Disabling it for now.
+				// log.Info("reconcile - updating resource", "resource", foundResource.Object)
 				err = client.Update(context.TODO(), foundResource)
 			}
 			if err != nil {

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -42,7 +42,7 @@ const (
 	PlanWatchDrainTimeout           = time.Second * 2
 	DefaultClusterReconcileInterval = "20m"
 
-	ListPaginationLimit = 500
+	ListPaginationLimit = 100
 )
 
 // Configs initialized at startup

--- a/interoperator/pkg/constants/constants.go
+++ b/interoperator/pkg/constants/constants.go
@@ -42,7 +42,7 @@ const (
 	PlanWatchDrainTimeout           = time.Second * 2
 	DefaultClusterReconcileInterval = "20m"
 
-	ListPaginationLimit = 50
+	ListPaginationLimit = 500
 )
 
 // Configs initialized at startup

--- a/interoperator/pkg/watches/watches.go
+++ b/interoperator/pkg/watches/watches.go
@@ -5,6 +5,7 @@ import (
 	reflect "reflect"
 
 	osbv1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/osb/v1alpha1"
+	resourcev1alpha1 "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/api/resource/v1alpha1"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/config"
 	"github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/properties"
 	rendererFactory "github.com/cloudfoundry-incubator/service-fabrik-broker/interoperator/internal/renderer/factory"
@@ -387,10 +388,15 @@ func NodeFilter() predicate.Predicate {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			switch new := e.ObjectNew.(type) {
 			case *corev1.Node:
-                old := e.ObjectOld.(*corev1.Node)
-                if !reflect.DeepEqual(old.Status.Allocatable, new.Status.Allocatable) {
-                    return true
-                }
+				old := e.ObjectOld.(*corev1.Node)
+				if !reflect.DeepEqual(old.Status.Allocatable, new.Status.Allocatable) {
+					return true
+				}
+			case *resourcev1alpha1.SFCluster:
+				old := e.ObjectOld.(*resourcev1alpha1.SFCluster)
+				if !reflect.DeepEqual(old.Status, new.Status) {
+					return true
+				}
 			}
 			return false
 		},

--- a/interoperator/pkg/watches/watches.go
+++ b/interoperator/pkg/watches/watches.go
@@ -385,16 +385,12 @@ func NodeFilter() predicate.Predicate {
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			old, ok := e.ObjectOld.(*corev1.Node)
-			if !ok {
-				return true
-			}
-			new, ok := e.ObjectNew.(*corev1.Node)
-			if !ok {
-				return true
-			}
-			if !reflect.DeepEqual(old.Status.Allocatable, new.Status.Allocatable) {
-				return true
+			switch new := e.ObjectNew.(type) {
+			case *corev1.Node:
+                old := e.ObjectOld.(*corev1.Node)
+                if !reflect.DeepEqual(old.Status.Allocatable, new.Status.Allocatable) {
+                    return true
+                }
 			}
 			return false
 		},


### PR DESCRIPTION
Event filter is added for node resource. It will filter out unwanted update events for node.
Using this filter to sfclusterusagecontroller will reduce the number of reconciliation and thus reduce logs.
(recently we have seen that nodes are getting updated frequently in gardener and as the sfclusterusagecontroller is watchinhg on nodes, this is causing redundant reconcillation of the controller)